### PR TITLE
Exporting fakes.NewTestEnv.

### DIFF
--- a/go/pkg/command/BUILD.bazel
+++ b/go/pkg/command/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//go/digest:go_default_library",
+        "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_pborman_uuid//:go_default_library",
     ],
 )
@@ -15,4 +16,9 @@ go_test(
     name = "go_default_test",
     srcs = ["command_test.go"],
     embed = [":go_default_library"],
+    deps = [
+        "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
+    ],
 )

--- a/go/pkg/command/command_test.go
+++ b/go/pkg/command/command_test.go
@@ -1,6 +1,13 @@
 package command
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+)
 
 func TestStableId_SameCommands(t *testing.T) {
 	t.Parallel()
@@ -299,5 +306,71 @@ func TestValidate_Success(t *testing.T) {
 	}
 	if err := c.Validate(); err != nil {
 		t.Errorf("expected Validate of %v = nil, got %v", c, err)
+	}
+}
+
+func TestToREProto(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmd     *Command
+		wantCmd *repb.Command
+	}{
+		{
+			name:    "pass args",
+			cmd:     &Command{Args: []string{"foo", "bar"}},
+			wantCmd: &repb.Command{Arguments: []string{"foo", "bar"}},
+		},
+		{
+			name:    "pass working directory",
+			cmd:     &Command{WorkingDir: "a/b"},
+			wantCmd: &repb.Command{WorkingDirectory: "a/b"},
+		},
+		{
+			name:    "sort output files",
+			cmd:     &Command{OutputFiles: []string{"foo", "bar", "abc"}},
+			wantCmd: &repb.Command{OutputFiles: []string{"abc", "bar", "foo"}},
+		},
+		{
+			name:    "sort output directories",
+			cmd:     &Command{OutputDirs: []string{"foo", "bar", "abc"}},
+			wantCmd: &repb.Command{OutputDirectories: []string{"abc", "bar", "foo"}},
+		},
+		{
+			name: "sort environment variables",
+			cmd: &Command{
+				InputSpec: &InputSpec{
+					EnvironmentVariables: map[string]string{"b": "3", "a": "2", "c": "1"},
+				},
+			},
+			wantCmd: &repb.Command{
+				EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+					&repb.Command_EnvironmentVariable{Name: "a", Value: "2"},
+					&repb.Command_EnvironmentVariable{Name: "b", Value: "3"},
+					&repb.Command_EnvironmentVariable{Name: "c", Value: "1"},
+				},
+			},
+		},
+		{
+			name: "sort platform",
+			cmd:  &Command{Platform: map[string]string{"b": "3", "a": "2", "c": "1"}},
+			wantCmd: &repb.Command{
+				Platform: &repb.Platform{
+					Properties: []*repb.Platform_Property{
+						&repb.Platform_Property{Name: "a", Value: "2"},
+						&repb.Platform_Property{Name: "b", Value: "3"},
+						&repb.Platform_Property{Name: "c", Value: "1"},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.cmd.FillDefaultFieldValues()
+			gotCmd := tc.cmd.ToREProto()
+			if diff := cmp.Diff(tc.wantCmd, gotCmd, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("%s: buildCommand gave result diff (-want +got):\n%s", tc.name, diff)
+			}
+		})
 	}
 }

