### PR TITLE
Warn on empty instance name instead of failing.

### DIFF
--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -268,7 +268,7 @@ func DialRaw(ctx context.Context, params DialParams) (*grpc.ClientConn, error) {
 // functionality.
 func NewClient(ctx context.Context, instanceName string, params DialParams, opts ...Opt) (*Client, error) {
 	if instanceName == "" {
-		return nil, fmt.Errorf("instance needs to be specified")
+		log.Warning("Instance name was not specified.")
 	}
 	if params.Service == "" {
 		return nil, fmt.Errorf("service needs to be specified")


### PR DESCRIPTION
### Description
As stated in the [design doc](https://docs.google.com/document/d/1AaGk7fOPByEvpAbqeXIyE8HX_A3_axxNnvroblTZ_6s/edit#heading=h.7ayoyyemcljy) `instance name` should be allowed to be empty.

### Changes
Log a warning instead of failing, when the instance name is empty.
