### PR TITLE
Set the empty digest for empty directories when flattening a tree

### DIFF
--- a/go/pkg/tree/tree.go
+++ b/go/pkg/tree/tree.go
@@ -268,6 +268,7 @@ func flattenTree(root digest.Digest, rootPath string, dirs map[digest.Digest]*re
 		if len(dir.Files)+len(dir.Directories)+len(dir.Symlinks) == 0 {
 			flatFiles[flatDir.p] = &Output{
 				Path:             flatDir.p,
+				Digest:           digest.Empty,
 				IsEmptyDirectory: true,
 			}
 			continue

--- a/go/pkg/tree/tree_test.go
+++ b/go/pkg/tree/tree_test.go
@@ -1032,13 +1032,13 @@ func TestFlattenTreeRepeated(t *testing.T) {
 	}
 	wantOutputs := map[string]*Output{
 		"x/baz":     &Output{Digest: bazDigest},
-		"x/a/b/c":   &Output{IsEmptyDirectory: true},
+		"x/a/b/c":   &Output{IsEmptyDirectory: true, Digest: digest.Empty},
 		"x/a/b/foo": &Output{Digest: fooDigest},
 		"x/a/b/bar": &Output{Digest: barDigest, IsExecutable: true},
-		"x/b/c":     &Output{IsEmptyDirectory: true},
+		"x/b/c":     &Output{IsEmptyDirectory: true, Digest: digest.Empty},
 		"x/b/foo":   &Output{Digest: fooDigest},
 		"x/b/bar":   &Output{Digest: barDigest, IsExecutable: true},
-		"x/c":       &Output{IsEmptyDirectory: true},
+		"x/c":       &Output{IsEmptyDirectory: true, Digest: digest.Empty},
 	}
 	if len(outputs) != len(wantOutputs) {
 		t.Errorf("FlattenTree gave wrong number of outputs: want %d, got %d", len(wantOutputs), len(outputs))


### PR DESCRIPTION
This one bit us because we were flattening the tree and then attempting to find any missing blobs. Our CAS proxy was then blowing up because it couldn't discern the correct replica from the hash. 

I think this behavior is more inline with what `tree.ComputeOutputsToUpload` does. Perhaps we should do something similar with symlinks? 