### PR TITLE
Remove explicit "set -e" from presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,7 +3,6 @@ validate_config: 1
 tasks:
   ubuntu1804:
     shell_commands:
-      - "set -e"
       - "echo +++ Check go format"
       - "./check-gofmt.sh `find go -name '*.go'`"
       - "echo +++ Check go vet"
@@ -17,7 +16,6 @@ tasks:
     platform: ubuntu1804
     name: "go build / test"
     shell_commands:
-      - "set -e"
       - "echo +++ Running go build"
       - "go build ./..."
       - "echo +++ Running go test"


### PR DESCRIPTION
This was made the default in https://github.com/bazelbuild/continuous-integration/pull/957.