### PR TITLE
Adding in-memory filemetadata cache.

### DIFF
--- a/go/cmd/rexec/main.go
+++ b/go/cmd/rexec/main.go
@@ -72,7 +72,7 @@ func main() {
 	}
 	defer grpcClient.Close()
 	c := &rexec.Client{
-		FileMetadataCache: &filemetadata.NoopFileMetadataCache{},
+		FileMetadataCache: filemetadata.NewNoopCache(),
 		GrpcClient:        grpcClient,
 	}
 	res, _ := c.Run(ctx, cmd, opt, outerr.SystemOutErr)

--- a/go/pkg/cache/BUILD.bazel
+++ b/go/pkg/cache/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cache.go"],
+    importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/cache",
+    visibility = ["//visibility:public"],
+    deps = ["//go/pkg/cache/singleflightcache:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["cache_test.go"],
+    embed = [":go_default_library"],
+)

--- a/go/pkg/cache/cache.go
+++ b/go/pkg/cache/cache.go
@@ -1,0 +1,70 @@
+// Package cache implements a cache backend.
+package cache
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/cache/singleflightcache"
+)
+
+// Cache is a cache backend.
+type Cache struct {
+	mu     *sync.RWMutex
+	caches *sync.Map
+}
+
+var (
+	instance *Cache
+	once     sync.Once
+)
+
+// GetInstance retrieves the singleton instance of the cache backend. This is useful in the
+// future to enforce memory bounds on the entire cache usage of a program.
+func GetInstance() *Cache {
+	once.Do(func() {
+		instance = &Cache{
+			mu:     &sync.RWMutex{},
+			caches: &sync.Map{},
+		}
+	})
+	return instance
+}
+
+// Reset resets the cache.
+func (c *Cache) Reset() {
+	c.mu = &sync.RWMutex{}
+	c.caches = &sync.Map{}
+}
+
+// LoadOrStore attempts to first read a value from the corresponding cache namespace. If no entry
+// is found, it will use the return value of the passed fn to store in the cache. Concurrent
+// callers of LoadOrStore on the same namespace and key will execute fn once. This is to avoid
+// costly redundant work to compute the value to store in cache.
+func (c *Cache) LoadOrStore(ns string, key interface{}, fn func() (interface{}, error)) (interface{}, error) {
+	// Load first to avoid instantiating a new cache for LoadOrStore.
+	nsCache, ok := c.caches.Load(ns)
+	if !ok {
+		nsCache, _ = c.caches.LoadOrStore(ns, &singleflightcache.Cache{})
+	}
+	cache, ok := nsCache.(*singleflightcache.Cache)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type in namespace cache map")
+	}
+	return cache.LoadOrStore(key, fn)
+}
+
+// Delete deletes a value corresponding to the given namespace and key.
+func (c *Cache) Delete(ns string, key interface{}) error {
+	// Load first to avoid instantiating a new cache for LoadOrStore.
+	nsCache, ok := c.caches.Load(ns)
+	if !ok {
+		nsCache, _ = c.caches.LoadOrStore(ns, &singleflightcache.Cache{})
+	}
+	cache, ok := nsCache.(*singleflightcache.Cache)
+	if !ok {
+		return fmt.Errorf("unexpected type in namespace cache map")
+	}
+	cache.Delete(key)
+	return nil
+}

