### PR TITLE
avoid mac build error because repository_rules.bzl needs a BUILD file

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -121,7 +121,7 @@ http_archive(
 
 go_repository(
     name = "com_github_bazelbuild_remote_apis",
-    commit = "c0682f068a6044f395a7e28526abe1de56beffa8",
+    commit = "e7282cf0f0e16e7ba84209be5417279e6815bee7",
     importpath = "github.com/bazelbuild/remote-apis",
 )
 


### PR DESCRIPTION
In another project (https://github.com/buchgr/bazel-remote/pull/97)
I noticed a mac build error in buildkite with the previous configuration
claiming that repository_rules.bzl needed a matching BUILD file.
Updating to the tip of master helped- I suspect due to
https://github.com/bazelbuild/remote-apis/pull/83