--- a/go/pkg/fakes/BUILD.bazel
+++ b/go/pkg/fakes/BUILD.bazel
@@ -13,6 +13,8 @@ go_library(
     deps = [
         "//go/client:go_default_library",
         "//go/digest:go_default_library",
+        "//go/pkg/command:go_default_library",
+        "//go/pkg/rexec:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",

--- a/go/pkg/fakes/server.go
+++ b/go/pkg/fakes/server.go
@@ -2,11 +2,24 @@ package fakes
 
 import (
 	"context"
-	"google.golang.org/grpc"
+	"io/ioutil"
 	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/digest"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/command"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/rexec"
+	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	rc "github.com/bazelbuild/remote-apis-sdks/go/client"
 	regrpc "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	bsgrpc "google.golang.org/genproto/googleapis/bytestream"
 )
 
@@ -56,4 +69,161 @@ func (s *Server) NewTestClient(ctx context.Context) (*rc.Client, error) {
 		Service:    s.listener.Addr().String(),
 		NoSecurity: true,
 	})
+}
+
+// TestEnv is a wrapper for convenient integration tests of remote execution.
+type TestEnv struct {
+	Client     *rexec.Client
+	Server     *Server
+	ExecRoot   string
+	GrpcClient *rc.Client
+	t          *testing.T
+}
+
+// NewTestEnv initializes a TestEnv containing a fake server, a client connected to it,
+// and a temporary directory used as execution root for inputs and outputs.
+func NewTestEnv(t *testing.T) *TestEnv {
+	// Set up temp directory.
+	execRoot, err := ioutil.TempDir("", strings.ReplaceAll(t.Name(), string(filepath.Separator), "_"))
+	if err != nil {
+		t.Fatalf("failed to make temp dir: %v", err)
+	}
+	// Set up the fake.
+	s, err := NewServer()
+	if err != nil {
+		t.Fatalf("Error starting fake server: %v", err)
+	}
+	grpcClient, err := s.NewTestClient(context.Background())
+	if err != nil {
+		t.Fatalf("Error connecting to server: %v", err)
+	}
+	return &TestEnv{
+		Client:     &rexec.Client{&rexec.NoopFileDigestCache{}, grpcClient},
+		Server:     s,
+		ExecRoot:   execRoot,
+		GrpcClient: grpcClient,
+		t:          t,
+	}
+}
+
+// Cleanup shuts down the server and client and removes the temporary directory.
+func (e *TestEnv) Cleanup() {
+	e.GrpcClient.Close()
+	e.Server.Stop()
+	os.RemoveAll(e.ExecRoot)
+}
+
+type option interface {
+	Apply(*repb.ActionResult, *Server)
+}
+
+// OutputFile is to be added as an output of the fake action.
+type OutputFile struct {
+	Path     string
+	Contents string
+}
+
+// Apply puts the file in the fake CAS and the given ActionResult.
+func (f *OutputFile) Apply(ac *repb.ActionResult, s *Server) {
+	bytes := []byte(f.Contents)
+	s.Exec.OutputBlobs = append(s.Exec.OutputBlobs, bytes)
+	dg := s.CAS.Put(bytes)
+	ac.OutputFiles = append(ac.OutputFiles, &repb.OutputFile{Path: f.Path, Digest: dg.ToProto()})
+}
+
+// StdOut is to be added as an output of the fake action.
+type StdOut string
+
+// Apply puts the action stdout in the fake CAS and the given ActionResult.
+func (o StdOut) Apply(ac *repb.ActionResult, s *Server) {
+	bytes := []byte(o)
+	s.Exec.OutputBlobs = append(s.Exec.OutputBlobs, bytes)
+	dg := s.CAS.Put(bytes)
+	ac.StdoutDigest = dg.ToProto()
+}
+
+// StdOutRaw is to be added as a raw output of the fake action.
+type StdOutRaw string
+
+// Apply puts the action stdout as raw bytes in the given ActionResult.
+func (o StdOutRaw) Apply(ac *repb.ActionResult, s *Server) {
+	ac.StdoutRaw = []byte(o)
+}
+
+// StdErr is to be added as an output of the fake action.
+type StdErr string
+
+// Apply puts the action stderr in the fake CAS and the given ActionResult.
+func (o StdErr) Apply(ac *repb.ActionResult, s *Server) {
+	bytes := []byte(o)
+	s.Exec.OutputBlobs = append(s.Exec.OutputBlobs, bytes)
+	dg := s.CAS.Put(bytes)
+	ac.StderrDigest = dg.ToProto()
+}
+
+// StdErrRaw is to be added as a raw output of the fake action.
+type StdErrRaw string
+
+// Apply puts the action stderr as raw bytes in the given ActionResult.
+func (o StdErrRaw) Apply(ac *repb.ActionResult, s *Server) {
+	ac.StderrRaw = []byte(o)
+}
+
+// ExecutionCacheHit of true will cause the ActionResult to be returned as a cache hit during
+// fake execution.
+type ExecutionCacheHit bool
+
+// Apply on true will cause the ActionResult to be returned as a cache hit during fake execution.
+func (c ExecutionCacheHit) Apply(ac *repb.ActionResult, s *Server) {
+	s.Exec.Cached = bool(c)
+}
+
+// Set sets up the fake to return the given result on the given command execution.
+// It is not possible to make the fake result in a LocalErrorResultStatus or an InterruptedResultStatus.
+func (e *TestEnv) Set(cmd *command.Command, opt *command.ExecutionOptions, res *command.Result, opts ...option) (cmdDg, acDg digest.Digest) {
+	cmd.FillDefaultFieldValues()
+	ft, err := rc.BuildTreeFromInputs(cmd.ExecRoot, cmd.InputSpec)
+	if err != nil {
+		e.t.Fatalf("error building input tree in fake setup: %v", err)
+		return digest.Empty, digest.Empty
+	}
+	root, _, err := rc.PackageTree(ft)
+	if err != nil {
+		e.t.Fatalf("error building input tree in fake setup: %v", err)
+		return digest.Empty, digest.Empty
+	}
+
+	cmdPb := cmd.ToREProto()
+	cmdDg = digest.TestNewFromMessage(cmdPb)
+	ac := &repb.Action{
+		CommandDigest:   cmdDg.ToProto(),
+		InputRootDigest: root.ToProto(),
+		DoNotCache:      opt.DoNotCache,
+	}
+	if cmd.Timeout > 0 {
+		ac.Timeout = ptypes.DurationProto(cmd.Timeout)
+	}
+	ar := &repb.ActionResult{
+		ExitCode: int32(res.ExitCode),
+	}
+	acDg = digest.TestNewFromMessage(ac)
+	for _, o := range opts {
+		o.Apply(ar, e.Server)
+	}
+	e.Server.Exec.ActionResult = ar
+	switch res.Status {
+	case command.TimeoutResultStatus:
+		e.Server.Exec.Status = status.New(codes.DeadlineExceeded, "timeout")
+	case command.RemoteErrorResultStatus:
+		st, ok := status.FromError(res.Err)
+		if !ok {
+			st = status.New(codes.Internal, "remote error")
+		}
+		e.Server.Exec.Status = st
+	case command.CacheHitResultStatus:
+		if !e.Server.Exec.Cached { // Assume the user means in this case the actual ActionCache should miss.
+			e.Server.ActionCache.Put(acDg, ar)
+		}
+	}
+	return cmdDg, acDg
 }

