### PR TITLE
Removing duplicated interface definition

### DIFF
--- a/go/pkg/rexec/BUILD.bazel
+++ b/go/pkg/rexec/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "//go/digest:go_default_library",
         "//go/pkg/chunker:go_default_library",
         "//go/pkg/command:go_default_library",
-        "//go/pkg/filemetadata:go_default_library",
         "//go/pkg/outerr:go_default_library",
         "//go/pkg/tree:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",

--- a/go/pkg/rexec/rexec.go
+++ b/go/pkg/rexec/rexec.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bazelbuild/remote-apis-sdks/go/digest"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/chunker"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/command"
-	"github.com/bazelbuild/remote-apis-sdks/go/pkg/filemetadata"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/outerr"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/tree"
 	"github.com/golang/protobuf/proto"
@@ -22,14 +21,9 @@ import (
 	log "github.com/golang/glog"
 )
 
-// FileMetadataCache is a cache for file contents->Metadata.
-type FileMetadataCache interface {
-	Get(string) (*filemetadata.Metadata, error)
-}
-
 // Client is a remote execution client.
 type Client struct {
-	FileMetadataCache FileMetadataCache
+	FileMetadataCache tree.FileMetadataCache
 	GrpcClient        *rc.Client
 }
 


### PR DESCRIPTION
Interfaces should be defined where they are used; but rexec doesn't actually *use* the FileMetadataCache, it just passes it on to the tree package which actually uses it.
Having the interface defined in rexec adds another place that we would have to fix when the interface changes.