### PR TITLE
Don't retry Internal errors

### DIFF
--- a/go/pkg/client/batch_retries_test.go
+++ b/go/pkg/client/batch_retries_test.go
@@ -40,7 +40,7 @@ func (f *flakyBatchServer) BatchReadBlobs(ctx context.Context, req *repb.BatchRe
 			Responses: []*repb.BatchReadBlobsResponse_Response{
 				{Digest: digest.TestNew("a", 1).ToProto(), Status: &spb.Status{Code: int32(codes.OK)}, Data: []byte{1}},
 				// all retriable errors.
-				{Digest: digest.TestNew("b", 1).ToProto(), Status: &spb.Status{Code: int32(codes.Internal)}},
+				{Digest: digest.TestNew("b", 1).ToProto(), Status: &spb.Status{Code: int32(codes.ResourceExhausted)}},
 				{Digest: digest.TestNew("c", 1).ToProto(), Status: &spb.Status{Code: int32(codes.Canceled)}},
 				{Digest: digest.TestNew("d", 1).ToProto(), Status: &spb.Status{Code: int32(codes.Aborted)}},
 			},
@@ -53,7 +53,7 @@ func (f *flakyBatchServer) BatchReadBlobs(ctx context.Context, req *repb.BatchRe
 			Responses: []*repb.BatchReadBlobsResponse_Response{
 				{Digest: digest.TestNew("b", 1).ToProto(), Status: &spb.Status{Code: int32(codes.OK)}, Data: []byte{2}},
 				// all retriable errors.
-				{Digest: digest.TestNew("c", 1).ToProto(), Status: &spb.Status{Code: int32(codes.Internal)}},
+				{Digest: digest.TestNew("c", 1).ToProto(), Status: &spb.Status{Code: int32(codes.ResourceExhausted)}},
 				{Digest: digest.TestNew("d", 1).ToProto(), Status: &spb.Status{Code: int32(codes.Canceled)}},
 			},
 		}
@@ -64,7 +64,7 @@ func (f *flakyBatchServer) BatchReadBlobs(ctx context.Context, req *repb.BatchRe
 		resp := &repb.BatchReadBlobsResponse{
 			Responses: []*repb.BatchReadBlobsResponse_Response{
 				// One non-retriable error.
-				{Digest: digest.TestNew("c", 1).ToProto(), Status: &spb.Status{Code: int32(codes.Internal)}},
+				{Digest: digest.TestNew("c", 1).ToProto(), Status: &spb.Status{Code: int32(codes.ResourceExhausted)}},
 				{Digest: digest.TestNew("d", 1).ToProto(), Status: &spb.Status{Code: int32(codes.PermissionDenied)}},
 			},
 		}
@@ -86,7 +86,7 @@ func (f *flakyBatchServer) BatchUpdateBlobs(ctx context.Context, req *repb.Batch
 			Responses: []*repb.BatchUpdateBlobsResponse_Response{
 				{Digest: digest.TestNew("a", 1).ToProto(), Status: &spb.Status{Code: int32(codes.OK)}},
 				// all retriable errors.
-				{Digest: digest.TestNew("b", 1).ToProto(), Status: &spb.Status{Code: int32(codes.Internal)}},
+				{Digest: digest.TestNew("b", 1).ToProto(), Status: &spb.Status{Code: int32(codes.ResourceExhausted)}},
 				{Digest: digest.TestNew("c", 1).ToProto(), Status: &spb.Status{Code: int32(codes.Canceled)}},
 				{Digest: digest.TestNew("d", 1).ToProto(), Status: &spb.Status{Code: int32(codes.Aborted)}},
 			},
@@ -99,7 +99,7 @@ func (f *flakyBatchServer) BatchUpdateBlobs(ctx context.Context, req *repb.Batch
 			Responses: []*repb.BatchUpdateBlobsResponse_Response{
 				{Digest: digest.TestNew("b", 1).ToProto(), Status: &spb.Status{Code: int32(codes.OK)}},
 				// all retriable errors.
-				{Digest: digest.TestNew("c", 1).ToProto(), Status: &spb.Status{Code: int32(codes.Internal)}},
+				{Digest: digest.TestNew("c", 1).ToProto(), Status: &spb.Status{Code: int32(codes.ResourceExhausted)}},
 				{Digest: digest.TestNew("d", 1).ToProto(), Status: &spb.Status{Code: int32(codes.Canceled)}},
 			},
 		}
@@ -110,7 +110,7 @@ func (f *flakyBatchServer) BatchUpdateBlobs(ctx context.Context, req *repb.Batch
 		resp := &repb.BatchUpdateBlobsResponse{
 			Responses: []*repb.BatchUpdateBlobsResponse_Response{
 				// One non-retriable error.
-				{Digest: digest.TestNew("c", 1).ToProto(), Status: &spb.Status{Code: int32(codes.Internal)}},
+				{Digest: digest.TestNew("c", 1).ToProto(), Status: &spb.Status{Code: int32(codes.ResourceExhausted)}},
 				{Digest: digest.TestNew("d", 1).ToProto(), Status: &spb.Status{Code: int32(codes.PermissionDenied)}},
 			},
 		}

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -413,7 +413,7 @@ func RetryTransient() *Retrier {
 			}
 			switch s.Code() {
 			case codes.Canceled, codes.Unknown, codes.DeadlineExceeded, codes.Aborted,
-				codes.Internal, codes.Unavailable, codes.Unauthenticated, codes.ResourceExhausted:
+				codes.Unavailable, codes.Unauthenticated, codes.ResourceExhausted:
 				return true
 			default:
 				return false

--- a/go/pkg/client/retries_test.go
+++ b/go/pkg/client/retries_test.go
@@ -57,7 +57,7 @@ func (f *flakyServer) Write(stream bsgrpc.ByteStream_WriteServer) error {
 		return status.Error(codes.FailedPrecondition, fmt.Sprintf("expected first chunk, got %v", req))
 	}
 	if numCalls < 5 {
-		return status.Error(codes.Internal, "another transient error!")
+		return status.Error(codes.ResourceExhausted, "another transient error!")
 	}
 	return stream.SendAndClose(&bspb.WriteResponse{CommittedSize: 4})
 }
@@ -72,7 +72,7 @@ func (f *flakyServer) Read(req *bspb.ReadRequest, stream bsgrpc.ByteStream_ReadS
 		if err := stream.Send(&bspb.ReadResponse{Data: []byte("bl")}); err != nil {
 			return err
 		}
-		return status.Error(codes.Internal, "another transient error!")
+		return status.Error(codes.ResourceExhausted, "another transient error!")
 	}
 	// Client now will only ask for the remaining two bytes.
 	if numCalls < 5 {
@@ -133,7 +133,7 @@ func (f *flakyServer) GetTree(req *repb.GetTreeRequest, stream regrpc.ContentAdd
 		if err := stream.Send(resp); err != nil {
 			return err
 		}
-		return status.Error(codes.Internal, "another transient error!")
+		return status.Error(codes.ResourceExhausted, "another transient error!")
 	}
 	// Client now will only ask for the remaining directories.
 	if numCalls < 5 {
@@ -152,7 +152,7 @@ func (f *flakyServer) Execute(req *repb.ExecuteRequest, stream regrpc.Execution_
 	}
 	stream.Send(&oppb.Operation{Done: false, Name: "dummy"})
 	// After this error, retries should to go the WaitExecution method.
-	return status.Error(codes.Internal, "another transient error!")
+	return status.Error(codes.ResourceExhausted, "another transient error!")
 }
 
 func (f *flakyServer) WaitExecution(req *repb.WaitExecutionRequest, stream regrpc.Execution_WaitExecutionServer) error {
@@ -162,7 +162,7 @@ func (f *flakyServer) WaitExecution(req *repb.WaitExecutionRequest, stream regrp
 	}
 	if numCalls < 4 {
 		stream.Send(&oppb.Operation{Done: false, Name: "dummy"})
-		return status.Error(codes.Internal, "another transient error!")
+		return status.Error(codes.ResourceExhausted, "another transient error!")
 	}
 	// Execute (above) will fail twice (and be retried twice) before ExecuteAndWait() switches to
 	// WaitExecution. WaitExecution will fail 4 more times more before succeeding, for a total of 6 retries.


### PR DESCRIPTION
gRPC describes this as used for serious errors; I don't think it should be retried as transient (FWIW we would not normally retry that code).