### PR TITLE
Ignore invalid symlinks when computing Merkle tree

### DIFF
--- a/go/pkg/tree/tree.go
+++ b/go/pkg/tree/tree.go
@@ -66,7 +66,14 @@ func loadFiles(execRoot string, excl []*command.InputExclusion, path string, fs 
 	meta := cache.Get(absPath)
 	t := command.FileInputType
 	if meta.Err != nil {
-		if e, ok := meta.Err.(*filemetadata.FileError); !ok || !e.IsDirectory {
+		e, ok := meta.Err.(*filemetadata.FileError)
+		if !ok {
+			return meta.Err
+		}
+		if e.IsInvalidSymlink {
+			return nil
+		}
+		if !e.IsDirectory {
 			return meta.Err
 		}
 		t = command.DirectoryInputType

--- a/go/pkg/tree/tree_test.go
+++ b/go/pkg/tree/tree_test.go
@@ -463,6 +463,32 @@ func TestComputeMerkleTree(t *testing.T) {
 			},
 		},
 		{
+			desc: "File invalid symlink",
+			input: []*inputPath{
+				{path: "fooDir/foo", fileContents: fooBlob, isExecutable: true},
+				{path: "foo", isSymlink: true, symlinkTarget: "fooDir/foo"},
+				{path: "bar", isSymlink: true, symlinkTarget: "fooDir/bar"},
+			},
+			spec: &command.InputSpec{
+				Inputs: []string{"fooDir", "foo"},
+			},
+			rootDir: &repb.Directory{
+				Directories: []*repb.DirectoryNode{{Name: "fooDir", Digest: fooDirDgPb}},
+				Files:       []*repb.FileNode{{Name: "foo", Digest: fooDgPb, IsExecutable: true}},
+			},
+			additionalBlobs: [][]byte{fooBlob, fooDirBlob},
+			wantCacheCalls: map[string]int{
+				"fooDir":     1,
+				"fooDir/foo": 1,
+				"foo":        1,
+			},
+			wantStats: &Stats{
+				InputDirectories: 2,
+				InputFiles:       2,
+				TotalInputBytes:  2*fooDg.Size + fooDirDg.Size,
+			},
+		},
+		{
 			desc: "Directory absolute symlink",
 			input: []*inputPath{
 				{path: "fooDir/foo", fileContents: fooBlob, isExecutable: true},


### PR DESCRIPTION
When given an output directory containing an invalid symlink (i.e., a
symlink pointing to a non-existent file), the SDK fails to compute
Merkle tree because of Stat failure. This change makes the SDK ignore
it.

Tested by both using this version of re-client and added unit-tests.