### PR TITLE
Building Merkle tree into Chunkers

### DIFF
--- a/go/client/bytestream.go
+++ b/go/client/bytestream.go
@@ -15,7 +15,7 @@ import (
 
 // WriteBytes uploads a byte slice.
 func (c *Client) WriteBytes(ctx context.Context, name string, data []byte) error {
-	return c.WriteChunked(ctx, name, chunker.NewFromBlob(data, int(c.chunkMaxSize)))
+	return c.WriteChunked(ctx, name, chunker.NewFromBlob(data, int(c.ChunkMaxSize)))
 }
 
 // WriteChunked uploads chunked data with a given resource name to the CAS.

--- a/go/client/cas.go
+++ b/go/client/cas.go
@@ -65,7 +65,7 @@ func (c *Client) UploadIfMissing(ctx context.Context, data ...*chunker.Chunker) 
 		eg.Go(func() error {
 			defer func() { <-c.casUploaders }()
 			if i%logInterval == 0 {
-				log.V(2).Infof("%d batches left to store", len(batches))
+				log.V(2).Infof("%d batches left to store", len(batches)-i)
 			}
 			if len(batch) > 1 {
 				log.V(3).Infof("Uploading batch of %d blobs", len(batch))
@@ -111,7 +111,7 @@ func (c *Client) UploadIfMissing(ctx context.Context, data ...*chunker.Chunker) 
 func (c *Client) WriteBlobs(ctx context.Context, blobs map[digest.Digest][]byte) error {
 	var chunkers []*chunker.Chunker
 	for _, blob := range blobs {
-		chunkers = append(chunkers, chunker.NewFromBlob(blob, int(c.chunkMaxSize)))
+		chunkers = append(chunkers, chunker.NewFromBlob(blob, int(c.ChunkMaxSize)))
 	}
 	return c.UploadIfMissing(ctx, chunkers...)
 }
@@ -127,7 +127,7 @@ func (c *Client) WriteProto(ctx context.Context, msg proto.Message) (digest.Dige
 
 // WriteBlob uploads a blob to the CAS.
 func (c *Client) WriteBlob(ctx context.Context, blob []byte) (digest.Digest, error) {
-	ch := chunker.NewFromBlob(blob, int(c.chunkMaxSize))
+	ch := chunker.NewFromBlob(blob, int(c.ChunkMaxSize))
 	dg := ch.Digest()
 	return dg, c.WriteChunked(ctx, c.ResourceNameWrite(dg.Hash, dg.Size), ch)
 }
@@ -355,7 +355,7 @@ func (c *Client) MissingBlobs(ctx context.Context, ds []digest.Digest) ([]digest
 		eg.Go(func() error {
 			defer func() { <-c.casUploaders }()
 			if i%logInterval == 0 {
-				log.V(3).Infof("%d missing batches left to query", len(batches))
+				log.V(3).Infof("%d missing batches left to query", len(batches)-i)
 			}
 			var batchPb []*repb.Digest
 			for _, dg := range batch {

--- a/go/client/client.go
+++ b/go/client/client.go
@@ -58,8 +58,9 @@ type Client struct {
 	// Retrier is the Retrier that is used for RPCs made by this client.
 	//
 	// This field is logically "protected" and is intended for use by extensions of Client.
-	Retrier      *Retrier
-	chunkMaxSize ChunkMaxSize
+	Retrier *Retrier
+	// ChunkMaxSize is maximum chunk size to use for CAS uploads/downloads.
+	ChunkMaxSize ChunkMaxSize
 	useBatchOps  UseBatchOps
 	casUploaders chan bool
 	rpcTimeout   time.Duration
@@ -78,7 +79,7 @@ type ChunkMaxSize int
 
 // Apply sets the client's maximal chunk size s.
 func (s ChunkMaxSize) Apply(c *Client) {
-	c.chunkMaxSize = s
+	c.ChunkMaxSize = s
 }
 
 // UseBatchOps can be set to true to use batch CAS operations when uploading multiple blobs, or
@@ -233,7 +234,7 @@ func NewClient(conn *grpc.ClientConn, instanceName string, opts ...Opt) (*Client
 		operations:   opgrpc.NewOperationsClient(conn),
 		rpcTimeout:   time.Minute,
 		Closer:       conn,
-		chunkMaxSize: chunker.DefaultChunkSize,
+		ChunkMaxSize: chunker.DefaultChunkSize,
 		useBatchOps:  true,
 		casUploaders: make(chan bool, DefaultCASConcurrency),
 	}

--- a/go/pkg/tree/BUILD.bazel
+++ b/go/pkg/tree/BUILD.bazel
@@ -2,37 +2,28 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["rexec.go"],
-    importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/rexec",
+    srcs = ["tree.go"],
+    importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/tree",
     visibility = ["//visibility:public"],
     deps = [
-        "//go/client:go_default_library",
         "//go/digest:go_default_library",
         "//go/pkg/chunker:go_default_library",
         "//go/pkg/command:go_default_library",
-        "//go/pkg/filemetadata:go_default_library",
-        "//go/pkg/outerr:go_default_library",
-        "//go/pkg/tree:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
-        "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
-        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
-        "@org_golang_google_grpc//codes:go_default_library",
-        "@org_golang_google_grpc//status:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["rexec_test.go"],
+    srcs = ["tree_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//go/digest:go_default_library",
+        "//go/pkg/chunker:go_default_library",
         "//go/pkg/command:go_default_library",
-        "//go/pkg/fakes:go_default_library",
-        "//go/pkg/outerr:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
-        "@org_golang_google_grpc//codes:go_default_library",
-        "@org_golang_google_grpc//status:go_default_library",
     ],
 )

--- a/go/pkg/tree/tree.go
+++ b/go/pkg/tree/tree.go
@@ -1,0 +1,268 @@
+// Package tree provides functionality for constructing a Merkle tree of uploadable inputs.
+package tree
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/digest"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/chunker"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/command"
+	"github.com/golang/protobuf/proto"
+
+	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+)
+
+// treeNode represents a file tree, which is an intermediate representation used to encode a Merkle
+// tree later. It corresponds roughly to a *repb.Directory, but with pointers, not digests, used to
+// refer to other nodes.
+type treeNode struct {
+	Files map[string]*chunker.Chunker
+	Dirs  map[string]*treeNode
+}
+
+// shouldIgnore returns whether a given input should be excluded based on the given InputExclusions,
+func shouldIgnore(inp string, t command.InputType, excl []*command.InputExclusion) bool {
+	for _, r := range excl {
+		if r.Type != command.UnspecifiedInputType && r.Type != t {
+			continue
+		}
+		if m, _ := regexp.MatchString(r.Regex, inp); m {
+			return true
+		}
+	}
+	return false
+}
+
+// loadFiles reads all files specified by the given InputSpec (descending into subdirectories
+// recursively), and loads their contents into the provided map.
+func loadFiles(execRoot string, excl []*command.InputExclusion, path string, fs map[string]*chunker.Chunker, chunkSize int) error {
+	absPath := filepath.Join(execRoot, path)
+	fi, err := os.Stat(absPath)
+	if err != nil {
+		return err
+	}
+	var t command.InputType
+	switch mode := fi.Mode(); {
+	case mode.IsDir():
+		t = command.DirectoryInputType
+	case mode.IsRegular():
+		t = command.FileInputType
+	default:
+		return fmt.Errorf("unsupported input type: %s, %v", absPath, mode)
+	}
+
+	if shouldIgnore(absPath, t, excl) {
+		return nil
+	}
+	if t == command.FileInputType {
+		dg, err := digest.NewFromFile(absPath)
+		if err != nil {
+			return err
+		}
+		fs[path] = chunker.NewFromFile(absPath, dg, chunkSize)
+		return nil
+	}
+	// Directory
+	files, err := ioutil.ReadDir(absPath)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range files {
+		if e := loadFiles(execRoot, excl, filepath.Join(path, f.Name()), fs, chunkSize); e != nil {
+			return e
+		}
+	}
+	return nil
+}
+
+// ComputeMerkleTree packages an InputSpec into uploadable inputs, returned as Chunkers.
+func ComputeMerkleTree(execRoot string, is *command.InputSpec, chunkSize int) (root digest.Digest, inputs []*chunker.Chunker, err error) {
+	fs := make(map[string]*chunker.Chunker)
+	for _, i := range is.Inputs {
+		if i == "" {
+			return digest.Empty, nil, errors.New("empty Input, use \".\" for entire exec root")
+		}
+		if e := loadFiles(execRoot, is.InputExclusions, i, fs, chunkSize); e != nil {
+			return digest.Empty, nil, e
+		}
+	}
+	for _, i := range is.VirtualInputs {
+		if i.Path == "" {
+			return digest.Empty, nil, errors.New("empty Path in VirtualInputs")
+		}
+		fs[i.Path] = chunker.NewFromBlob(i.Contents, chunkSize)
+	}
+	ft := buildTree(fs)
+	var blobs map[digest.Digest]*chunker.Chunker
+	root, blobs, err = packageTree(ft, chunkSize)
+	if err != nil {
+		return digest.Empty, nil, err
+	}
+	for _, ch := range blobs {
+		inputs = append(inputs, ch)
+	}
+	return root, inputs, nil
+}
+
+func buildTree(files map[string]*chunker.Chunker) *treeNode {
+	// This is not the fastest way to build a Merkle tree, but it should do for the intended uses of
+	// this library.
+	root := &treeNode{}
+	for name, ch := range files {
+		segs := strings.Split(name, "/")
+		// The last segment is the filename, so split it off.
+		segs, base := segs[0:len(segs)-1], segs[len(segs)-1]
+
+		node := root
+		for _, s := range segs {
+			if node.Dirs == nil {
+				node.Dirs = make(map[string]*treeNode)
+			}
+			child := node.Dirs[s]
+			if child == nil {
+				child = &treeNode{}
+				node.Dirs[s] = child
+			}
+			node = child
+		}
+
+		if node.Files == nil {
+			node.Files = make(map[string]*chunker.Chunker)
+		}
+		node.Files[base] = ch
+	}
+	return root
+}
+
+func packageTree(t *treeNode, chunkSize int) (root digest.Digest, blobs map[digest.Digest]*chunker.Chunker, err error) {
+	if t == nil {
+		return digest.Empty, nil, errors.New("nil treeNode while packaging tree")
+	}
+	dir := &repb.Directory{}
+	blobs = make(map[digest.Digest]*chunker.Chunker)
+
+	for name, child := range t.Dirs {
+		if name == "" {
+			return digest.Empty, nil, errors.New("empty directory name while packaging tree")
+		}
+		dg, childBlobs, err := packageTree(child, chunkSize)
+		if err != nil {
+			return digest.Empty, nil, err
+		}
+		dir.Directories = append(dir.Directories, &repb.DirectoryNode{Name: name, Digest: dg.ToProto()})
+		for d, b := range childBlobs {
+			blobs[d] = b
+		}
+	}
+	sort.Slice(dir.Directories, func(i, j int) bool { return dir.Directories[i].Name < dir.Directories[j].Name })
+
+	for name, ch := range t.Files {
+		if name == "" {
+			return digest.Empty, nil, errors.New("empty file name while packaging tree")
+		}
+		if _, ok := t.Dirs[name]; ok {
+			return digest.Empty, nil, errors.New("directory and file with the same name while packaging tree")
+		}
+		dg := ch.Digest()
+		dir.Files = append(dir.Files, &repb.FileNode{Name: name, Digest: dg.ToProto(), IsExecutable: true})
+		blobs[dg] = ch
+	}
+	sort.Slice(dir.Files, func(i, j int) bool { return dir.Files[i].Name < dir.Files[j].Name })
+
+	encDir, err := proto.Marshal(dir)
+	if err != nil {
+		return digest.Empty, nil, err
+	}
+	ch := chunker.NewFromBlob(encDir, chunkSize)
+	dg := ch.Digest()
+	blobs[dg] = ch
+	return dg, blobs, nil
+}
+
+// Output represents a leaf output node in a nested directory structure (either a file or a
+// symlink).
+type Output struct {
+	Digest        digest.Digest
+	Path          string
+	IsExecutable  bool
+	SymlinkTarget string
+}
+
+// FlattenTree takes a Tree message and calculates the relative paths of all the files to
+// the tree root. Note that only files are included in the returned slice, not the intermediate
+// directories. Empty directories will be skipped, and directories containing only other directories
+// will be omitted as well.
+func FlattenTree(tree *repb.Tree, rootPath string) (map[string]*Output, error) {
+	root, err := digest.NewFromMessage(tree.Root)
+	if err != nil {
+		return nil, err
+	}
+	dirs := make(map[digest.Digest]*repb.Directory)
+	dirs[root] = tree.Root
+	for _, ch := range tree.Children {
+		dg, e := digest.NewFromMessage(ch)
+		if e != nil {
+			return nil, e
+		}
+		dirs[dg] = ch
+	}
+	return flattenTree(root, rootPath, dirs)
+}
+
+func flattenTree(root digest.Digest, rootPath string, dirs map[digest.Digest]*repb.Directory) (map[string]*Output, error) {
+	// Create a queue of unprocessed directories, along with their flattened
+	// path names.
+	type queueElem struct {
+		d digest.Digest
+		p string
+	}
+	queue := []*queueElem{}
+	queue = append(queue, &queueElem{d: root, p: rootPath})
+
+	// Process the queue, recording all flattened Outputs as we go.
+	flatFiles := make(map[string]*Output)
+	for len(queue) > 0 {
+		flatDir := queue[0]
+		queue = queue[1:]
+
+		dir, ok := dirs[flatDir.d]
+		if !ok {
+			return nil, fmt.Errorf("couldn't find directory %s with digest %s", flatDir.p, flatDir.d)
+		}
+
+		// Add files to the set to return
+		for _, file := range dir.Files {
+			out := &Output{
+				Path:         filepath.Join(flatDir.p, file.Name),
+				Digest:       digest.NewFromProtoUnvalidated(file.Digest),
+				IsExecutable: file.IsExecutable,
+			}
+			flatFiles[out.Path] = out
+		}
+
+		// Add symlinks to the set to return
+		for _, sm := range dir.Symlinks {
+			out := &Output{
+				Path:          filepath.Join(flatDir.p, sm.Name),
+				SymlinkTarget: sm.Target,
+			}
+			flatFiles[out.Path] = out
+		}
+
+		// Add subdirectories to the queue
+		for _, subdir := range dir.Directories {
+			digest := digest.NewFromProtoUnvalidated(subdir.Digest)
+			name := filepath.Join(flatDir.p, subdir.Name)
+			queue = append(queue, &queueElem{d: digest, p: name})
+		}
+	}
+	return flatFiles, nil
+}

--- a/go/pkg/tree/tree_test.go
+++ b/go/pkg/tree/tree_test.go
@@ -382,7 +382,7 @@ func TestComputeMerkleTree(t *testing.T) {
 						t.Errorf("  Diff between unpacked roots (want -> got):\n%s", diff)
 					}
 				} else {
-					t.Logf("  Root digest gotten not present in blobs map")
+					t.Errorf("  Root digest gotten not present in blobs map")
 				}
 			}
 			if diff := cmp.Diff(wantBlobs, gotBlobs); diff != "" {
@@ -434,8 +434,7 @@ func TestComputeMerkleTreeErrors(t *testing.T) {
 			t.Fatalf("failed to construct input dir structure: %v", err)
 		}
 		t.Run(tc.desc, func(t *testing.T) {
-			_, _, err := ComputeMerkleTree(root, tc.spec, chunker.DefaultChunkSize)
-			if err == nil {
+			if _, _, err := ComputeMerkleTree(root, tc.spec, chunker.DefaultChunkSize); err == nil {
 				t.Errorf("ComputeMerkleTree(%v) succeeded, want error", tc.spec)
 			}
 		})

--- a/go/pkg/tree/tree_test.go
+++ b/go/pkg/tree/tree_test.go
@@ -1,0 +1,522 @@
+package tree
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/digest"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/chunker"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/command"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
+
+	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+)
+
+func mustMarshal(t *testing.T, p proto.Message) []byte {
+	t.Helper()
+	b, err := proto.Marshal(p)
+	if err != nil {
+		t.Fatalf("error marshalling proto during test setup: %s", err)
+	}
+	return b
+}
+
+type inputPath struct {
+	path          string
+	fileContents  []byte
+	isSymlink     bool
+	isAbsolute    bool
+	symlinkTarget string
+}
+
+func construct(dir string, ips []*inputPath) error {
+	for _, ip := range ips {
+		path := filepath.Join(dir, ip.path)
+		if ip.isSymlink {
+			target := ip.symlinkTarget
+			if ip.isAbsolute {
+				target = filepath.Join(dir, target)
+			}
+			if err := os.Symlink(target, path); err != nil {
+				return err
+			}
+			continue
+		}
+		// Regular file.
+		if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
+			return err
+		}
+		if err := ioutil.WriteFile(path, ip.fileContents, 0777); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestComputeMerkleTree(t *testing.T) {
+	fooBlob, barBlob := []byte("foo"), []byte("bar")
+	fooDg, barDg := digest.NewFromBlob(fooBlob), digest.NewFromBlob(barBlob)
+	fooDgPb, barDgPb := fooDg.ToProto(), barDg.ToProto()
+
+	fooDir := &repb.Directory{Files: []*repb.FileNode{{Name: "foo", Digest: fooDgPb, IsExecutable: true}}}
+	barDir := &repb.Directory{Files: []*repb.FileNode{{Name: "bar", Digest: barDgPb, IsExecutable: true}}}
+	foobarDir := &repb.Directory{Files: []*repb.FileNode{
+		{Name: "bar", Digest: barDgPb, IsExecutable: true},
+		{Name: "foo", Digest: fooDgPb, IsExecutable: true},
+	}}
+
+	fooDirBlob, barDirBlob, foobarDirBlob := mustMarshal(t, fooDir), mustMarshal(t, barDir), mustMarshal(t, foobarDir)
+	fooDirDg, barDirDg, foobarDirDg := digest.NewFromBlob(fooDirBlob), digest.NewFromBlob(barDirBlob), digest.NewFromBlob(foobarDirBlob)
+	fooDirDgPb, barDirDgPb := fooDirDg.ToProto(), barDirDg.ToProto()
+
+	tests := []struct {
+		desc  string
+		input []*inputPath
+		spec  *command.InputSpec
+		// The expected results are calculated by marshalling rootDir, then expecting the result to be
+		// the digest of rootDir plus a map containing rootDir's marshalled blob and all the additional
+		// blobs.
+		rootDir         *repb.Directory
+		additionalBlobs [][]byte
+	}{
+		{
+			desc:            "Empty directory",
+			input:           nil,
+			spec:            &command.InputSpec{},
+			rootDir:         &repb.Directory{},
+			additionalBlobs: nil,
+		},
+		{
+			desc: "Files at root",
+			input: []*inputPath{
+				{path: "foo", fileContents: fooBlob},
+				{path: "bar", fileContents: barBlob},
+			},
+			spec: &command.InputSpec{
+				Inputs: []string{"foo", "bar"},
+			},
+			rootDir:         foobarDir,
+			additionalBlobs: [][]byte{fooBlob, barBlob},
+		},
+		{
+			desc: "File below root",
+			input: []*inputPath{
+				{path: "fooDir/foo", fileContents: fooBlob},
+				{path: "barDir/bar", fileContents: barBlob},
+			},
+			spec: &command.InputSpec{
+				Inputs: []string{"fooDir", "barDir"},
+			},
+			rootDir: &repb.Directory{Directories: []*repb.DirectoryNode{
+				{Name: "barDir", Digest: barDirDgPb},
+				{Name: "fooDir", Digest: fooDirDgPb},
+			}},
+			additionalBlobs: [][]byte{fooBlob, barBlob, fooDirBlob, barDirBlob},
+		},
+		{
+			desc: "File absolute symlink",
+			input: []*inputPath{
+				{path: "fooDir/foo", fileContents: fooBlob},
+				{path: "bar", isSymlink: true, isAbsolute: true, symlinkTarget: "fooDir/foo"},
+			},
+			spec: &command.InputSpec{
+				Inputs: []string{"fooDir", "bar"},
+			},
+			rootDir: &repb.Directory{
+				Directories: []*repb.DirectoryNode{{Name: "fooDir", Digest: fooDirDgPb}},
+				Files:       []*repb.FileNode{{Name: "bar", Digest: fooDgPb, IsExecutable: true}},
+			},
+			additionalBlobs: [][]byte{fooBlob, fooDirBlob},
+		},
+		{
+			desc: "File relative symlink",
+			input: []*inputPath{
+				{path: "fooDir/foo", fileContents: fooBlob},
+				{path: "bar", isSymlink: true, symlinkTarget: "fooDir/foo"},
+			},
+			spec: &command.InputSpec{
+				Inputs: []string{"fooDir", "bar"},
+			},
+			rootDir: &repb.Directory{
+				Directories: []*repb.DirectoryNode{{Name: "fooDir", Digest: fooDirDgPb}},
+				Files:       []*repb.FileNode{{Name: "bar", Digest: fooDgPb, IsExecutable: true}},
+			},
+			additionalBlobs: [][]byte{fooBlob, fooDirBlob},
+		},
+		{
+			desc: "Directory absolute symlink",
+			input: []*inputPath{
+				{path: "fooDir/foo", fileContents: fooBlob},
+				{path: "barDirTarget/bar", fileContents: barBlob},
+				{path: "barDir", isSymlink: true, isAbsolute: true, symlinkTarget: "barDirTarget"},
+			},
+			spec: &command.InputSpec{
+				Inputs: []string{"fooDir", "barDir"},
+			},
+			rootDir: &repb.Directory{Directories: []*repb.DirectoryNode{
+				{Name: "barDir", Digest: barDirDgPb},
+				{Name: "fooDir", Digest: fooDirDgPb},
+			}},
+			additionalBlobs: [][]byte{fooBlob, barBlob, fooDirBlob, barDirBlob},
+		},
+		{
+			desc: "Directory relative symlink",
+			input: []*inputPath{
+				{path: "fooDir/foo", fileContents: fooBlob},
+				{path: "barDirTarget/bar", fileContents: barBlob},
+				{path: "barDir", isSymlink: true, symlinkTarget: "barDirTarget"},
+			},
+			spec: &command.InputSpec{
+				Inputs: []string{"fooDir", "barDir"},
+			},
+			rootDir: &repb.Directory{Directories: []*repb.DirectoryNode{
+				{Name: "barDir", Digest: barDirDgPb},
+				{Name: "fooDir", Digest: fooDirDgPb},
+			}},
+			additionalBlobs: [][]byte{fooBlob, barBlob, fooDirBlob, barDirBlob},
+		},
+		{
+			desc: "De-duplicating files",
+			input: []*inputPath{
+				{path: "fooDir/foo", fileContents: fooBlob},
+				{path: "foobarDir/foo", fileContents: fooBlob},
+				{path: "foobarDir/bar", fileContents: barBlob},
+			},
+			spec: &command.InputSpec{
+				Inputs: []string{"fooDir", "foobarDir"},
+			},
+			rootDir: &repb.Directory{Directories: []*repb.DirectoryNode{
+				{Name: "fooDir", Digest: fooDirDgPb},
+				{Name: "foobarDir", Digest: foobarDirDg.ToProto()},
+			}},
+			additionalBlobs: [][]byte{fooBlob, barBlob, fooDirBlob, foobarDirBlob},
+		},
+		{
+			desc: "De-duplicating directories",
+			input: []*inputPath{
+				{path: "fooDir1/foo", fileContents: fooBlob},
+				{path: "fooDir2/foo", fileContents: fooBlob},
+			},
+			spec: &command.InputSpec{
+				Inputs: []string{"fooDir1", "fooDir2"},
+			},
+			rootDir: &repb.Directory{Directories: []*repb.DirectoryNode{
+				{Name: "fooDir1", Digest: fooDirDgPb},
+				{Name: "fooDir2", Digest: fooDirDgPb},
+			}},
+			additionalBlobs: [][]byte{fooBlob, fooDirBlob},
+		},
+		{
+			desc: "De-duplicating files with directories",
+			input: []*inputPath{
+				{path: "fooDirBlob", fileContents: fooDirBlob},
+				{path: "fooDir/foo", fileContents: fooBlob},
+			},
+			spec: &command.InputSpec{
+				Inputs: []string{"fooDirBlob", "fooDir"},
+			},
+			rootDir: &repb.Directory{
+				Directories: []*repb.DirectoryNode{{Name: "fooDir", Digest: fooDirDgPb}},
+				Files:       []*repb.FileNode{{Name: "fooDirBlob", Digest: fooDirDgPb, IsExecutable: true}},
+			},
+			additionalBlobs: [][]byte{fooBlob, fooDirBlob},
+		},
+		{
+			desc: "File exclusions",
+			input: []*inputPath{
+				{path: "fooDir/foo", fileContents: fooBlob},
+				{path: "fooDir/foo.txt", fileContents: fooBlob},
+				{path: "barDir/bar", fileContents: barBlob},
+				{path: "barDir/bar.txt", fileContents: barBlob},
+			},
+			spec: &command.InputSpec{
+				Inputs: []string{"fooDir", "barDir"},
+				InputExclusions: []*command.InputExclusion{
+					&command.InputExclusion{Regex: `txt$`, Type: command.FileInputType},
+				},
+			},
+			rootDir: &repb.Directory{Directories: []*repb.DirectoryNode{
+				{Name: "barDir", Digest: barDirDgPb},
+				{Name: "fooDir", Digest: fooDirDgPb},
+			}},
+			additionalBlobs: [][]byte{fooBlob, barBlob, fooDirBlob, barDirBlob},
+		},
+		{
+			desc: "Directory exclusions",
+			input: []*inputPath{
+				{path: "foo", fileContents: fooBlob},
+				{path: "fooDir/foo", fileContents: fooBlob},
+				{path: "barDir/bar", fileContents: barBlob},
+			},
+			spec: &command.InputSpec{
+				Inputs: []string{"foo", "fooDir", "barDir"},
+				InputExclusions: []*command.InputExclusion{
+					&command.InputExclusion{Regex: `foo`, Type: command.DirectoryInputType},
+				},
+			},
+			rootDir: &repb.Directory{
+				Directories: []*repb.DirectoryNode{{Name: "barDir", Digest: barDirDgPb}},
+				Files:       []*repb.FileNode{{Name: "foo", Digest: fooDgPb, IsExecutable: true}},
+			},
+			additionalBlobs: [][]byte{fooBlob, barBlob, barDirBlob},
+		},
+		{
+			desc: "All type exclusions",
+			input: []*inputPath{
+				{path: "foo", fileContents: fooBlob},
+				{path: "fooDir/foo", fileContents: fooBlob},
+				{path: "barDir/bar", fileContents: barBlob},
+			},
+			spec: &command.InputSpec{
+				Inputs: []string{"foo", "fooDir", "barDir"},
+				InputExclusions: []*command.InputExclusion{
+					&command.InputExclusion{Regex: `foo`, Type: command.UnspecifiedInputType},
+				},
+			},
+			rootDir: &repb.Directory{
+				Directories: []*repb.DirectoryNode{{Name: "barDir", Digest: barDirDgPb}},
+			},
+			additionalBlobs: [][]byte{barBlob, barDirBlob},
+		},
+		{
+			desc: "Virtual inputs",
+			spec: &command.InputSpec{
+				VirtualInputs: []*command.VirtualInput{
+					&command.VirtualInput{Path: "fooDir/foo", Contents: fooBlob},
+					&command.VirtualInput{Path: "barDir/bar", Contents: barBlob},
+				},
+			},
+			rootDir: &repb.Directory{Directories: []*repb.DirectoryNode{
+				{Name: "barDir", Digest: barDirDgPb},
+				{Name: "fooDir", Digest: fooDirDgPb},
+			}},
+			additionalBlobs: [][]byte{fooBlob, barBlob, fooDirBlob, barDirBlob},
+		},
+		{
+			// NOTE: The use of maps in our implementation means that the traversal order is unstable. The
+			// outputs are required to be in lexicographic order, so if ComputeMerkleTree is not sorting
+			// correctly, this test will fail (except in the rare occasion the traversal order is
+			// coincidentally correct).
+			desc: "Correct sorting",
+			input: []*inputPath{
+				{path: "a", fileContents: fooBlob},
+				{path: "b", fileContents: fooBlob},
+				{path: "c", fileContents: fooBlob},
+				{path: "d", fileContents: fooBlob},
+				{path: "e", fileContents: fooBlob},
+				{path: "f", fileContents: fooBlob},
+				{path: "g/foo", fileContents: fooBlob},
+				{path: "h/foo", fileContents: fooBlob},
+				{path: "i/foo", fileContents: fooBlob},
+				{path: "j/foo", fileContents: fooBlob},
+				{path: "k/foo", fileContents: fooBlob},
+				{path: "l/foo", fileContents: fooBlob},
+			},
+			spec: &command.InputSpec{
+				Inputs: []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"},
+			},
+			rootDir: &repb.Directory{
+				Files: []*repb.FileNode{
+					{Name: "a", Digest: fooDgPb, IsExecutable: true},
+					{Name: "b", Digest: fooDgPb, IsExecutable: true},
+					{Name: "c", Digest: fooDgPb, IsExecutable: true},
+					{Name: "d", Digest: fooDgPb, IsExecutable: true},
+					{Name: "e", Digest: fooDgPb, IsExecutable: true},
+					{Name: "f", Digest: fooDgPb, IsExecutable: true},
+				},
+				Directories: []*repb.DirectoryNode{
+					{Name: "g", Digest: fooDirDgPb},
+					{Name: "h", Digest: fooDirDgPb},
+					{Name: "i", Digest: fooDirDgPb},
+					{Name: "j", Digest: fooDirDgPb},
+					{Name: "k", Digest: fooDirDgPb},
+					{Name: "l", Digest: fooDirDgPb},
+				},
+			},
+			additionalBlobs: [][]byte{fooBlob, fooDirBlob},
+		},
+	}
+
+	for _, tc := range tests {
+		root, err := ioutil.TempDir("", tc.desc)
+		if err != nil {
+			t.Fatalf("failed to make temp dir: %v", err)
+		}
+		defer os.RemoveAll(root)
+		if err := construct(root, tc.input); err != nil {
+			t.Fatalf("failed to construct input dir structure: %v", err)
+		}
+
+		t.Run(tc.desc, func(t *testing.T) {
+			wantBlobs := make(map[digest.Digest][]byte)
+			rootBlob := mustMarshal(t, tc.rootDir)
+			rootDg := digest.NewFromBlob(rootBlob)
+			wantBlobs[rootDg] = rootBlob
+			for _, b := range tc.additionalBlobs {
+				wantBlobs[digest.NewFromBlob(b)] = b
+			}
+
+			gotBlobs := make(map[digest.Digest][]byte)
+			gotRootDg, inputs, err := ComputeMerkleTree(root, tc.spec, chunker.DefaultChunkSize)
+			if err != nil {
+				t.Errorf("ComputeMerkleTree(...) = gave error %v, want success", err)
+			}
+			for _, ch := range inputs {
+				blob, err := ch.FullData()
+				if err != nil {
+					t.Errorf("chunker %v FullData() returned error %v", ch, err)
+				}
+				gotBlobs[ch.Digest()] = blob
+			}
+			if diff := cmp.Diff(rootDg, gotRootDg); diff != "" {
+				t.Errorf("ComputeMerkleTree(...) gave diff (want -> got) on root:\n%s", diff)
+				if gotRootBlob, ok := gotBlobs[gotRootDg]; ok {
+					gotRoot := new(repb.Directory)
+					if err := proto.Unmarshal(gotRootBlob, gotRoot); err != nil {
+						t.Errorf("  When unpacking root blob, got error: %s", err)
+					} else {
+						diff := cmp.Diff(tc.rootDir, gotRoot)
+						t.Errorf("  Diff between unpacked roots (want -> got):\n%s", diff)
+					}
+				} else {
+					t.Logf("  Root digest gotten not present in blobs map")
+				}
+			}
+			if diff := cmp.Diff(wantBlobs, gotBlobs); diff != "" {
+				t.Errorf("ComputeMerkleTree(...) gave diff (want -> got) on blobs:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestComputeMerkleTreeErrors(t *testing.T) {
+	tests := []struct {
+		desc  string
+		input []*inputPath
+		spec  *command.InputSpec
+	}{
+		{
+			desc: "empty input",
+			spec: &command.InputSpec{Inputs: []string{""}},
+		},
+		{
+			desc: "empty virtual input",
+			spec: &command.InputSpec{
+				VirtualInputs: []*command.VirtualInput{
+					&command.VirtualInput{Path: "", Contents: []byte("foo")},
+				},
+			},
+		},
+		{
+			desc: "missing input",
+			spec: &command.InputSpec{Inputs: []string{"foo"}},
+		},
+		{
+			desc: "missing nested input",
+			input: []*inputPath{
+				{path: "a", fileContents: []byte("a")},
+				{path: "dir/a", fileContents: []byte("a")},
+			},
+			spec: &command.InputSpec{Inputs: []string{"a", "dir", "dir/b"}},
+		},
+	}
+
+	for _, tc := range tests {
+		root, err := ioutil.TempDir("", tc.desc)
+		if err != nil {
+			t.Fatalf("failed to make temp dir: %v", err)
+		}
+		defer os.RemoveAll(root)
+		if err := construct(root, tc.input); err != nil {
+			t.Fatalf("failed to construct input dir structure: %v", err)
+		}
+		t.Run(tc.desc, func(t *testing.T) {
+			_, _, err := ComputeMerkleTree(root, tc.spec, chunker.DefaultChunkSize)
+			if err == nil {
+				t.Errorf("ComputeMerkleTree(%v) succeeded, want error", tc.spec)
+			}
+		})
+	}
+}
+
+func TestFlattenTreeRepeated(t *testing.T) {
+	// Directory structure:
+	// <root>
+	//  +-baz -> digest 1003/10 (rw)
+	//  +-a
+	//    + b
+	//      + c    ## empty subdir
+	//      +-foo -> digest 1001/1 (rw)
+	//      +-bar -> digest 1002/2 (rwx)
+	//  + b
+	//    + c    ## empty subdir
+	//    +-foo -> digest 1001/1 (rw)
+	//    +-bar -> digest 1002/2 (rwx)
+	//  + c    ## empty subdir
+	fooDigest := digest.TestNew("1001", 1)
+	barDigest := digest.TestNew("1002", 2)
+	bazDigest := digest.TestNew("1003", 10)
+	dirC := &repb.Directory{}
+	cDigest := digest.TestNewFromMessage(dirC)
+	dirB := &repb.Directory{
+		Files: []*repb.FileNode{
+			{Name: "foo", Digest: fooDigest.ToProto(), IsExecutable: false},
+			{Name: "bar", Digest: barDigest.ToProto(), IsExecutable: true},
+		},
+		Directories: []*repb.DirectoryNode{
+			{Name: "c", Digest: cDigest.ToProto()},
+		},
+	}
+	bDigest := digest.TestNewFromMessage(dirB)
+	dirA := &repb.Directory{
+		Directories: []*repb.DirectoryNode{
+			{Name: "b", Digest: bDigest.ToProto()},
+		}}
+	aDigest := digest.TestNewFromMessage(dirA)
+	root := &repb.Directory{
+		Directories: []*repb.DirectoryNode{
+			{Name: "a", Digest: aDigest.ToProto()},
+			{Name: "b", Digest: bDigest.ToProto()},
+			{Name: "c", Digest: cDigest.ToProto()},
+		},
+		Files: []*repb.FileNode{
+			{Name: "baz", Digest: bazDigest.ToProto()},
+		},
+	}
+	tree := &repb.Tree{
+		Root:     root,
+		Children: []*repb.Directory{dirA, dirB, dirC},
+	}
+	outputs, err := FlattenTree(tree, "x")
+	if err != nil {
+		t.Errorf("FlattenTree gave error %v", err)
+	}
+	wantOutputs := map[string]*Output{
+		"x/baz":     &Output{Digest: bazDigest},
+		"x/a/b/foo": &Output{Digest: fooDigest},
+		"x/a/b/bar": &Output{Digest: barDigest, IsExecutable: true},
+		"x/b/foo":   &Output{Digest: fooDigest},
+		"x/b/bar":   &Output{Digest: barDigest, IsExecutable: true},
+	}
+	if len(outputs) != len(wantOutputs) {
+		t.Errorf("FlattenTree gave wrong number of outputs: want %d, got %d", len(wantOutputs), len(outputs))
+	}
+	for path, wantOut := range wantOutputs {
+		got, ok := outputs[path]
+		if !ok {
+			t.Errorf("expected output %s is missing", path)
+		}
+		if got.Path != path {
+			t.Errorf("FlattenTree keyed %s output with %s path", got.Path, path)
+		}
+		if wantOut.Digest != got.Digest {
+			t.Errorf("FlattenTree gave digest diff on %s: want %v, got: %v", path, wantOut.Digest, got.Digest)
+		}
+		if wantOut.IsExecutable != got.IsExecutable {
+			t.Errorf("FlattenTree gave IsExecutable diff on %s: want %v, got: %v", path, wantOut.IsExecutable, got.IsExecutable)
+		}
+	}
+}


### PR DESCRIPTION
Forking client/tree into a separate package. For the time being, keeping the old code as well, will remove it once all existing users are migrated.
Coverting rexec to use the new package along with the new UploadIfMissing, completing the fix of #32.
Tested manually on a command with 400000 input files.