--- a/go/pkg/cache/cache_test.go
+++ b/go/pkg/cache/cache_test.go
@@ -1,0 +1,79 @@
+package cache
+
+import (
+	"testing"
+)
+
+const (
+	ns1  = "namespace1"
+	ns2  = "namespace2"
+	key1 = "key1"
+	key2 = "key2"
+	val1 = "val1"
+	val2 = "val2"
+)
+
+func TestMultipleNamespaces(t *testing.T) {
+	c := GetInstance()
+
+	got1, err := c.LoadOrStore(ns1, key1, func() (interface{}, error) { return val1, nil })
+	if err != nil {
+		t.Errorf("LoadOrStore(%v,%v) returned error: %v", ns1, key1, err)
+	}
+	if got1 != val1 {
+		t.Errorf("LoadOrStore(%v,%v) loaded wrong value: got %v, want %v", ns1, key1, got1, val1)
+	}
+	got2, err := c.LoadOrStore(ns2, key1, func() (interface{}, error) { return val2, nil })
+	if err != nil {
+		t.Errorf("LoadOrStore(%v,%v) returned error: %v", ns2, key1, err)
+	}
+	if got2 != val2 {
+		t.Errorf("LoadOrStore(%v,%v) loaded wrong value: got %v, want %v", ns2, key1, got2, val2)
+	}
+	got3, err := c.LoadOrStore(ns1, key1, func() (interface{}, error) { return val1, nil })
+	if err != nil {
+		t.Errorf("LoadOrStore(%v,%v) returned error: %v", ns1, key1, err)
+	}
+	if got3 != val1 {
+		t.Errorf("LoadOrStore(%v,%v) loaded wrong value: got %v, want %v", ns1, key1, got3, val1)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	c := GetInstance()
+
+	got1, err := c.LoadOrStore(ns1, key1, func() (interface{}, error) { return val1, nil })
+	if err != nil {
+		t.Fatalf("LoadOrStore(%v,%v) returned error: %v", ns1, key1, err)
+	}
+	if got1 != val1 {
+		t.Fatalf("LoadOrStore(%v,%v) loaded wrong value: got %v, want %v", ns1, key1, got1, val1)
+	}
+	got2, err := c.LoadOrStore(ns2, key1, func() (interface{}, error) { return val2, nil })
+	if err != nil {
+		t.Fatalf("LoadOrStore(%v,%v) returned error: %v", ns2, key1, err)
+	}
+	if got2 != val2 {
+		t.Fatalf("LoadOrStore(%v,%v) loaded wrong value: got %v, want %v", ns2, key1, got2, val2)
+	}
+
+	err = c.Delete(ns1, key1)
+	if err != nil {
+		t.Errorf("Delete(%v,%v) returned error: %v", ns1, key1, err)
+	}
+
+	got1, err = c.LoadOrStore(ns1, key1, func() (interface{}, error) { return val2, nil })
+	if err != nil {
+		t.Errorf("LoadOrStore(%v,%v) returned error: %v", ns1, key1, err)
+	}
+	if got1 != val2 {
+		t.Errorf("LoadOrStore(%v,%v) loaded wrong value: got %v, want %v", ns1, key1, got1, val2)
+	}
+	got2, err = c.LoadOrStore(ns2, key1, func() (interface{}, error) { return val1, nil })
+	if err != nil {
+		t.Errorf("LoadOrStore(%v,%v) returned error: %v", ns2, key1, err)
+	}
+	if got2 != val2 {
+		t.Errorf("LoadOrStore(%v,%v) loaded wrong value: got %v, want %v", ns2, key1, got2, val2)
+	}
+}

--- a/go/pkg/cache/singleflightcache/BUILD.bazel
+++ b/go/pkg/cache/singleflightcache/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["singleflightcache.go"],
+    importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/cache/singleflightcache",
+    visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["singleflightcache_test.go"],
+    embed = [":go_default_library"],
+)

