### PR TITLE
Update cache entries of output files

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -361,6 +361,7 @@ google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51/go.mod h1:IbNlFCBr
 google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20191028173616-919d9bdd9fe6 h1:UXl+Zk3jqqcbEVV7ace5lrt4YdA4tXiz3f/KbmD29Vo=
 google.golang.org/genproto v0.0.0-20191028173616-919d9bdd9fe6/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
+google.golang.org/genproto v0.0.0-20200624020401-64a14ca9d1ad h1:uAwc13+y0Y8QZLTYhLCu6lHhnG99ecQU5FYTj8zxAng=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1 h1:Hz2g2wirWK7H0qIIhGIqRGTuMwTE8HEKFnDZZ7lm9NU=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=

--- a/go/pkg/cache/singleflightcache/singleflightcache_test.go
+++ b/go/pkg/cache/singleflightcache/singleflightcache_test.go
@@ -12,6 +12,8 @@ const (
 	key2 = "key2"
 	val1 = "val1"
 	val2 = "val2"
+	key3 = "key3"
+	val3 = "val3"
 )
 
 func TestSimpleValueStore(t *testing.T) {
@@ -160,4 +162,60 @@ func TestLoadDelete(t *testing.T) {
 		go del()
 	}
 	wg.Wait()
+}
+
+func TestStore(t *testing.T) {
+	c := &Cache{}
+	wg := &sync.WaitGroup{}
+	load := func() {
+		if err := c.Store(key3, val3); err != nil {
+			t.Errorf("Store(%v) failed: %v", key3, err)
+		}
+		// LoadOrStore should load the already loaded value "val3" and shouldn't
+		// overwrite "val1" to "key3".
+		val, err := c.LoadOrStore(key3, func() (interface{}, error) { return val1, nil })
+		if err != nil {
+			t.Errorf("LoadOrStore(%v) failed: %v", key3, err)
+		}
+		if val != val3 {
+			t.Errorf("LoadOrStore(%v) = %v, want %v", key3, val, val3)
+		}
+		wg.Done()
+	}
+	del := func() {
+		c.Delete(key3)
+		wg.Done()
+	}
+	wg.Add(100)
+	for i := 0; i < 50; i++ {
+		go load()
+		go del()
+	}
+	wg.Wait()
+}
+
+func TestStoreOverwrite(t *testing.T) {
+	c := &Cache{}
+
+	val, err := c.LoadOrStore(key3, func() (interface{}, error) { return val1, nil })
+	if err != nil {
+		t.Errorf("LoadOrStore(%v) failed: %v", key3, err)
+	}
+	if val != val1 {
+		t.Errorf("LoadOrStore(%v) = %v, want %v", key3, val, val1)
+	}
+
+	if err := c.Store(key3, val3); err != nil {
+		t.Errorf("Store(%v) failed: %v", key3, err)
+	}
+
+	// LoadOrStore should load the already loaded value "val3" and shouldn't
+	// overwrite "val1" to "key3".
+	val, err = c.LoadOrStore(key3, func() (interface{}, error) { return val1, nil })
+	if err != nil {
+		t.Errorf("LoadOrStore(%v) failed: %v", key3, err)
+	}
+	if val != val3 {
+		t.Errorf("LoadOrStore(%v) = %v, want %v", key3, val, val3)
+	}
 }

--- a/go/pkg/client/BUILD.bazel
+++ b/go/pkg/client/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//go/pkg/balancer/proto:go_default_library",
         "//go/pkg/chunker:go_default_library",
         "//go/pkg/digest:go_default_library",
+        "//go/pkg/filemetadata:go_default_library",
         "//go/pkg/retry:go_default_library",
         "//go/pkg/tree:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",

--- a/go/pkg/filemetadata/cache.go
+++ b/go/pkg/filemetadata/cache.go
@@ -54,6 +54,15 @@ func (c *fmCache) Delete(filename string) error {
 	return c.Backend.Delete(namespace, abs)
 }
 
