### PR TITLE
client: make DownloadFiles public

### DIFF
--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -615,7 +615,7 @@ func (c *Client) DownloadActionOutputs(ctx context.Context, resPb *repb.ActionRe
 			downloads[out.Digest] = out
 		}
 	}
-	if err := c.downloadFiles(ctx, execRoot, downloads); err != nil {
+	if err := c.DownloadFiles(ctx, execRoot, downloads); err != nil {
 		return err
 	}
 	for _, output := range downloads {
@@ -668,7 +668,7 @@ func copyFile(execRoot, from, to string) error {
 	return err
 }
 
-func (c *Client) downloadFiles(ctx context.Context, execRoot string, outputs map[digest.Digest]*tree.Output) error {
+func (c *Client) DownloadFiles(ctx context.Context, execRoot string, outputs map[digest.Digest]*tree.Output) error {
 	if cap(c.casDownloaders) <= 0 {
 		return fmt.Errorf("CASConcurrency should be at least 1")
 	}

--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -668,6 +668,7 @@ func copyFile(execRoot, from, to string) error {
 	return err
 }
 
+// DownloadFiles downloads the output files under |execRoot|.
 func (c *Client) DownloadFiles(ctx context.Context, execRoot string, outputs map[digest.Digest]*tree.Output) error {
 	if cap(c.casDownloaders) <= 0 {
 		return fmt.Errorf("CASConcurrency should be at least 1")


### PR DESCRIPTION
I'd like to use this function from our client implementation tracked in https://crbug.com/1110569

We will use local disk cache for blobs in our client, but existing functions in this SDK don't allow to integrate our cache implementation easily.