### PR TITLE
Fix generic comparisons on protobuf messages

### DIFF
--- a/go/client/BUILD.bazel
+++ b/go/client/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
-        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_pborman_uuid//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@go_googleapis//google/bytestream:bytestream_go_proto",

--- a/go/client/batch_retries_test.go
+++ b/go/client/batch_retries_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bazelbuild/remote-apis-sdks/go/client"
 	"github.com/bazelbuild/remote-apis-sdks/go/digest"
 	"github.com/bazelbuild/remote-apis-sdks/go/retry"
+	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc"
@@ -184,7 +185,7 @@ func TestBatchUpdateBlobsIndividualRequestRetries(t *testing.T) {
 	for i, req := range wantRequests {
 		if diff := cmp.Diff(req, fake.updateRequests[i], cmpopts.SortSlices(func(a, b interface{}) bool {
 			return fmt.Sprint(a) < fmt.Sprint(b)
-		})); diff != "" {
+		}), cmp.Comparer(proto.Equal)); diff != "" {
 			t.Errorf("client.BatchWriteBlobs(ctx, blobs) diff on request at index %d (want -> got):\n%s", i, diff)
 		}
 	}
@@ -262,7 +263,7 @@ func TestBatchReadBlobsIndividualRequestRetries(t *testing.T) {
 	for i, req := range wantRequests {
 		if diff := cmp.Diff(req, fake.readRequests[i], cmpopts.SortSlices(func(a, b interface{}) bool {
 			return fmt.Sprint(a) < fmt.Sprint(b)
-		})); diff != "" {
+		}), cmp.Comparer(proto.Equal)); diff != "" {
 			t.Errorf("client.BatchWriteBlobs(ctx, blobs) diff on request at index %d (want -> got):\n%s", i, diff)
 		}
 	}

--- a/go/client/exec.go
+++ b/go/client/exec.go
@@ -11,7 +11,6 @@ import (
 	log "github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -271,7 +270,7 @@ func (c *Client) ExecuteAndWait(ctx context.Context, req *repb.ExecuteRequest) (
 	// values and without returning an error, then lastOp will never be modified. Alternatively
 	// the server could return an empty operation explicitly prior to closing the stream. Either
 	// case is a server error.
-	if cmp.Equal(lastOp, &oppb.Operation{}) {
+	if proto.Equal(lastOp, &oppb.Operation{}) {
 		return nil, errors.New("unexpected server behaviour: an empty Operation was returned, or no operation was returned")
 	}
 

--- a/go/pkg/command/BUILD.bazel
+++ b/go/pkg/command/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
     ],

--- a/go/pkg/command/command_test.go
+++ b/go/pkg/command/command_test.go
@@ -3,6 +3,7 @@ package command
 import (
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
@@ -368,7 +369,7 @@ func TestToREProto(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.cmd.FillDefaultFieldValues()
 			gotCmd := tc.cmd.ToREProto()
-			if diff := cmp.Diff(tc.wantCmd, gotCmd, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.wantCmd, gotCmd, cmpopts.EquateEmpty(), cmp.Comparer(proto.Equal)); diff != "" {
 				t.Errorf("%s: buildCommand gave result diff (-want +got):\n%s", tc.name, diff)
 			}
 		})

--- a/go/pkg/rexec/BUILD.bazel
+++ b/go/pkg/rexec/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
         "//go/pkg/fakes:go_default_library",
         "//go/pkg/outerr:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",


### PR DESCRIPTION
Closes #93. Generated protobuf messages contain internal data structures
that general purpose comparison functions (e.g., reflect.DeepEqual,
pretty.Compare, etc) do not properly compare. It is already the case
today that these functions may report a difference when two messages
are actually semantically equivalent.

Fix all usages by either calling proto.Equal directly if
the top-level types are themselves proto.Message, or by calling
cmp.Equal with the cmp.Comparer(proto.Equal) option specified.
This option teaches cmp to use proto.Equal anytime it encounters
proto.Message types.