### PR TITLE
 Adding capability to handle virtual inputs.

### DIFF
--- a/go/client/tree.go
+++ b/go/client/tree.go
@@ -96,6 +96,9 @@ func BuildTreeFromInputs(execRoot string, is *command.InputSpec) (*FileTree, err
 			return nil, e
 		}
 	}
+	for _, i := range is.VirtualInputs {
+		fs[i.Path] = i.Contents
+	}
 	return BuildTree(fs), nil
 }
 

--- a/go/client/tree_test.go
+++ b/go/client/tree_test.go
@@ -331,6 +331,24 @@ func TestBuildTreeFromInputs(t *testing.T) {
 			},
 			want: &client.FileTree{},
 		},
+		{
+			desc: "virtual inputs",
+			input: nil,
+			spec: &command.InputSpec{
+				VirtualInputs: []*command.VirtualInput{
+					&command.VirtualInput{Path: "a/foo.txt", Contents: []byte("foo")},
+					&command.VirtualInput{Path: "bar.txt", Contents: []byte("bar")},
+				},
+			},
+			want: &client.FileTree{
+				Files: map[string][]byte{"bar.txt": []byte("bar")},
+				Dirs: map[string]*client.FileTree{
+					"a": &client.FileTree{
+						Files: map[string][]byte{"foo.txt": []byte("foo")},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/go/client/tree_test.go
+++ b/go/client/tree_test.go
@@ -332,7 +332,7 @@ func TestBuildTreeFromInputs(t *testing.T) {
 			want: &client.FileTree{},
 		},
 		{
-			desc: "virtual inputs",
+			desc:  "virtual inputs",
 			input: nil,
 			spec: &command.InputSpec{
 				VirtualInputs: []*command.VirtualInput{

--- a/go/internal/test/fakes/ac.go
+++ b/go/internal/test/fakes/ac.go
@@ -14,7 +14,7 @@ import (
 
 // ActionCache implements the RE ActionCache interface, storing fixed results.
 type ActionCache struct {
-	mu        sync.RWMutex
+	mu      sync.RWMutex
 	results map[digest.Digest]*repb.ActionResult
 	reads   map[digest.Digest]int
 	writes  map[digest.Digest]int

--- a/go/pkg/command/command.go
+++ b/go/pkg/command/command.go
@@ -45,6 +45,13 @@ type InputExclusion struct {
 	Type InputType
 }
 
+// VirtualInput represents an input that does not actually exist as a file on disk, but we want
+// to stage it as a file on disk for the command execution.
+type VirtualInput struct {
+	// The path for the input file to be staged at, relative to the ExecRoot.
+	Path string
+}
+
 // InputSpec represents all the required inputs to a remote command.
 type InputSpec struct {
 	// Input paths (files or directories) that need to be present for the command execution.

--- a/go/pkg/command/command.go
+++ b/go/pkg/command/command.go
@@ -55,7 +55,7 @@ type VirtualInput struct {
 	Contents []byte
 
 	// Whether the file should be staged as executable.
-  IsExecutable bool
+	IsExecutable bool
 }
 
 // InputSpec represents all the required inputs to a remote command.

--- a/go/pkg/command/command.go
+++ b/go/pkg/command/command.go
@@ -50,12 +50,21 @@ type InputExclusion struct {
 type VirtualInput struct {
 	// The path for the input file to be staged at, relative to the ExecRoot.
 	Path string
+
+	// The byte contents of the file to be staged.
+	Contents []byte
+
+	// Whether the file should be staged as executable.
+  IsExecutable bool
 }
 
 // InputSpec represents all the required inputs to a remote command.
 type InputSpec struct {
 	// Input paths (files or directories) that need to be present for the command execution.
 	Inputs []string
+
+	// Inputs not present on the local file system, but should be staged for command execution.
+	VirtualInputs []*VirtualInput
 
 	// Inputs matching these patterns will be excluded.
 	InputExclusions []*InputExclusion


### PR DESCRIPTION
This doesn't handle the executable bit correctly, but then nothing else in the current client does. It's an upstream bug that I will fix separately, for now the unit tests do not include the executable bit case.