--- a/go/pkg/cache/singleflightcache/singleflightcache.go
+++ b/go/pkg/cache/singleflightcache/singleflightcache.go
@@ -1,0 +1,71 @@
+// Package singleflightcache implements a cache that supports single-flight value computation.
+//
+// Single-flight value computation means that for concurrent callers of the cache, only one caller
+// will compute the value to avoid redundant work which could be system intensive.
+package singleflightcache
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Cache is a cache that supports single-flight value computation.
+type Cache struct {
+	// store is the actual cache where data is stored.
+	store sync.Map
+	// locks is a map of locks per key. This map is used to ensure only one reader/writer of
+	// the key can have write access.
+	locks sync.Map
+	// mu is a mutex to ensure exclusive access to the locks map in the case of Delete.
+	mu sync.RWMutex
+}
+
+// LoadOrStore is similar to a sync.Map except that it receives a function that computes the value
+// to store instead of the value directly. It ensures that the function is only executed once for
+// concurrent callers of the LoadOrStore function.
+func (c *Cache) LoadOrStore(key interface{}, valFn func() (interface{}, error)) (interface{}, error) {
+	val, ok := c.store.Load(key)
+	if ok {
+		return val, nil
+	}
+	// Lock the cache for reading to avoid a race condition with Delete.
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	mu := &sync.RWMutex{}
+	mu.Lock()
+	defer mu.Unlock()
+
+	l, loaded := c.locks.LoadOrStore(key, mu)
+	lock, ok := l.(*sync.RWMutex)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type found in lock map")
+	}
+	if loaded {
+		lock.RLock()
+		val, ok := c.store.Load(key)
+		lock.RUnlock()
+		if ok {
+			return val, nil
+		}
+		// If no value is in the cache, then the lock creator failed to set a value. Upgrade
+		// the lock to a write lock and re-attempt to compute the value.
+		lock.Lock()
+		defer lock.Unlock()
+	}
+	val, err := valFn()
+	if err != nil {
+		return nil, err
+	}
+	c.store.Store(key, val)
+	return val, nil
+}
+
+// Delete removes a key from the cache.
+func (c *Cache) Delete(key interface{}) {
+	if _, exists := c.locks.Load(key); exists {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.locks.Delete(key)
+		c.store.Delete(key)
+	}
+}

