### PR TITLE
rexec: Do not try downloading empty streams

### DIFF
--- a/go/pkg/rexec/rexec.go
+++ b/go/pkg/rexec/rexec.go
@@ -67,7 +67,7 @@ func (c *Client) NewContext(ctx context.Context, cmd *command.Command, opt *comm
 func (ec *Context) downloadStream(raw []byte, dgPb *repb.Digest, write func([]byte)) error {
 	if raw != nil {
 		write(raw)
-	} else if dgPb != nil {
+	} else if dgPb != nil && dgPb.SizeBytes > 0 {
 		dg, err := digest.NewFromProto(dgPb)
 		if err != nil {
 			return err


### PR DESCRIPTION
In the case where no stderr or stdout is emitted rexec will attempt to download
a stream that has a zero size.

Add a check to see that the stream is not empty before trying to download it.