--- a/go/pkg/rexec/BUILD.bazel
+++ b/go/pkg/rexec/BUILD.bazel
@@ -24,13 +24,11 @@ go_test(
     srcs = ["rexec_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//go/digest:go_default_library",
         "//go/pkg/command:go_default_library",
         "//go/pkg/fakes:go_default_library",
         "//go/pkg/outerr:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
-        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
     ],

--- a/go/pkg/rexec/rexec_test.go
+++ b/go/pkg/rexec/rexec_test.go
@@ -21,8 +21,8 @@ import (
 )
 
 func TestExecCacheHit(t *testing.T) {
-	e := fakes.NewTestEnv(t)
-	defer e.Cleanup()
+	e, cleanup := fakes.NewTestEnv(t)
+	defer cleanup()
 	cmd := &command.Command{
 		Args:        []string{"tool"},
 		ExecRoot:    e.ExecRoot,
@@ -63,8 +63,8 @@ func TestExecCacheHit(t *testing.T) {
 
 // TestExecNotAcceptCached should skip both client-side and server side action cache lookups.
 func TestExecNotAcceptCached(t *testing.T) {
-	e := fakes.NewTestEnv(t)
-	defer e.Cleanup()
+	e, cleanup := fakes.NewTestEnv(t)
+	defer cleanup()
 	cmd := &command.Command{Args: []string{"tool"}, ExecRoot: e.ExecRoot}
 	opt := &command.ExecutionOptions{AcceptCached: false}
 	wantRes := &command.Result{Status: command.SuccessResultStatus}
@@ -106,8 +106,8 @@ func TestExecManualCacheMiss(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			e := fakes.NewTestEnv(t)
-			defer e.Cleanup()
+			e, cleanup := fakes.NewTestEnv(t)
+			defer cleanup()
 			cmd := &command.Command{Args: []string{"tool"}, ExecRoot: e.ExecRoot}
 			opt := &command.ExecutionOptions{AcceptCached: true, DownloadOutputs: true}
 			wantRes := &command.Result{Status: tc.want}
@@ -127,8 +127,8 @@ func TestExecManualCacheMiss(t *testing.T) {
 }
 
 func TestExecDoNotCache_NotAcceptCached(t *testing.T) {
-	e := fakes.NewTestEnv(t)
-	defer e.Cleanup()
+	e, cleanup := fakes.NewTestEnv(t)
+	defer cleanup()
 	cmd := &command.Command{Args: []string{"tool"}, ExecRoot: e.ExecRoot}
 	// DoNotCache true implies in particular that we also skip action cache lookups, local or remote.
 	opt := &command.ExecutionOptions{DoNotCache: true}
@@ -171,8 +171,8 @@ func TestExecRemoteFailureDownloadsPartialResults(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			e := fakes.NewTestEnv(t)
-			defer e.Cleanup()
+			e, cleanup := fakes.NewTestEnv(t)
+			defer cleanup()
 			cmd := &command.Command{
 				Args:        []string{"tool"},
 				OutputFiles: []string{"a/b/out"},
@@ -244,8 +244,8 @@ func TestDoNotDownloadOutputs(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			e := fakes.NewTestEnv(t)
-			defer e.Cleanup()
+			e, cleanup := fakes.NewTestEnv(t)
+			defer cleanup()
 			cmd := &command.Command{
 				Args:        []string{"tool"},
 				OutputFiles: []string{"a/b/out"},

--- a/go/pkg/rexec/rexec_test.go
+++ b/go/pkg/rexec/rexec_test.go
@@ -1,4 +1,6 @@
-package rexec
+// Package rexec_test contains tests for rexec package. It is a different package to avoid an
+// import cycle.
+package rexec_test
 
 import (
 	"bytes"
@@ -6,80 +8,33 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
-	"github.com/bazelbuild/remote-apis-sdks/go/digest"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/command"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/fakes"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/outerr"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 )
 
-// newTestEnv initializes the fake server, a client connected to it, and a temporary directory.
-func newTestEnv(t *testing.T) (*Client, *fakes.Server, string, func()) {
-	// Set up temp directory.
-	execRoot, err := ioutil.TempDir("", strings.ReplaceAll(t.Name(), string(filepath.Separator), "_"))
-	if err != nil {
-		t.Fatalf("failed to make temp dir: %v", err)
-	}
-	// Set up the fake.
-	s, err := fakes.NewServer()
-	if err != nil {
-		t.Fatalf("Error starting fake server: %v", err)
-	}
-	grpcClient, err := s.NewTestClient(context.Background())
-	if err != nil {
-		t.Fatalf("Error connecting to server: %v", err)
-	}
-	return &Client{&NoopFileDigestCache{}, grpcClient}, s, execRoot, func() {
-		grpcClient.Close()
-		s.Stop()
-		os.RemoveAll(execRoot)
-	}
-}
-
 func TestExecCacheHit(t *testing.T) {
-	c, s, execRoot, cleanup := newTestEnv(t)
-	defer cleanup()
-	cmdPb := &repb.Command{
-		Arguments:   []string{"tool"},
-		OutputFiles: []string{"a/b/out"},
-	}
-	cmdDg := digest.TestNewFromMessage(cmdPb)
-	ac := &repb.Action{
-		CommandDigest:   cmdDg.ToProto(),
-		InputRootDigest: digest.Empty.ToProto(),
-	}
-	acDg := digest.TestNewFromMessage(ac)
-	outDg := digest.NewFromBlob([]byte("output"))
-	errDg := digest.NewFromBlob([]byte("stderr"))
-	ar := &repb.ActionResult{
-		ExitCode:     0,
-		OutputFiles:  []*repb.OutputFile{&repb.OutputFile{Path: "a/b/out", Digest: outDg.ToProto()}},
-		StdoutRaw:    []byte("stdout"),
-		StderrDigest: errDg.ToProto(),
-	}
-	s.ActionCache.PutAction(ac, ar)
-	// Populate action outputs in CAS manually, because Execute will never be called.
-	s.CAS.Put([]byte("output"))
-	s.CAS.Put([]byte("stderr"))
-
+	e := fakes.NewTestEnv(t)
+	defer e.Cleanup()
 	cmd := &command.Command{
 		Args:        []string{"tool"},
-		ExecRoot:    execRoot,
+		ExecRoot:    e.ExecRoot,
 		OutputFiles: []string{"a/b/out"},
 	}
+	opt := command.DefaultExecutionOptions()
+	wantRes := &command.Result{Status: command.CacheHitResultStatus}
+	cmdDg, acDg := e.Set(cmd, opt, wantRes, &fakes.OutputFile{"a/b/out", "output"}, fakes.StdOut("stdout"), fakes.StdErrRaw("stderr"))
 	oe := outerr.NewRecordingOutErr()
 
-	res, meta := c.Run(context.Background(), cmd, command.DefaultExecutionOptions(), oe)
+	res, meta := e.Client.Run(context.Background(), cmd, opt, oe)
 
-	wantRes := &command.Result{Status: command.CacheHitResultStatus}
 	wantMeta := &command.Metadata{
 		CommandDigest: cmdDg,
 		ActionDigest:  acDg,
@@ -96,7 +51,7 @@ func TestExecCacheHit(t *testing.T) {
 	if !bytes.Equal(oe.Stderr(), []byte("stderr")) {
 		t.Errorf("Run() gave stderr diff: want \"stderr\", got: %v", oe.Stderr())
 	}
-	path := filepath.Join(execRoot, "a/b/out")
+	path := filepath.Join(e.ExecRoot, "a/b/out")
 	contents, err := ioutil.ReadFile(path)
 	if err != nil {
 		t.Errorf("error reading from %s: %v", path, err)
@@ -108,30 +63,18 @@ func TestExecCacheHit(t *testing.T) {
 
 // TestExecNotAcceptCached should skip both client-side and server side action cache lookups.
 func TestExecNotAcceptCached(t *testing.T) {
-	c, s, execRoot, cleanup := newTestEnv(t)
-	defer cleanup()
-	cmdPb := &repb.Command{
-		Arguments: []string{"tool"},
-	}
-	cmdDg := digest.TestNewFromMessage(cmdPb)
-	ac := &repb.Action{
-		CommandDigest:   cmdDg.ToProto(),
-		InputRootDigest: digest.Empty.ToProto(),
-	}
-	acDg := digest.TestNewFromMessage(ac)
-	s.ActionCache.PutAction(ac, &repb.ActionResult{StdoutRaw: []byte("cached")})
-	s.Exec.ActionResult = &repb.ActionResult{StdoutRaw: []byte("not cached")}
-
-	cmd := &command.Command{
-		Args:     []string{"tool"},
-		ExecRoot: execRoot,
-	}
+	e := fakes.NewTestEnv(t)
+	defer e.Cleanup()
+	cmd := &command.Command{Args: []string{"tool"}, ExecRoot: e.ExecRoot}
 	opt := &command.ExecutionOptions{AcceptCached: false}
+	wantRes := &command.Result{Status: command.SuccessResultStatus}
+	_, acDg := e.Set(cmd, opt, wantRes, fakes.StdOutRaw("not cached"))
+	e.Server.ActionCache.Put(acDg, &repb.ActionResult{StdoutRaw: []byte("cached")})
+
 	oe := outerr.NewRecordingOutErr()
 
-	res, _ := c.Run(context.Background(), cmd, opt, oe)
+	res, _ := e.Client.Run(context.Background(), cmd, opt, oe)
 
-	wantRes := &command.Result{Status: command.SuccessResultStatus}
 	if diff := cmp.Diff(wantRes, res); diff != "" {
 		t.Errorf("Run() gave result diff (-want +got):\n%s", diff)
 	}
@@ -139,7 +82,7 @@ func TestExecNotAcceptCached(t *testing.T) {
 		t.Errorf("Run() gave stdout diff: want \"not cached\", got: %v", oe.Stdout())
 	}
 	// We did specify DoNotCache=false, so the new result should now be cached:
-	if diff := cmp.Diff(s.Exec.ActionResult, s.ActionCache.Get(acDg)); diff != "" {
+	if diff := cmp.Diff(e.Server.Exec.ActionResult, e.Server.ActionCache.Get(acDg)); diff != "" {
 		t.Errorf("Run() did not cache executed result  (-want +got):\n%s", diff)
 	}
 }
@@ -163,28 +106,16 @@ func TestExecManualCacheMiss(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			c, s, execRoot, cleanup := newTestEnv(t)
-			defer cleanup()
-			errDg := digest.NewFromBlob([]byte("stderr"))
-			ar := &repb.ActionResult{
-				ExitCode:     0,
-				StderrDigest: errDg.ToProto(),
-			}
-			s.Exec.Cached = tc.cached
-			s.Exec.ActionResult = ar
-			s.Exec.OutputBlobs = [][]byte{[]byte("stderr")}
-
-			cmd := &command.Command{
-				Args:     []string{"tool"},
-				ExecRoot: execRoot,
-			}
-			opt := &command.ExecutionOptions{
-				AcceptCached:    true,
-				DownloadOutputs: true,
-			}
-			oe := outerr.NewRecordingOutErr()
-			res, _ := c.Run(context.Background(), cmd, opt, oe)
+			e := fakes.NewTestEnv(t)
+			defer e.Cleanup()
+			cmd := &command.Command{Args: []string{"tool"}, ExecRoot: e.ExecRoot}
+			opt := &command.ExecutionOptions{AcceptCached: true, DownloadOutputs: true}
 			wantRes := &command.Result{Status: tc.want}
+			e.Set(cmd, opt, wantRes, fakes.StdErr("stderr"), fakes.ExecutionCacheHit(tc.cached))
+			oe := outerr.NewRecordingOutErr()
+
+			res, _ := e.Client.Run(context.Background(), cmd, opt, oe)
+
 			if diff := cmp.Diff(wantRes, res); diff != "" {
 				t.Errorf("Run() gave result diff (-want +got):\n%s", diff)
 			}
@@ -196,31 +127,18 @@ func TestExecManualCacheMiss(t *testing.T) {
 }
 
 func TestExecDoNotCache_NotAcceptCached(t *testing.T) {
-	c, s, execRoot, cleanup := newTestEnv(t)
-	defer cleanup()
-	cmdPb := &repb.Command{
-		Arguments: []string{"tool"},
-	}
-	cmdDg := digest.TestNewFromMessage(cmdPb)
-	ac := &repb.Action{
-		CommandDigest:   cmdDg.ToProto(),
-		InputRootDigest: digest.Empty.ToProto(),
-	}
-	acDg := digest.TestNewFromMessage(ac)
-	s.ActionCache.PutAction(ac, &repb.ActionResult{StdoutRaw: []byte("cached")})
-	s.Exec.ActionResult = &repb.ActionResult{StdoutRaw: []byte("not cached")}
-
-	cmd := &command.Command{
-		Args:     []string{"tool"},
-		ExecRoot: execRoot,
-	}
+	e := fakes.NewTestEnv(t)
+	defer e.Cleanup()
+	cmd := &command.Command{Args: []string{"tool"}, ExecRoot: e.ExecRoot}
 	// DoNotCache true implies in particular that we also skip action cache lookups, local or remote.
 	opt := &command.ExecutionOptions{DoNotCache: true}
+	wantRes := &command.Result{Status: command.SuccessResultStatus}
+	_, acDg := e.Set(cmd, opt, wantRes, fakes.StdOutRaw("not cached"))
+	e.Server.ActionCache.Put(acDg, &repb.ActionResult{StdoutRaw: []byte("cached")})
 	oe := outerr.NewRecordingOutErr()
 
-	res, _ := c.Run(context.Background(), cmd, opt, oe)
+	res, _ := e.Client.Run(context.Background(), cmd, opt, oe)
 
-	wantRes := &command.Result{Status: command.SuccessResultStatus}
 	if diff := cmp.Diff(wantRes, res); diff != "" {
 		t.Errorf("Run() gave result diff (-want +got):\n%s", diff)
 	}
@@ -228,139 +146,62 @@ func TestExecDoNotCache_NotAcceptCached(t *testing.T) {
 		t.Errorf("Run() gave stdout diff: want \"not cached\", got: %v", oe.Stdout())
 	}
 	// The action cache should still contain the same result, because we specified DoNotCache.
-	if !bytes.Equal(s.ActionCache.Get(acDg).StdoutRaw, []byte("cached")) {
+	if !bytes.Equal(e.Server.ActionCache.Get(acDg).StdoutRaw, []byte("cached")) {
 		t.Error("Run() cached result for do_not_cache=true")
 	}
 }
 
-func TestExecNonZeroExit(t *testing.T) {
-	c, s, execRoot, cleanup := newTestEnv(t)
-	defer cleanup()
-	s.Exec.ActionResult = &repb.ActionResult{ExitCode: 52, StderrRaw: []byte("error")}
-
-	cmd := &command.Command{
-		Args:     []string{"tool"},
-		ExecRoot: execRoot,
-	}
-	oe := outerr.NewRecordingOutErr()
-
-	res, _ := c.Run(context.Background(), cmd, command.DefaultExecutionOptions(), oe)
-
-	wantRes := &command.Result{ExitCode: 52, Status: command.NonZeroExitResultStatus}
-	if diff := cmp.Diff(wantRes, res); diff != "" {
-		t.Errorf("Run() gave result diff (-want +got):\n%s", diff)
-	}
-	if !bytes.Equal(oe.Stderr(), []byte("error")) {
-		t.Errorf("Run() gave stderr diff: want \"error\", got: %v", oe.Stderr())
-	}
-}
-
-func TestExecRemoteFailure(t *testing.T) {
-	c, s, execRoot, cleanup := newTestEnv(t)
-	defer cleanup()
-	s.Exec.Status = status.New(codes.Internal, "problem")
-
-	cmd := &command.Command{
-		Args:     []string{"tool"},
-		ExecRoot: execRoot,
-	}
-	oe := outerr.NewRecordingOutErr()
-
-	res, _ := c.Run(context.Background(), cmd, command.DefaultExecutionOptions(), oe)
-
-	wantRes := command.NewRemoteErrorResult(s.Exec.Status.Err())
-	if diff := cmp.Diff(wantRes, res); diff != "" {
-		t.Errorf("Run() gave result diff (-want +got):\n%s", diff)
-	}
-	if len(oe.Stdout()) != 0 {
-		t.Errorf("Run() gave unexpected stdout: %v", oe.Stdout())
-	}
-	if len(oe.Stderr()) != 0 {
-		t.Errorf("Run() gave unexpected stderr: %v", oe.Stderr())
-	}
-}
-
 func TestExecRemoteFailureDownloadsPartialResults(t *testing.T) {
-	c, s, execRoot, cleanup := newTestEnv(t)
-	defer cleanup()
-	outDg := digest.NewFromBlob([]byte("output"))
-	errDg := digest.NewFromBlob([]byte("stderr"))
-	s.Exec.ActionResult = &repb.ActionResult{
-		ExitCode:     53,
-		StderrDigest: errDg.ToProto(),
-		OutputFiles:  []*repb.OutputFile{&repb.OutputFile{Path: "a/b/out", Digest: outDg.ToProto()}},
+	tests := []struct {
+		name    string
+		wantRes *command.Result
+	}{
+		{
+			name:    "non zero exit",
+			wantRes: &command.Result{ExitCode: 52, Status: command.NonZeroExitResultStatus},
+		},
+		{
+			name:    "remote error",
+			wantRes: command.NewRemoteErrorResult(status.New(codes.Internal, "problem").Err()),
+		},
+		{
+			name:    "timeout",
+			wantRes: command.NewTimeoutResult(),
+		},
 	}
-	s.Exec.OutputBlobs = [][]byte{[]byte("stderr"), []byte("output")}
-	s.Exec.Status = status.New(codes.Internal, "problem")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := fakes.NewTestEnv(t)
+			defer e.Cleanup()
+			cmd := &command.Command{
+				Args:        []string{"tool"},
+				OutputFiles: []string{"a/b/out"},
+				ExecRoot:    e.ExecRoot,
+			}
+			opt := command.DefaultExecutionOptions()
+			e.Set(cmd, opt, tc.wantRes, fakes.StdErr("stderr"), &fakes.OutputFile{"a/b/out", "output"})
+			oe := outerr.NewRecordingOutErr()
 
-	cmd := &command.Command{
-		Args:        []string{"tool"},
-		OutputFiles: []string{"a/b/out"},
-		ExecRoot:    execRoot,
-	}
-	oe := outerr.NewRecordingOutErr()
+			res, _ := e.Client.Run(context.Background(), cmd, opt, oe)
 
-	res, _ := c.Run(context.Background(), cmd, command.DefaultExecutionOptions(), oe)
-
-	wantRes := command.NewRemoteErrorResult(s.Exec.Status.Err())
-	if diff := cmp.Diff(wantRes, res); diff != "" {
-		t.Errorf("Run() gave result diff (-want +got):\n%s", diff)
-	}
-	if len(oe.Stdout()) != 0 {
-		t.Errorf("Run() gave unexpected stdout: %v", oe.Stdout())
-	}
-	if !bytes.Equal(oe.Stderr(), []byte("stderr")) {
-		t.Errorf("Run() gave stderr diff: want \"stderr\", got: %v", oe.Stderr())
-	}
-	path := filepath.Join(execRoot, "a/b/out")
-	contents, err := ioutil.ReadFile(path)
-	if err != nil {
-		t.Errorf("error reading from %s: %v", path, err)
-	}
-	if !bytes.Equal(contents, []byte("output")) {
-		t.Errorf("expected %s to contain \"output\", got %v", path, contents)
-	}
-}
-
-func TestExecTimeoutDownloadsPartialResults(t *testing.T) {
-	c, s, execRoot, cleanup := newTestEnv(t)
-	defer cleanup()
-	outDg := digest.NewFromBlob([]byte("output"))
-	errDg := digest.NewFromBlob([]byte("stderr"))
-	s.Exec.ActionResult = &repb.ActionResult{
-		ExitCode:     53,
-		StderrDigest: errDg.ToProto(),
-		OutputFiles:  []*repb.OutputFile{&repb.OutputFile{Path: "a/b/out", Digest: outDg.ToProto()}},
-	}
-	s.Exec.OutputBlobs = [][]byte{[]byte("stderr"), []byte("output")}
-	s.Exec.Status = status.New(codes.DeadlineExceeded, "timeout")
-
-	cmd := &command.Command{
-		Args:        []string{"tool"},
-		OutputFiles: []string{"a/b/out"},
-		ExecRoot:    execRoot,
-	}
-	oe := outerr.NewRecordingOutErr()
-
-	res, _ := c.Run(context.Background(), cmd, command.DefaultExecutionOptions(), oe)
-
-	wantRes := command.NewTimeoutResult()
-	if diff := cmp.Diff(wantRes, res); diff != "" {
-		t.Errorf("Run() gave result diff (-want +got):\n%s", diff)
-	}
-	if len(oe.Stdout()) != 0 {
-		t.Errorf("Run() gave unexpected stdout: %v", oe.Stdout())
-	}
-	if !bytes.Equal(oe.Stderr(), []byte("stderr")) {
-		t.Errorf("Run() gave stderr diff: want \"stderr\", got: %v", oe.Stderr())
-	}
-	path := filepath.Join(execRoot, "a/b/out")
-	contents, err := ioutil.ReadFile(path)
-	if err != nil {
-		t.Errorf("error reading from %s: %v", path, err)
-	}
-	if !bytes.Equal(contents, []byte("output")) {
-		t.Errorf("expected %s to contain \"output\", got %v", path, contents)
+			if diff := cmp.Diff(tc.wantRes, res); diff != "" {
+				t.Errorf("Run() gave result diff (-want +got):\n%s", diff)
+			}
+			if len(oe.Stdout()) != 0 {
+				t.Errorf("Run() gave unexpected stdout: %v", oe.Stdout())
+			}
+			if !bytes.Equal(oe.Stderr(), []byte("stderr")) {
+				t.Errorf("Run() gave stderr diff: want \"stderr\", got: %v", oe.Stderr())
+			}
+			path := filepath.Join(e.ExecRoot, "a/b/out")
+			contents, err := ioutil.ReadFile(path)
+			if err != nil {
+				t.Errorf("error reading from %s: %v", path, err)
+			}
+			if !bytes.Equal(contents, []byte("output")) {
+				t.Errorf("expected %s to contain \"output\", got %v", path, contents)
+			}
+		})
 	}
 }
 
@@ -377,8 +218,12 @@ func TestDoNotDownloadOutputs(t *testing.T) {
 			wantRes: &command.Result{Status: command.SuccessResultStatus},
 		},
 		{
-			name:    "remote cached",
+			name:    "remote exec cache hit",
 			cached:  true,
+			wantRes: &command.Result{Status: command.CacheHitResultStatus},
+		},
+		{
+			name:    "action cache hit",
 			wantRes: &command.Result{Status: command.CacheHitResultStatus},
 		},
 		{
@@ -399,28 +244,18 @@ func TestDoNotDownloadOutputs(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			c, s, execRoot, cleanup := newTestEnv(t)
-			defer cleanup()
-			outDg := digest.NewFromBlob([]byte("output"))
-			errDg := digest.NewFromBlob([]byte("stderr"))
-			s.Exec.ActionResult = &repb.ActionResult{
-				ExitCode:     tc.exitCode,
-				StderrDigest: errDg.ToProto(),
-				OutputFiles:  []*repb.OutputFile{&repb.OutputFile{Path: "a/b/out", Digest: outDg.ToProto()}},
-			}
-			s.Exec.Cached = tc.cached
-			s.Exec.OutputBlobs = [][]byte{[]byte("stderr"), []byte("output")}
-			s.Exec.Status = tc.status
-
+			e := fakes.NewTestEnv(t)
+			defer e.Cleanup()
 			cmd := &command.Command{
 				Args:        []string{"tool"},
 				OutputFiles: []string{"a/b/out"},
-				ExecRoot:    execRoot,
+				ExecRoot:    e.ExecRoot,
 			}
+			opt := &command.ExecutionOptions{AcceptCached: true, DownloadOutputs: false}
+			e.Set(cmd, opt, tc.wantRes, fakes.StdErr("stderr"), &fakes.OutputFile{"a/b/out", "output"}, fakes.ExecutionCacheHit(tc.cached))
 			oe := outerr.NewRecordingOutErr()
 
-			opt := &command.ExecutionOptions{AcceptCached: true, DownloadOutputs: false}
-			res, _ := c.Run(context.Background(), cmd, opt, oe)
+			res, _ := e.Client.Run(context.Background(), cmd, opt, oe)
 
 			if diff := cmp.Diff(tc.wantRes, res); diff != "" {
 				t.Errorf("Run() gave result diff (-want +got):\n%s", diff)
@@ -431,128 +266,9 @@ func TestDoNotDownloadOutputs(t *testing.T) {
 			if !bytes.Equal(oe.Stderr(), []byte("stderr")) {
 				t.Errorf("Run() gave stderr diff: want \"stderr\", got: %v", oe.Stderr())
 			}
-			path := filepath.Join(execRoot, "a/b/out")
+			path := filepath.Join(e.ExecRoot, "a/b/out")
 			if _, err := os.Stat(path); !os.IsNotExist(err) {
 				t.Errorf("expected output file %s to not be downloaded, but it was", path)
-			}
-		})
-	}
-}
-
-func TestDoNotDownloadOutputs_cached(t *testing.T) {
-	c, s, execRoot, cleanup := newTestEnv(t)
-	defer cleanup()
-	cmdPb := &repb.Command{
-		Arguments:   []string{"tool"},
-		OutputFiles: []string{"a/b/out"},
-	}
-	cmdDg := digest.TestNewFromMessage(cmdPb)
-	ac := &repb.Action{
-		CommandDigest:   cmdDg.ToProto(),
-		InputRootDigest: digest.Empty.ToProto(),
-	}
-	outDg := digest.NewFromBlob([]byte("output"))
-	errDg := digest.NewFromBlob([]byte("stderr"))
-	ar := &repb.ActionResult{
-		ExitCode:     0,
-		OutputFiles:  []*repb.OutputFile{&repb.OutputFile{Path: "a/b/out", Digest: outDg.ToProto()}},
-		StderrDigest: errDg.ToProto(),
-	}
-	s.ActionCache.PutAction(ac, ar)
-	// Populate action outputs in CAS manually, because Execute will never be called.
-	s.CAS.Put([]byte("output"))
-	s.CAS.Put([]byte("stderr"))
-
-	opt := &command.ExecutionOptions{
-		AcceptCached:    true,
-		DownloadOutputs: false,
-	}
-	cmd := &command.Command{
-		Args:        []string{"tool"},
-		ExecRoot:    execRoot,
-		OutputFiles: []string{"a/b/out"},
-	}
-	oe := outerr.NewRecordingOutErr()
-
-	res, _ := c.Run(context.Background(), cmd, opt, oe)
-
-	wantRes := &command.Result{Status: command.CacheHitResultStatus}
-	if diff := cmp.Diff(wantRes, res); diff != "" {
-		t.Errorf("Run() gave result diff (-want +got):\n%s", diff)
-	}
-	if len(oe.Stdout()) != 0 {
-		t.Errorf("Run() gave unexpected stdout: %v", oe.Stdout())
-	}
-	if !bytes.Equal(oe.Stderr(), []byte("stderr")) {
-		t.Errorf("Run() gave stderr diff: want \"stderr\", got: %v", oe.Stderr())
-	}
-	path := filepath.Join(execRoot, "a/b/out")
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Errorf("expected output file %s to not be downloaded, but it was", path)
-	}
-}
-
-func TestBuildCommand(t *testing.T) {
-	tests := []struct {
-		name    string
-		cmd     *command.Command
-		wantCmd *repb.Command
-	}{
-		{
-			name:    "pass args",
-			cmd:     &command.Command{Args: []string{"foo", "bar"}},
-			wantCmd: &repb.Command{Arguments: []string{"foo", "bar"}},
-		},
-		{
-			name:    "pass working directory",
-			cmd:     &command.Command{WorkingDir: "a/b"},
-			wantCmd: &repb.Command{WorkingDirectory: "a/b"},
-		},
-		{
-			name:    "sort output files",
-			cmd:     &command.Command{OutputFiles: []string{"foo", "bar", "abc"}},
-			wantCmd: &repb.Command{OutputFiles: []string{"abc", "bar", "foo"}},
-		},
-		{
-			name:    "sort output directories",
-			cmd:     &command.Command{OutputDirs: []string{"foo", "bar", "abc"}},
-			wantCmd: &repb.Command{OutputDirectories: []string{"abc", "bar", "foo"}},
-		},
-		{
-			name: "sort environment variables",
-			cmd: &command.Command{
-				InputSpec: &command.InputSpec{
-					EnvironmentVariables: map[string]string{"b": "3", "a": "2", "c": "1"},
-				},
-			},
-			wantCmd: &repb.Command{
-				EnvironmentVariables: []*repb.Command_EnvironmentVariable{
-					&repb.Command_EnvironmentVariable{Name: "a", Value: "2"},
-					&repb.Command_EnvironmentVariable{Name: "b", Value: "3"},
-					&repb.Command_EnvironmentVariable{Name: "c", Value: "1"},
-				},
-			},
-		},
-		{
-			name: "sort platform",
-			cmd:  &command.Command{Platform: map[string]string{"b": "3", "a": "2", "c": "1"}},
-			wantCmd: &repb.Command{
-				Platform: &repb.Platform{
-					Properties: []*repb.Platform_Property{
-						&repb.Platform_Property{Name: "a", Value: "2"},
-						&repb.Platform_Property{Name: "b", Value: "3"},
-						&repb.Platform_Property{Name: "c", Value: "1"},
-					},
-				},
-			},
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			tc.cmd.FillDefaultFieldValues()
-			gotCmd := buildCommand(tc.cmd)
-			if diff := cmp.Diff(tc.wantCmd, gotCmd, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("%s: buildCommand gave result diff (-want +got):\n%s", tc.name, diff)
 			}
 		})
 	}


### PR DESCRIPTION
Refactoring the current rexec_test to use it. Note that tests have not
been removed! They just became more easily packaged into test structs
using the new fake.