### PR TITLE
 Embed error in filemetadata Metadata struct instead of returning the error explicitly.

### DIFF
--- a/go/pkg/tree/tree_test.go
+++ b/go/pkg/tree/tree_test.go
@@ -90,7 +90,7 @@ func newCallCountingMetadataCache(execRoot string, t *testing.T) *callCountingMe
 	}
 }
 
-func (c *callCountingMetadataCache) Get(path string) (*filemetadata.Metadata, error) {
+func (c *callCountingMetadataCache) Get(path string) *filemetadata.Metadata {
 	c.t.Helper()
 	p, err := filepath.Rel(c.execRoot, path)
 	if err != nil {


### PR DESCRIPTION
This change facilitates caching of filemetadata query errors.