### PR TITLE
return digest of root directory from ComputeOutputsToUpload

### DIFF
--- a/go/pkg/tree/tree.go
+++ b/go/pkg/tree/tree.go
@@ -378,11 +378,16 @@ func ComputeOutputsToUpload(execRoot string, paths []string, chunkSize int, cach
 		if err != nil {
 			return nil, nil, err
 		}
+		ch, err := chunker.NewFromProto(rootDir, chunkSize)
+		if err != nil {
+			return nil, nil, err
+		}
+		outs[ch.Digest()] = ch
 		treePb.Root = rootDir
 		for _, c := range childDirs {
 			treePb.Children = append(treePb.Children, c)
 		}
-		ch, err := chunker.NewFromProto(treePb, chunkSize)
+		ch, err = chunker.NewFromProto(treePb, chunkSize)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/go/pkg/tree/tree_test.go
+++ b/go/pkg/tree/tree_test.go
@@ -1251,6 +1251,8 @@ func TestComputeOutputsToUploadDirectories(t *testing.T) {
 				t.Fatalf("ComputeOutputsToUpload(...) tree proto with digest %+v not uploaded", dg)
 			}
 			wantBlobs[dg] = treeBlob
+			rootBlob := mustMarshal(tc.wantTreeRoot)
+			wantBlobs[digest.NewFromBlob(rootBlob)] = rootBlob
 			if diff := cmp.Diff(wantBlobs, gotBlobs); diff != "" {
 				t.Errorf("ComputeOutputsToUpload(...) gave diff (-want +got) on blobs:\n%s", diff)
 			}


### PR DESCRIPTION
This is to make GetTree to CAS work for root directory digest when
we upload all chunkers returned from ComputeOutputsToUpload.