+// Update updates the cache entry for the filename with the given value.
+func (c *fmCache) Update(filename string, cacheEntry *Metadata) error {
+	absFilename, err := filepath.Abs(filename)
+	if err != nil {
+		return err
+	}
+	return c.Backend.Store(namespace, absFilename, cacheEntry)
+}
+
 // Reset clears the cache.
 func (c *fmCache) Reset() {
 	c.Backend.Reset()

--- a/go/pkg/filemetadata/filemetadata.go
+++ b/go/pkg/filemetadata/filemetadata.go
@@ -66,6 +66,7 @@ func Compute(filename string) *Metadata {
 type Cache interface {
 	Get(path string) *Metadata
 	Delete(filename string) error
+	Update(path string, cacheEntry *Metadata) error
 	Reset()
 	GetCacheHits() uint64
 	GetCacheMisses() uint64
@@ -81,6 +82,11 @@ func (c *noopCache) Get(path string) *Metadata {
 
 // Delete removes an entry from the cache. It is a noop for the Noop cache.
 func (c *noopCache) Delete(string) error {
+	return nil
+}
+
+// Update updates a cache entry with the given value. It is a noop for Noop cache.
+func (c *noopCache) Update(string, *Metadata) error {
 	return nil
 }
 

--- a/go/pkg/rexec/rexec.go
+++ b/go/pkg/rexec/rexec.go
@@ -120,7 +120,7 @@ func (ec *Context) downloadResults() *command.Result {
 		return command.NewRemoteErrorResult(err)
 	}
 	if ec.opt.DownloadOutputs {
-		if err := ec.client.GrpcClient.DownloadActionOutputs(ec.ctx, ec.resPb, ec.cmd.ExecRoot); err != nil {
+		if err := ec.client.GrpcClient.DownloadActionOutputs(ec.ctx, ec.resPb, ec.cmd.ExecRoot, ec.client.FileMetadataCache); err != nil {
 			return command.NewRemoteErrorResult(err)
 		}
 	}

--- a/go/pkg/tree/tree_test.go
+++ b/go/pkg/tree/tree_test.go
@@ -122,6 +122,16 @@ func (c *callCountingMetadataCache) Delete(path string) error {
 	return c.cache.Delete(path)
 }
 
+func (c *callCountingMetadataCache) Update(path string, ce *filemetadata.Metadata) error {
+	c.t.Helper()
+	p, err := filepath.Rel(c.execRoot, path)
+	if err != nil {
+		c.t.Errorf("expected %v to be under %v", path, c.execRoot)
+	}
+	c.calls[p]++
+	return c.cache.Update(path, ce)
+}
+
 func (c *callCountingMetadataCache) Reset() {
 	c.t.Helper()
 	c.cache.Reset()


### PR DESCRIPTION
When we download files as part of action result, we also want to update
the digest of the downlaoded file into the file metadata cache so that:
1. Actions that have inputs as outputs reflect the updated digest of the
output
2. We don't have to recompute the digest of outputs if its already
present in the cache and the outputs are used as inputs to another
action

Test:
1. Updated existing unit-test to verify that digest is set in cache

2. Tested the change by integrating it with reproxy:
Ran this command with/ without this change:
FLAG_platform="container-image=docker://gcr.io/androidbuild-re-dockerimage/android-build-remoteexec-image@sha256:582efb38f0c229ea39952fff9e132ccbe183e14869b39888010dacf56b360d62,jdk-version=10" FLAG_exec_strategy=remote FLAG_server_address="unix:///tmp/reproxy.sock" FLAG_exec_root=`pwd` prebuilts/remoteexecution-client/latest//rewrapper --labels=type=tool --platform="Pool=default,container-image=docker://gcr.io/androidbuild-re-dockerimage/android-build-remoteexec-image@sha256:582efb38f0c229ea39952fff9e132ccbe183e14869b39888010dacf56b360d62" --exec_strategy=remote --inputs=test.txt --output_files=test.txt -- /bin/bash -c "x=\`cat test.txt\`; echo \$x,\$PWD > test.txt"

Without the change, it gets cache-hits when I run the above command more than once and with the change it
re-executes the action everytime.