### PR TITLE
Refactor to expose some Client fields for extensions.

### DIFF
--- a/go/client/bytestream.go
+++ b/go/client/bytestream.go
@@ -14,7 +14,7 @@ import (
 // WriteBytes uploads a byte slice.
 func (c *Client) WriteBytes(ctx context.Context, name string, data []byte) error {
 	cancelCtx, cancel := context.WithCancel(ctx)
-	opts := c.rpcOpts()
+	opts := c.RPCOpts()
 	defer cancel()
 	closure := func() error {
 		// Use lower-level Write in order to not retry twice.
@@ -58,7 +58,7 @@ func (c *Client) WriteBytes(ctx context.Context, name string, data []byte) error
 		}
 		return nil
 	}
-	return c.retrier.do(cancelCtx, closure)
+	return c.Retrier.Do(cancelCtx, closure)
 }
 
 // ReadBytes fetches a resource's contents into a byte slice.
@@ -137,6 +137,6 @@ func (c *Client) readStreamed(ctx context.Context, name string, offset, limit in
 		}
 		return nil
 	}
-	e = c.retrier.do(cancelCtx, closure)
+	e = c.Retrier.Do(cancelCtx, closure)
 	return n, e
 }

--- a/go/client/cas.go
+++ b/go/client/cas.go
@@ -149,7 +149,7 @@ func (c *Client) BatchWriteBlobs(ctx context.Context, blobs map[digest.Key][]byt
 	}
 	closure := func() error {
 		var resp *repb.BatchUpdateBlobsResponse
-		err := c.callWithTimeout(ctx, func(ctx context.Context) (e error) {
+		err := c.CallWithTimeout(ctx, func(ctx context.Context) (e error) {
 			resp, e = c.cas.BatchUpdateBlobs(ctx, &repb.BatchUpdateBlobsRequest{
 				InstanceName: c.InstanceName,
 				Requests:     reqs,
@@ -168,7 +168,7 @@ func (c *Client) BatchWriteBlobs(ctx context.Context, blobs map[digest.Key][]byt
 			st := status.FromProto(r.Status)
 			if st.Code() != codes.OK {
 				e := st.Err()
-				if c.retrier.ShouldRetry(e) {
+				if c.Retrier.ShouldRetry(e) {
 					failedReqs = append(failedReqs, &repb.BatchUpdateBlobsRequest_Request{
 						Digest: r.Digest,
 						Data:   blobs[digest.ToKey(r.Digest)],
@@ -191,7 +191,7 @@ func (c *Client) BatchWriteBlobs(ctx context.Context, blobs map[digest.Key][]byt
 		}
 		return nil
 	}
-	return c.retrier.do(ctx, closure)
+	return c.Retrier.Do(ctx, closure)
 }
 
 // makeBatches splits a list of digests into batches of size no more than the maximum.
@@ -411,7 +411,7 @@ func (c *Client) GetDirectoryTree(ctx context.Context, d *repb.Digest) (result [
 		}
 		return nil
 	}
-	if err := c.retrier.do(ctx, closure); err != nil {
+	if err := c.Retrier.Do(ctx, closure); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/go/client/exec.go
+++ b/go/client/exec.go
@@ -228,7 +228,7 @@ func (c *Client) ExecuteAndWait(ctx context.Context, req *repb.ExecuteRequest) (
 	wait := false    // Should we retry by calling WaitExecution instead of Execute?
 	opError := false // Are we propagating an Operation status as an error for the retrier's benefit?
 	lastOp := &oppb.Operation{}
-	opts := c.rpcOpts()
+	opts := c.RPCOpts()
 	closure := func() (e error) {
 		var res regrpc.Execution_ExecuteClient
 		// In both cases, use the lower-level methods to avoid retrying twice.
@@ -261,7 +261,7 @@ func (c *Client) ExecuteAndWait(ctx context.Context, req *repb.ExecuteRequest) (
 		}
 		return nil
 	}
-	err = c.retrier.do(ctx, closure)
+	err = c.Retrier.Do(ctx, closure)
 	if err != nil && !opError {
 		return nil, err
 	}


### PR DESCRIPTION
Verified that the following makes no changes / requires no changes:

```
go mod tidy
gofmt -w go
golint ./...
go vet ./...
```

Tested successfully with:

```
bazel test ...
go test ./...
```