--- a/go/pkg/cache/singleflightcache/singleflightcache_test.go
+++ b/go/pkg/cache/singleflightcache/singleflightcache_test.go
@@ -1,0 +1,163 @@
+package singleflightcache
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+const (
+	key1 = "key1"
+	key2 = "key2"
+	val1 = "val1"
+	val2 = "val2"
+)
+
+func TestSimpleValueStore(t *testing.T) {
+	c := &Cache{}
+	val, err := c.LoadOrStore(key1, func() (interface{}, error) { return val1, nil })
+	if err != nil {
+		t.Errorf("LoadOrStore(%v) failed: %v", key1, err)
+	}
+	if val != val1 {
+		t.Errorf("LoadOrStore(%v) loaded wrong value: got %v, want %v", key1, val, val1)
+	}
+
+	val, err = c.LoadOrStore(key2, func() (interface{}, error) { return val2, nil })
+	if err != nil {
+		t.Errorf("LoadOrStore(%v) failed: %v", key2, err)
+	}
+	if val != val2 {
+		t.Errorf("LoadOrStore(%v) loaded wrong value: got %v, want %v", key2, val, val2)
+	}
+}
+
+func TestSingleFlightStore(t *testing.T) {
+	c := &Cache{}
+	var ops uint64
+	loadFn := func() (interface{}, error) {
+		atomic.AddUint64(&ops, 1)
+		return val1, nil
+	}
+	wg := &sync.WaitGroup{}
+	load := func() {
+		val, err := c.LoadOrStore(key1, loadFn)
+		if err != nil {
+			t.Errorf("LoadOrStore(%v) failed: %v", key1, err)
+		}
+		if val != val1 {
+			t.Errorf("LoadOrStore(%v) loaded wrong value: got %v, want %v", key1, val, val1)
+		}
+		wg.Done()
+	}
+	wg.Add(50)
+	for i := 0; i < 50; i++ {
+		go load()
+	}
+	wg.Wait()
+
+	if ops != 1 {
+		t.Errorf("Wrong number of loads executed: got %v, want 1", ops)
+	}
+}
+
+func TestValFnFailure(t *testing.T) {
+	c := &Cache{}
+	val, err := c.LoadOrStore(key1, func() (interface{}, error) { return nil, errors.New("error") })
+	if err == nil {
+		t.Errorf("LoadOrStore(%v) failed: %v", key1, err)
+	}
+
+	val, err = c.LoadOrStore(key1, func() (interface{}, error) { return val1, nil })
+	if err != nil {
+		t.Errorf("LoadOrStore(%v) failed: %v", key1, err)
+	}
+	if val != val1 {
+		t.Errorf("LoadOrStore(%v) loaded wrong value: got %v, want %v", key1, val, val1)
+	}
+}
+
+func TestValFnMultipleFailure(t *testing.T) {
+	c := &Cache{}
+
+	wg := &sync.WaitGroup{}
+	want := errors.New("error")
+	var ops uint64
+	load := func() {
+		_, got := c.LoadOrStore(key1, func() (interface{}, error) {
+			atomic.AddUint64(&ops, 1)
+			return nil, want
+		})
+		if want != got {
+			t.Errorf("LoadOrStore(%v) = _,%v, want _,%v", key1, got, want)
+		}
+		wg.Done()
+	}
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go load()
+	}
+	wg.Wait()
+
+	if ops != 50 {
+		t.Errorf("Wrong number of loads executed: got %v, want 50", ops)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	c := &Cache{}
+	val, err := c.LoadOrStore(key1, func() (interface{}, error) { return val1, nil })
+	if err != nil {
+		t.Fatalf("LoadOrStore(%v) failed: %v", key1, err)
+	}
+	if val != val1 {
+		t.Fatalf("LoadOrStore(%v) loaded wrong value: got %v, want %v", key1, val, val1)
+	}
+
+	c.Delete(key1)
+
+	val, err = c.LoadOrStore(key1, func() (interface{}, error) { return val2, nil })
+	if err != nil {
+		t.Errorf("LoadOrStore(%v) failed: %v", key1, err)
+	}
+	if val != val2 {
+		t.Errorf("LoadOrStore(%v) loaded wrong value: got %v, want %v", key1, val, val2)
+	}
+}
+
+// This test launches several concurrent goroutines to load/store and delete keys from the map. The
+// purpose of the test is to expose whether a race condition would result in an inconsistent state
+// of the internal maps of the cache, which would result in an error reported by LoadOrStore.
+func TestLoadDelete(t *testing.T) {
+	c := &Cache{}
+	wg := &sync.WaitGroup{}
+	load := func() {
+		val, err := c.LoadOrStore(key1, func() (interface{}, error) { return val1, nil })
+		if err != nil {
+			t.Errorf("LoadOrStore(%v) failed: %v", key1, err)
+		}
+		if val != val1 {
+			t.Errorf("LoadOrStore(%v) loaded wrong value: got %v, want %v", key1, val, val1)
+		}
+		val, err = c.LoadOrStore(key2, func() (interface{}, error) { return val2, nil })
+		if err != nil {
+			t.Errorf("LoadOrStore(%v) failed: %v", key2, err)
+		}
+		if val != val2 {
+			t.Errorf("LoadOrStore(%v) loaded wrong value: got %v, want %v", key2, val, val2)
+		}
+		wg.Done()
+	}
+	del := func() {
+		c.Delete(key1)
+		c.Delete(key2)
+		wg.Done()
+	}
+	wg.Add(100)
+	for i := 0; i < 50; i++ {
+		go load()
+		go del()
+	}
+	wg.Wait()
+}

