### PR TITLE
Tool to show inputs/outputs & command of an action

### DIFF
--- a/go/api/command/BUILD.bazel
+++ b/go/api/command/BUILD.bazel
@@ -12,7 +12,7 @@ proto_library(
 go_proto_library(
     name = "command_go_proto",
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/api/command",
-    proto = ":command_proto",
+    proto = ":cmd_proto",
     visibility = ["//visibility:public"],
 )
 
@@ -21,4 +21,11 @@ go_library(
     embed = [":command_go_proto"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/api/command",
     visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "cmd_proto",
+    srcs = ["command.proto"],
+    visibility = ["//visibility:public"],
+    deps = ["@com_google_protobuf//:timestamp_proto"],
 )

--- a/go/cmd/remotetool/main.go
+++ b/go/cmd/remotetool/main.go
@@ -28,6 +28,7 @@ type OpType string
 
 const (
 	downloadActionResult OpType = "download_action_result"
+	showAction           OpType = "show_action"
 )
 
 var (
@@ -42,7 +43,7 @@ func validate() {
 	}
 
 	switch OpType(*operation) {
-	case downloadActionResult:
+	case downloadActionResult, showAction:
 		return
 
 	default:
@@ -71,6 +72,13 @@ func main() {
 		if err := c.DownloadActionResult(ctx, *digest, *pathPrefix); err != nil {
 			log.Exitf("error downloading action result for digest %v: %v", *digest, err)
 		}
+
+	case showAction:
+		res, err := c.ShowAction(ctx, *digest)
+		if err != nil {
+			log.Exitf("error fetching action %v: %v", *digest, err)
+		}
+		fmt.Fprintf(os.Stdout, res)
 
 	default:
 		log.Exitf("unsupported operation %v.", *operation)

--- a/go/pkg/tool/BUILD.bazel
+++ b/go/pkg/tool/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//go/pkg/client:go_default_library",
         "//go/pkg/digest:go_default_library",
         "//go/pkg/filemetadata:go_default_library",
+        "//go/pkg/tree:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_golang_glog//:go_default_library",
     ],
@@ -21,6 +22,6 @@ go_test(
     deps = [
         "//go/pkg/command:go_default_library",
         "//go/pkg/fakes:go_default_library",
-        "//go/pkg/outerr:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
     ],
 )

--- a/go/pkg/tool/tool.go
+++ b/go/pkg/tool/tool.go
@@ -3,13 +3,16 @@
 package tool
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/filemetadata"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/tree"
 
 	rc "github.com/bazelbuild/remote-apis-sdks/go/pkg/client"
 	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
@@ -29,20 +32,9 @@ type Client struct {
 // DownloadActionResult downloads the action result of the given action digest
 // if it exists in the RBE cache.
 func (c *Client) DownloadActionResult(ctx context.Context, actionDigest, pathPrefix string) error {
-	acDg, err := digest.NewFromString(actionDigest)
+	resPb, err := c.getActionResult(ctx, actionDigest)
 	if err != nil {
 		return err
-	}
-	d := &repb.Digest{
-		Hash:      acDg.Hash,
-		SizeBytes: acDg.Size,
-	}
-	resPb, err := c.GrpcClient.CheckActionCache(ctx, d)
-	if err != nil {
-		return err
-	}
-	if resPb == nil {
-		return fmt.Errorf("action digest %v not found in cache", d)
 	}
 
 	log.Infof("Downloading action results of %v to %v.", actionDigest, pathPrefix)
@@ -77,4 +69,155 @@ func (c *Client) DownloadActionResult(ctx context.Context, actionDigest, pathPre
 	}
 	log.Infof("Successfully downloaded results of %v to %v.", actionDigest, pathPrefix)
 	return nil
+}
+
+// ShowAction parses and displays an action with its corresponding command.
+func (c *Client) ShowAction(ctx context.Context, actionDigest string) (string, error) {
+	var showActionRes bytes.Buffer
+	resPb, err := c.getActionResult(ctx, actionDigest)
+	if err != nil {
+		return "", err
+	}
+
+	acDg, err := digest.NewFromString(actionDigest)
+	if err != nil {
+		return "", err
+	}
+	actionProto := &repb.Action{}
+	if err := c.GrpcClient.ReadProto(ctx, acDg, actionProto); err != nil {
+		return "", err
+	}
+	showActionRes.WriteString("Command\n========\n")
+	showActionRes.WriteString(fmt.Sprintf("Command Digest: %v\n", actionProto.GetCommandDigest().Hash))
+
+	log.Infof("Reading command from action digest..")
+	commandProto := &repb.Command{}
+	cmdDg, err := digest.NewFromProto(actionProto.GetCommandDigest())
+	if err != nil {
+		return "", err
+	}
+	if err := c.GrpcClient.ReadProto(ctx, cmdDg, commandProto); err != nil {
+		return "", err
+	}
+	cmdStr := strings.Join(commandProto.GetArguments(), " ")
+	showActionRes.WriteString(fmt.Sprintf("\t%v\n", cmdStr))
+
+	log.Infof("Fetching input tree from input root digest..")
+	inpTree, err := c.getInputTree(ctx, actionProto.GetInputRootDigest())
+	if err != nil {
+		return "", err
+	}
+	showActionRes.WriteString("\nInputs\n======\n")
+	showActionRes.WriteString(inpTree)
+
+	log.Infof("Fetching output tree from action result..")
+	outs, err := c.getOutputs(ctx, resPb)
+	if err != nil {
+		return "", err
+	}
+	showActionRes.WriteString("\n\n")
+	showActionRes.WriteString(outs)
+	return showActionRes.String(), nil
+}
+
+func (c *Client) getOutputs(ctx context.Context, actionRes *repb.ActionResult) (string, error) {
+	var res bytes.Buffer
+	res.WriteString("Output Files:\n=============")
+	for _, of := range actionRes.GetOutputFiles() {
+		res.WriteString(fmt.Sprintf("\n%v, digest: %v", of.GetPath(), of.GetDigest().Hash))
+	}
+
+	res.WriteString("\n\nOutput Files From Directories:\n=================")
+	for _, od := range actionRes.GetOutputDirectories() {
+		treeDigest := od.GetTreeDigest()
+		dg, err := digest.NewFromProto(treeDigest)
+		if err != nil {
+			return "", err
+		}
+		outDirTree := &repb.Tree{}
+		if err := c.GrpcClient.ReadProto(ctx, dg, outDirTree); err != nil {
+			return "", err
+		}
+
+		outputs, err := c.flattenTree(ctx, outDirTree)
+		if err != nil {
+			return "", err
+		}
+		res.WriteString("\n")
+		res.WriteString(outputs)
+	}
+	return res.String(), nil
+}
+
+func (c *Client) getInputTree(ctx context.Context, root *repb.Digest) (string, error) {
+	var res bytes.Buffer
+
+	dg, err := digest.NewFromProto(root)
+	if err != nil {
+		return "", err
+	}
+	rootDir := &repb.Directory{}
+	if err := c.GrpcClient.ReadProto(ctx, dg, rootDir); err != nil {
+		return "", fmt.Errorf("error fetching root dir proto for digest %v: %v", dg, err)
+	}
+
+	if len(rootDir.GetDirectories()) < 1 {
+		return "", nil
+	}
+	rootDirNode := rootDir.GetDirectories()[0]
+	res.WriteString(fmt.Sprintf("%v: [Directory digest: %v]", rootDirNode.GetName(), rootDirNode.GetDigest().Hash))
+
+	dirs, err := c.GrpcClient.GetDirectoryTree(ctx, rootDirNode.GetDigest())
+	if err != nil {
+		return "", err
+	}
+	t := &repb.Tree{
+		Root:     rootDir,
+		Children: dirs,
+	}
+	inputs, err := c.flattenTree(ctx, t)
+	if err != nil {
+		return "", err
+	}
+	res.WriteString("\n")
+	res.WriteString(inputs)
+
+	return res.String(), nil
+}
+
+func (c *Client) flattenTree(ctx context.Context, t *repb.Tree) (string, error) {
+	var res bytes.Buffer
+	outputs, err := tree.FlattenTree(t, "")
+	if err != nil {
+		return "", err
+	}
+	for path, output := range outputs {
+		if output.IsEmptyDirectory {
+			res.WriteString(fmt.Sprintf("%v: [Directory digest: %v]\n", path, output.Digest))
+		} else if output.SymlinkTarget != "" {
+			res.WriteString(fmt.Sprintf("%v: [Symlink digest: %v, Symlink Target: %v]\n", path, output.Digest, output.SymlinkTarget))
+		} else {
+			res.WriteString(fmt.Sprintf("%v: [File digest: %v]\n", path, output.Digest))
+		}
+	}
+	return res.String(), nil
+}
+
+func (c *Client) getActionResult(ctx context.Context, actionDigest string) (*repb.ActionResult, error) {
+	acDg, err := digest.NewFromString(actionDigest)
+	if err != nil {
+		return nil, err
+	}
+	d := &repb.Digest{
+		Hash:      acDg.Hash,
+		SizeBytes: acDg.Size,
+	}
+	resPb, err := c.GrpcClient.CheckActionCache(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+	if resPb == nil {
+		return nil, fmt.Errorf("action digest %v not found in cache", d)
+	}
+	return resPb, nil
 }


### PR DESCRIPTION
The tool traverses both input and output directories recursively and
shows:
1. Empty directories
2. Files
3. Symlinks

The previous tool based on tools_remote only used to show the top level
output directories and didn't support symlinks.

As part of this change, I also:
1. Added fake GetTree() function (this was also a feature reequest from
the Goma team).
2. Added support for fake inputs in SDK.
3. Rearranged some of the fake server setup code so that options are
applied first before Merkle tree is computed. I'm doing this since fake
inputs need to be created from the options before Merkle tree is
computed.

Test: Unit-tests, variety of inteegration tests against actual action
digests in test stack.