### PR TITLE
Remove Validating cache

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,7 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pOkfl+p/TAqKOfFu+7KPlMVpok/w=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -370,6 +371,7 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.24.0 h1:vb/1TCsVn3DcJlQ0Gs1yB1pKI6Do2/QNwxdKqmc/b0s=
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
+google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go/pkg/filemetadata/cache_posix_test.go
+++ b/go/pkg/filemetadata/cache_posix_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestExecutableCacheLoad(t *testing.T) {
@@ -28,7 +27,7 @@ func TestExecutableCacheLoad(t *testing.T) {
 		Digest:       wantDg,
 		IsExecutable: true,
 	}
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Metadata{}, "MTime")); diff != "" {
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Get(%v) returned diff. (-want +got)\n%s", filename, diff)
 	}
 }

--- a/go/pkg/filemetadata/cache_test.go
+++ b/go/pkg/filemetadata/cache_test.go
@@ -4,12 +4,9 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
-	"time"
 
-	"github.com/bazelbuild/remote-apis-sdks/go/pkg/cache"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 var (
@@ -34,12 +31,13 @@ func TestSimpleCacheLoad(t *testing.T) {
 		Digest:       wantDg,
 		IsExecutable: false,
 	}
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Metadata{}, "MTime")); diff != "" {
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Get(%v) returned diff. (-want +got)\n%s", filename, diff)
 	}
 	if c.GetCacheHits() != 0 {
 		t.Errorf("Cache has wrong num of CacheHits, want 0, got %v", c.GetCacheHits())
 	}
+
 	if c.GetCacheMisses() != 1 {
 		t.Errorf("Cache has wrong num of CacheMisses, want 1, got %v", c.GetCacheMisses())
 	}
@@ -63,7 +61,7 @@ func TestCacheOnceLoadMultiple(t *testing.T) {
 		if got.Err != nil {
 			t.Errorf("Get(%v) failed. Got error: %v", filename, got.Err)
 		}
-		if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Metadata{}, "MTime")); diff != "" {
+		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("Get(%v) returned diff. (-want +got)\n%s", filename, diff)
 		}
 	}
@@ -92,12 +90,9 @@ func TestLoadAfterChangeWithoutValidation(t *testing.T) {
 		Digest:       wantDg,
 		IsExecutable: false,
 	}
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Metadata{}, "MTime")); diff != "" {
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("Get(%v) returned diff. (-want +got)\n%s", filename, diff)
 	}
-
-	// Sleep to avoid mtime not being updated between writes.
-	time.Sleep(time.Second)
 
 	change := []byte("change")
 	if err = ioutil.WriteFile(filename, change, os.ModeTemporary); err != nil {
@@ -107,7 +102,7 @@ func TestLoadAfterChangeWithoutValidation(t *testing.T) {
 	if got.Err != nil {
 		t.Errorf("Get(%v) failed. Got error: %v", filename, got.Err)
 	}
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Metadata{}, "MTime")); diff != "" {
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Get(%v) returned diff. (-want +got)\n%s", filename, diff)
 	}
 	if c.GetCacheHits() != 1 {
@@ -115,50 +110,5 @@ func TestLoadAfterChangeWithoutValidation(t *testing.T) {
 	}
 	if c.GetCacheMisses() != 1 {
 		t.Errorf("Cache has wrong num of CacheMisses, want 1, got %v", c.GetCacheMisses())
-	}
-}
-
-func TestLoadAfterChange(t *testing.T) {
-	c := &fmCache{Backend: cache.GetInstance(), Validate: true}
-	filename, err := createFile(t, false, "")
-	if err != nil {
-		t.Fatalf("Failed to create tmp file for testing digests: %v", err)
-	}
-	if err = ioutil.WriteFile(filename, contents, os.ModeTemporary); err != nil {
-		t.Fatalf("Failed to write to tmp file for testing digests: %v", err)
-	}
-	got := c.Get(filename)
-	if got.Err != nil {
-		t.Fatalf("Get(%v) failed. Got error: %v", filename, got.Err)
-	}
-	want := &Metadata{
-		Digest:       wantDg,
-		IsExecutable: false,
-	}
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Metadata{}, "MTime")); diff != "" {
-		t.Fatalf("Get(%v) returned diff. (-want +got)\n%s", filename, diff)
-	}
-
-	// Sleep to avoid mtime not being updated between writes.
-	time.Sleep(time.Second)
-
-	change := []byte("change")
-	digestAfterChange := digest.NewFromBlob(change)
-	if err = ioutil.WriteFile(filename, change, os.ModeTemporary); err != nil {
-		t.Fatalf("Failed to write to tmp file for testing digests: %v", err)
-	}
-	got = c.Get(filename)
-	if got.Err != nil {
-		t.Errorf("Get(%v) failed. Got error: %v", filename, got.Err)
-	}
-	want.Digest = digestAfterChange
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Metadata{}, "MTime")); diff != "" {
-		t.Errorf("Get(%v) returned diff. (-want +got)\n%s", filename, diff)
-	}
-	if c.GetCacheHits() != 0 {
-		t.Errorf("Cache has wrong num of CacheHits, want 0, got %v", c.GetCacheHits())
-	}
-	if c.GetCacheMisses() != 2 {
-		t.Errorf("Cache has wrong num of CacheMisses, want 2, got %v", c.GetCacheMisses())
 	}
 }

--- a/go/pkg/filemetadata/filemetadata.go
+++ b/go/pkg/filemetadata/filemetadata.go
@@ -4,7 +4,6 @@ package filemetadata
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
 )
@@ -13,7 +12,6 @@ import (
 type Metadata struct {
 	Digest       digest.Digest
 	IsExecutable bool
-	MTime        time.Time
 	Err          error
 }
 
@@ -54,7 +52,6 @@ func Compute(filename string) *Metadata {
 		md.Err = fe
 		return md
 	}
-	md.MTime = file.ModTime()
 	mode := file.Mode()
 	md.IsExecutable = (mode & 0100) != 0
 	if mode.IsDir() {


### PR DESCRIPTION
Since we are not using the mtime based validating cache anywhere and
dont have immediate plans of using it due to performance reasons, I'm
removing this code. This would make it a little bit simpler to update
the cache entry of the output files.

Test: Unit tests