--- a/go/pkg/fakes/server.go
+++ b/go/pkg/fakes/server.go
@@ -105,7 +105,7 @@ func NewTestEnv(t *testing.T) (*TestEnv, func()) {
 	}
 	return &TestEnv{
 			Client: &rexec.Client{
-				FileMetadataCache: &filemetadata.NoopFileMetadataCache{},
+				FileMetadataCache: filemetadata.NewNoopCache(),
 				GrpcClient:        grpcClient,
 			},
 			Server:   s,

--- a/go/pkg/filemetadata/BUILD.bazel
+++ b/go/pkg/filemetadata/BUILD.bazel
@@ -2,17 +2,27 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["filemetadata.go"],
+    srcs = [
+        "cache.go",
+        "filemetadata.go",
+    ],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/filemetadata",
     visibility = ["//visibility:public"],
-    deps = ["//go/pkg/digest:go_default_library"],
+    deps = [
+        "//go/pkg/cache:go_default_library",
+        "//go/pkg/digest:go_default_library",
+    ],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["filemetadata_test.go"],
+    srcs = [
+        "cache_test.go",
+        "filemetadata_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
+        "//go/pkg/cache:go_default_library",
         "//go/pkg/digest:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",

--- a/go/pkg/filemetadata/cache.go
+++ b/go/pkg/filemetadata/cache.go
@@ -1,0 +1,122 @@
+// Package filemetadata contains types of metadata for files, to be used for caching.
+package filemetadata
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/cache"
+)
+
+const (
+	namespace = "filemetadatacache"
+)
+
+// Cache is a store for file digests that supports invalidation.
+type fmCache struct {
+	Backend     *cache.Cache
+	CacheHits   uint64
+	CacheMisses uint64
+	Validate    bool
+}
+
+// NewSingleFlightCache returns a singleton-backed in-memory cache, with no validation.
+func NewSingleFlightCache() Cache {
+	return &fmCache{Backend: cache.GetInstance()}
+}
+
+// NewSingleFlightValidatedCache returns a singleton-backed in-memory cache, with validation.
+func NewSingleFlightValidatedCache() Cache {
+	return &fmCache{Backend: cache.GetInstance(), Validate: true}
+}
+
+// Get retrieves the metadata of the file with the given filename, whether from cache or by
+// computing the digest.
+func (c *fmCache) Get(filename string) *Metadata {
+	if err := c.check(); err != nil {
+		return &Metadata{Err: err}
+	}
+	abs, err := filepath.Abs(filename)
+	if err != nil {
+		return &Metadata{Err: err}
+	}
+	md, ch, err := c.loadMetadata(abs)
+	if err != nil {
+		return &Metadata{Err: err}
+	}
+	if !c.Validate {
+		c.updateMetrics(ch)
+		return md
+	}
+	valid, err := c.validate(abs, md.MTime)
+	if err != nil {
+		return &Metadata{Err: err}
+	}
+	if valid {
+		c.updateMetrics(ch)
+		return md
+	}
+	if err = c.Backend.Delete(namespace, abs); err != nil {
+		return &Metadata{Err: err}
+	}
+	md, ch, err = c.loadMetadata(abs)
+	if err != nil {
+		return &Metadata{Err: err}
+	}
+	c.updateMetrics(ch)
+	return md
+}
+
+// Delete deletes an entry from cache.
+func (c *fmCache) Delete(filename string) error {
+	if err := c.check(); err != nil {
+		return err
+	}
+	abs, err := filepath.Abs(filename)
+	if err != nil {
+		return err
+	}
+	return c.Backend.Delete(namespace, abs)
+}
+
+func (c *fmCache) check() error {
+	if c.Backend == nil {
+		return fmt.Errorf("no backend found for store")
+	}
+	return nil
+}
+
+func (c *fmCache) validate(filename string, mtime time.Time) (bool, error) {
+	file, err := os.Stat(filename)
+	if err != nil {
+		return false, err
+	}
+	return file.ModTime().Equal(mtime), nil
+}
+
+func (c *fmCache) loadMetadata(filename string) (*Metadata, bool, error) {
+	cacheHit := true
+	val, err := c.Backend.LoadOrStore(namespace, filename, func() (interface{}, error) {
+		cacheHit = false
+		return Compute(filename), nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	md, ok := val.(*Metadata)
+	if !ok {
+		return nil, false, fmt.Errorf("unexpected type stored in the cache")
+	}
+	return md, cacheHit, nil
+}
+
+func (c *fmCache) updateMetrics(cacheHit bool) {
+	if cacheHit {
+		atomic.AddUint64(&c.CacheHits, 1)
+	} else {
+		atomic.AddUint64(&c.CacheMisses, 1)
+	}
+}

--- a/go/pkg/filemetadata/cache_test.go
+++ b/go/pkg/filemetadata/cache_test.go
@@ -1,0 +1,186 @@
+package filemetadata
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/cache"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+var (
+	contents = []byte("example")
+	wantDg   = digest.NewFromBlob(contents)
+)
+
+func TestSimpleCacheLoad(t *testing.T) {
+	c := &fmCache{Backend: cache.GetInstance()}
+	filename, err := createFile(t, false, "")
+	if err != nil {
+		t.Fatalf("Failed to create tmp file for testing digests: %v", err)
+	}
+	if err = ioutil.WriteFile(filename, contents, os.ModeTemporary); err != nil {
+		t.Fatalf("Failed to write to tmp file for testing digests: %v", err)
+	}
+	got := c.Get(filename)
+	if got.Err != nil {
+		t.Errorf("Get(%v) failed. Got error: %v", filename, got.Err)
+	}
+	want := &Metadata{
+		Digest:       wantDg,
+		IsExecutable: false,
+	}
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Metadata{}, "MTime")); diff != "" {
+		t.Errorf("Get(%v) returned diff. (-want +got)\n%s", filename, diff)
+	}
+	if c.CacheHits != 0 {
+		t.Errorf("Cache has wrong num of CacheHits, want 0, got %v", c.CacheHits)
+	}
+	if c.CacheMisses != 1 {
+		t.Errorf("Cache has wrong num of CacheMisses, want 1, got %v", c.CacheMisses)
+	}
+}
+
+func TestExecutableCacheLoad(t *testing.T) {
+	c := &fmCache{Backend: cache.GetInstance()}
+	filename, err := createFile(t, true, "")
+	if err != nil {
+		t.Fatalf("Failed to create tmp file for testing digests: %v", err)
+	}
+	if err = ioutil.WriteFile(filename, contents, os.ModeTemporary); err != nil {
+		t.Fatalf("Failed to write to tmp file for testing digests: %v", err)
+	}
+	got := c.Get(filename)
+	if got.Err != nil {
+		t.Errorf("Get(%v) failed. Got error: %v", filename, got.Err)
+	}
+	want := &Metadata{
+		Digest:       wantDg,
+		IsExecutable: true,
+	}
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Metadata{}, "MTime")); diff != "" {
+		t.Errorf("Get(%v) returned diff. (-want +got)\n%s", filename, diff)
+	}
+}
+
+func TestCacheOnceLoadMultiple(t *testing.T) {
+	c := &fmCache{Backend: cache.GetInstance()}
+	filename, err := createFile(t, false, "")
+	if err != nil {
+		t.Fatalf("Failed to create tmp file for testing digests: %v", err)
+	}
+	if err = ioutil.WriteFile(filename, contents, os.ModeTemporary); err != nil {
+		t.Fatalf("Failed to write to tmp file for testing digests: %v", err)
+	}
+	want := &Metadata{
+		Digest:       wantDg,
+		IsExecutable: false,
+	}
+	for i := 0; i < 2; i++ {
+		got := c.Get(filename)
+		if got.Err != nil {
+			t.Errorf("Get(%v) failed. Got error: %v", filename, got.Err)
+		}
+		if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Metadata{}, "MTime")); diff != "" {
+			t.Errorf("Get(%v) returned diff. (-want +got)\n%s", filename, diff)
+		}
+	}
+	if c.CacheHits != 1 {
+		t.Errorf("Cache has wrong num of CacheHits, want 1, got %v", c.CacheHits)
+	}
+	if c.CacheMisses != 1 {
+		t.Errorf("Cache has wrong num of CacheMisses, want 1, got %v", c.CacheMisses)
+	}
+}
+
+func TestLoadAfterChangeWithoutValidation(t *testing.T) {
+	c := &fmCache{Backend: cache.GetInstance()}
+	filename, err := createFile(t, false, "")
+	if err != nil {
+		t.Fatalf("Failed to create tmp file for testing digests: %v", err)
+	}
+	if err = ioutil.WriteFile(filename, contents, os.ModeTemporary); err != nil {
+		t.Fatalf("Failed to write to tmp file for testing digests: %v", err)
+	}
+	got := c.Get(filename)
+	if got.Err != nil {
+		t.Fatalf("Get(%v) failed. Got error: %v", filename, got.Err)
+	}
+	want := &Metadata{
+		Digest:       wantDg,
+		IsExecutable: false,
+	}
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Metadata{}, "MTime")); diff != "" {
+		t.Fatalf("Get(%v) returned diff. (-want +got)\n%s", filename, diff)
+	}
+
+	// Sleep to avoid mtime not being updated between writes.
+	time.Sleep(time.Second)
+
+	change := []byte("change")
+	if err = ioutil.WriteFile(filename, change, os.ModeTemporary); err != nil {
+		t.Fatalf("Failed to write to tmp file for testing digests: %v", err)
+	}
+	got = c.Get(filename)
+	if got.Err != nil {
+		t.Errorf("Get(%v) failed. Got error: %v", filename, got.Err)
+	}
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Metadata{}, "MTime")); diff != "" {
+		t.Errorf("Get(%v) returned diff. (-want +got)\n%s", filename, diff)
+	}
+	if c.CacheHits != 1 {
+		t.Errorf("Cache has wrong num of CacheHits, want 1, got %v", c.CacheHits)
+	}
+	if c.CacheMisses != 1 {
+		t.Errorf("Cache has wrong num of CacheMisses, want 1, got %v", c.CacheMisses)
+	}
+}
+
+func TestLoadAfterChange(t *testing.T) {
+	c := &fmCache{Backend: cache.GetInstance(), Validate: true}
+	filename, err := createFile(t, false, "")
+	if err != nil {
+		t.Fatalf("Failed to create tmp file for testing digests: %v", err)
+	}
+	if err = ioutil.WriteFile(filename, contents, os.ModeTemporary); err != nil {
+		t.Fatalf("Failed to write to tmp file for testing digests: %v", err)
+	}
+	got := c.Get(filename)
+	if got.Err != nil {
+		t.Fatalf("Get(%v) failed. Got error: %v", filename, got.Err)
+	}
+	want := &Metadata{
+		Digest:       wantDg,
+		IsExecutable: false,
+	}
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Metadata{}, "MTime")); diff != "" {
+		t.Fatalf("Get(%v) returned diff. (-want +got)\n%s", filename, diff)
+	}
+
+	// Sleep to avoid mtime not being updated between writes.
+	time.Sleep(time.Second)
+
+	change := []byte("change")
+	digestAfterChange := digest.NewFromBlob(change)
+	if err = ioutil.WriteFile(filename, change, os.ModeTemporary); err != nil {
+		t.Fatalf("Failed to write to tmp file for testing digests: %v", err)
+	}
+	got = c.Get(filename)
+	if got.Err != nil {
+		t.Errorf("Get(%v) failed. Got error: %v", filename, got.Err)
+	}
+	want.Digest = digestAfterChange
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Metadata{}, "MTime")); diff != "" {
+		t.Errorf("Get(%v) returned diff. (-want +got)\n%s", filename, diff)
+	}
+	if c.CacheHits != 0 {
+		t.Errorf("Cache has wrong num of CacheHits, want 0, got %v", c.CacheHits)
+	}
+	if c.CacheMisses != 2 {
+		t.Errorf("Cache has wrong num of CacheMisses, want 2, got %v", c.CacheMisses)
+	}
+}

