### PR TITLE
Allow the user to specify additional DialOpts

### DIFF
--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -179,11 +179,15 @@ type DialParams struct {
 	// on individual calls. This overrides ActAsAccount, UseApplicationDefault, and UseComputeEngine.
 	// This is not the same as NoSecurity, as transport credentials will still be set.
 	TransportCredsOnly bool
+
+	// DialOpts defines the set of gRPC DialOptions to apply, in addition to any used internally.
+	DialOpts []grpc.DialOption
 }
 
 // Dial dials a given endpoint and returns the grpc connection that is established.
 func Dial(ctx context.Context, endpoint string, params DialParams) (*grpc.ClientConn, error) {
 	var opts []grpc.DialOption
+	opts = append(opts, params.DialOpts...)
 
 	if params.NoSecurity {
 		opts = append(opts, grpc.WithInsecure())


### PR DESCRIPTION
Pretty simple one; our use case is wanting to apply some custom interceptors (for metrics / stats etc).