### PR TITLE
Tool to download results of a given action digest

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,7 @@ github.com/bazelbuild/remote-apis v0.0.0-20190507145712-5556e9c6153f/go.mod h1:9
 github.com/bazelbuild/remote-apis v0.0.0-20191104140458-e77c4eb2ca48 h1:bgj+Oufa8F4rCHe/8omhml7cBlg3VmNhF66ed1vT2Bw=
 github.com/bazelbuild/remote-apis v0.0.0-20191104140458-e77c4eb2ca48/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
 github.com/bazelbuild/remote-apis v0.0.0-20200624085034-0afc3700d177 h1:JeDdP1ZsFOMctOzhcwYfLkGaLT8Nzxc1AXkXKUrWbAw=
+github.com/bazelbuild/remote-apis v0.0.0-20200812111343-5a7b1a472165 h1:2Wwz88RKomXNpY/Sqh0irk+lrQYhjJVR5lQvQc9PStQ=
 github.com/boombuler/barcode v1.0.0 h1:s1TvRnXwL2xJRaccrdcBQMZxq6X7DvsMogtmJeHDdrc=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625 h1:ckJgFhFWywOx+YLEMIJsTb+NV6NexWICk5+AMSuz3ss=

--- a/go/cmd/remotetool/BUILD.bazel
+++ b/go/cmd/remotetool/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/bazelbuild/remote-apis-sdks/go/cmd/remotetool",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//go/pkg/flags:go_default_library",
+        "//go/pkg/tool:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "remotetool",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/go/cmd/remotetool/main.go
+++ b/go/cmd/remotetool/main.go
@@ -1,0 +1,78 @@
+// Main package for the remotetool binary.
+//
+// Here's a sample invocation of this tool to download an action result:
+// bazelisk run //go/cmd/remotetool -- \
+// 	--instance=projects/rbe-android-ci/instances/default_instance \
+// 	--service remotebuildexecution.googleapis.com:443 \
+// 	--alsologtostderr --v 1 \
+// 	--credential_file ~/.config/foundry/keys/dev-foundry.json \
+// 	--digest=52a54724e6b3dff3bc44ef5dceb3aab5892f2fc7e37fce5aa6e16a7a266fbed6/147 \
+// 	--path=`pwd`/tmp
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/tool"
+
+	rflags "github.com/bazelbuild/remote-apis-sdks/go/pkg/flags"
+	log "github.com/golang/glog"
+)
+
+// OpType denotes the type of operation to perform.
+type OpType string
+
+const (
+	downloadActionResult OpType = "download_action_result"
+)
+
+var (
+	operation  = flag.String("operation", "download_action_result", "Specifies the operation to perform. Currently only download_action_result is supported.")
+	digest     = flag.String("digest", "", "Digest in <digest/size_bytes> format.")
+	pathPrefix = flag.String("path", "/tmp", "Directory to which outputs should be downloaded to. Defaults to /tmp/.")
+)
+
+func validate() {
+	if *digest == "" {
+		log.Exitf("--digest must be specified.")
+	}
+
+	switch OpType(*operation) {
+	case downloadActionResult:
+		return
+
+	default:
+		log.Exitf("unsupported operation %q.", *operation)
+	}
+}
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %v [-flags] -- --operation <op> arguments ...\n", path.Base(os.Args[0]))
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	validate()
+
+	ctx := context.Background()
+	grpcClient, err := rflags.NewClientFromFlags(ctx)
+	if err != nil {
+		log.Exitf("error connecting to remote execution client: %v", err)
+	}
+	defer grpcClient.Close()
+	c := &tool.Client{GrpcClient: grpcClient}
+
+	switch OpType(*operation) {
+	case downloadActionResult:
+		if err := c.DownloadActionResult(ctx, *digest, *pathPrefix); err != nil {
+			log.Exitf("error downloading action result for digest %v: %v", *digest, err)
+		}
+
+	default:
+		log.Exitf("unsupported operation %v.", *operation)
+	}
+}

--- a/go/pkg/client/BUILD.bazel
+++ b/go/pkg/client/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "//go/pkg/chunker:go_default_library",
         "//go/pkg/digest:go_default_library",
         "//go/pkg/fakes:go_default_library",
+        "//go/pkg/filemetadata:go_default_library",
         "//go/pkg/portpicker:go_default_library",
         "//go/pkg/retry:go_default_library",
         "//go/pkg/tree:go_default_library",

--- a/go/pkg/tool/BUILD.bazel
+++ b/go/pkg/tool/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["tool.go"],
+    importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/tool",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go/pkg/client:go_default_library",
+        "//go/pkg/digest:go_default_library",
+        "//go/pkg/filemetadata:go_default_library",
+        "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["tool_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//go/pkg/command:go_default_library",
+        "//go/pkg/fakes:go_default_library",
+        "//go/pkg/outerr:go_default_library",
+    ],
+)