--- a/go/pkg/filemetadata/filemetadata.go
+++ b/go/pkg/filemetadata/filemetadata.go
@@ -53,11 +53,20 @@ func Compute(filename string) *Metadata {
 	return md
 }
 
-// NoopFileMetadataCache is a non-caching metadata cache (always computes).
-type NoopFileMetadataCache struct{}
+// FileMetadataCache is a cache for file contents->Metadata.
+type Cache interface {
+	Get(path string) *Metadata
+}
+
+type noopCache struct{}
 
 // Get computes the metadata from the file contents.
 // If an error is returned, it will be in Metadata.Err of type *FileError.
-func (c *NoopFileMetadataCache) Get(path string) *Metadata {
+func (c *noopCache) Get(path string) *Metadata {
 	return Compute(path)
+}
+
+// NewNoopCache returns a cache that doesn't cache (evaluates on every Get).
+func NewNoopCache() Cache {
+	return &noopCache{}
 }

--- a/go/pkg/rexec/BUILD.bazel
+++ b/go/pkg/rexec/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//go/pkg/client:go_default_library",
         "//go/pkg/command:go_default_library",
         "//go/pkg/digest:go_default_library",
+        "//go/pkg/filemetadata:go_default_library",
         "//go/pkg/outerr:go_default_library",
         "//go/pkg/tree:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",

--- a/go/pkg/rexec/rexec.go
+++ b/go/pkg/rexec/rexec.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/chunker"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/command"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/filemetadata"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/outerr"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/tree"
 	"github.com/golang/protobuf/proto"
@@ -25,7 +26,7 @@ import (
 
 // Client is a remote execution client.
 type Client struct {
-	FileMetadataCache tree.FileMetadataCache
+	FileMetadataCache filemetadata.Cache
 	GrpcClient        *rc.Client
 }
 

--- a/go/pkg/tree/tree_test.go
+++ b/go/pkg/tree/tree_test.go
@@ -88,7 +88,7 @@ func construct(dir string, ips []*inputPath) error {
 
 type callCountingMetadataCache struct {
 	calls    map[string]int
-	cache    *filemetadata.NoopFileMetadataCache
+	cache    filemetadata.Cache
 	execRoot string
 	t        *testing.T
 }
@@ -96,7 +96,7 @@ type callCountingMetadataCache struct {
 func newCallCountingMetadataCache(execRoot string, t *testing.T) *callCountingMetadataCache {
 	return &callCountingMetadataCache{
 		calls:    make(map[string]int),
-		cache:    &filemetadata.NoopFileMetadataCache{},
+		cache:    filemetadata.NewNoopCache(),
 		execRoot: execRoot,
 		t:        t,
 	}
@@ -882,7 +882,7 @@ func TestComputeMerkleTreeErrors(t *testing.T) {
 			t.Fatalf("failed to construct input dir structure: %v", err)
 		}
 		t.Run(tc.desc, func(t *testing.T) {
-			if _, _, _, err := ComputeMerkleTree(root, tc.spec, chunker.DefaultChunkSize, &filemetadata.NoopFileMetadataCache{}); err == nil {
+			if _, _, _, err := ComputeMerkleTree(root, tc.spec, chunker.DefaultChunkSize, filemetadata.NewNoopCache()); err == nil {
 				t.Errorf("ComputeMerkleTree(%v) succeeded, want error", tc.spec)
 			}
 		})


### PR DESCRIPTION
Some refactoring of our previous code, including:
- the interface is now defined in filemetadata.Cache
- the actual types are not exported.
- instead, factory functions are used for both the noop cache
  and the single-flight cache