### PR TITLE
fix broken link in check-gofmt.sh

### DIFF
--- a/check-gofmt.sh
+++ b/check-gofmt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Source: https://golang.org/misc/git/pre-commit
+# Source: https://github.com/golang/go/blob/88da9ccb98ffaf84bb06b98c9a24af5d0a7025d2/misc/git/pre-commit
 
 unformatted=$(gofmt -l "$@")
 [ -z "$unformatted" ] && exit 0


### PR DESCRIPTION
misc/git/pre-commit was removed from the go repository by this CL:
https://go-review.googlesource.com/c/go/+/158677

This new link here was the last version of the file before it was removed,
and is unlikely to break again anytime soon.