--- a/go/pkg/tool/tool.go
+++ b/go/pkg/tool/tool.go
@@ -1,0 +1,80 @@
+// Package tool provides implementation of the debugging related operations
+// supported by go/cmd/remotetool package.
+package tool
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/filemetadata"
+
+	rc "github.com/bazelbuild/remote-apis-sdks/go/pkg/client"
+	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+	log "github.com/golang/glog"
+)
+
+const (
+	stdoutFile = "stdout"
+	stderrFile = "stderr"
+)
+
+// Client is a remote execution client.
+type Client struct {
+	GrpcClient *rc.Client
+}
+
+// DownloadActionResult downloads the action result of the given action digest
+// if it exists in the RBE cache.
+func (c *Client) DownloadActionResult(ctx context.Context, actionDigest, pathPrefix string) error {
+	acDg, err := digest.NewFromString(actionDigest)
+	if err != nil {
+		return err
+	}
+	d := &repb.Digest{
+		Hash:      acDg.Hash,
+		SizeBytes: acDg.Size,
+	}
+	resPb, err := c.GrpcClient.CheckActionCache(ctx, d)
+	if err != nil {
+		return err
+	}
+	if resPb == nil {
+		return fmt.Errorf("action digest %v not found in cache", d)
+	}
+
+	log.Infof("Downloading action results of %v to %v.", actionDigest, pathPrefix)
+	// We don't really need an in-memory filemetadata cache for debugging operations.
+	noopCache := filemetadata.NewNoopCache()
+	if err := c.GrpcClient.DownloadActionOutputs(ctx, resPb, pathPrefix, noopCache); err != nil {
+		log.Errorf("Failed downloading action outputs: %v.", err)
+	}
+
+	// We have not requested for stdout/stderr to be inlined in GetActionResult, so the server
+	// should be returning the digest instead of sending raw data.
+	outMsgs := map[string]*repb.Digest{
+		filepath.Join(pathPrefix, stdoutFile): resPb.StdoutDigest,
+		filepath.Join(pathPrefix, stderrFile): resPb.StderrDigest,
+	}
+	for path, reDg := range outMsgs {
+		if reDg == nil {
+			continue
+		}
+		dg := &digest.Digest{
+			Hash: reDg.GetHash(),
+			Size: reDg.GetSizeBytes(),
+		}
+		log.Infof("Downloading stdout/stderr to %v.", path)
+		bytes, err := c.GrpcClient.ReadBlob(ctx, *dg)
+		if err != nil {
+			log.Errorf("Unable to read blob for %v with digest %v.", path, dg)
+		}
+		if err := ioutil.WriteFile(path, bytes, 0644); err != nil {
+			log.Errorf("Unable to write output of digest %v to file %v.", dg, path)
+		}
+	}
+	log.Infof("Successfully downloaded results of %v to %v.", actionDigest, pathPrefix)
+	return nil
+}

--- a/go/pkg/tool/tool_test.go
+++ b/go/pkg/tool/tool_test.go
@@ -1,0 +1,48 @@
+package tool
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/command"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/fakes"
+)
+
+func TestTool_DownloadActionResult(t *testing.T) {
+	e, cleanup := fakes.NewTestEnv(t)
+	defer cleanup()
+	cmd := &command.Command{
+		Args:        []string{"tool"},
+		ExecRoot:    e.ExecRoot,
+		InputSpec:   &command.InputSpec{},
+		OutputFiles: []string{"a/b/out"},
+	}
+	opt := command.DefaultExecutionOptions()
+	output := "output"
+	_, acDg := e.Set(cmd, opt, &command.Result{Status: command.CacheHitResultStatus}, &fakes.OutputFile{Path: "a/b/out", Contents: output},
+		fakes.StdOut("stdout"), fakes.StdErr("stderr"))
+
+	toolClient := &Client{GrpcClient: e.Client.GrpcClient}
+	tmpDir := os.TempDir()
+	if err := toolClient.DownloadActionResult(context.Background(), acDg.String(), tmpDir); err != nil {
+		t.Fatalf("DownloadActionResult(%v,%v) failed: %v", acDg.String(), tmpDir, err)
+	}
+	verifyData := map[string]string{
+		filepath.Join(tmpDir, "a/b/out"): "output",
+		filepath.Join(tmpDir, "stdout"):  "stdout",
+		filepath.Join(tmpDir, "stderr"):  "stderr",
+	}
+	for fp, want := range verifyData {
+		c, err := ioutil.ReadFile(fp)
+		if err != nil {
+			t.Fatalf("Unable to read downloaded output file %v: %v", fp, err)
+		}
+		got := string(c)
+		if got != want {
+			t.Fatalf("Incorrect content in downloaded file %v, want %v, got %v", fp, want, got)
+		}
+	}
+}


### PR DESCRIPTION
More often we find ourselves wanting to download the results of an
action digest to see what they were. This tool lets us do that. Pass it
an action digest and it would download the results to the given
directory.

Test:
1. Ran against a test RBE stack and it downloaded the RBE action output
2. Unit tests