### PR TITLE
Add DownloadResults function to download the results of an action.

### DIFF
--- a/go/pkg/rexec/rexec.go
+++ b/go/pkg/rexec/rexec.go
@@ -109,7 +109,7 @@ func (ec *Context) setOutputMetadata() {
 	}
 }
 
-func (ec *Context) downloadResults() *command.Result {
+func (ec *Context) downloadResults(execRoot string, downloadOutputs bool) *command.Result {
 	ec.setOutputMetadata()
 	ec.Metadata.EventTimes[command.EventDownloadResults] = &command.TimeInterval{From: time.Now()}
 	defer func() { ec.Metadata.EventTimes[command.EventDownloadResults].To = time.Now() }()
@@ -119,8 +119,8 @@ func (ec *Context) downloadResults() *command.Result {
 	if err := ec.downloadStream(ec.resPb.StderrRaw, ec.resPb.StderrDigest, ec.oe.WriteErr); err != nil {
 		return command.NewRemoteErrorResult(err)
 	}
-	if ec.opt.DownloadOutputs {
-		if err := ec.client.GrpcClient.DownloadActionOutputs(ec.ctx, ec.resPb, ec.cmd.ExecRoot, ec.client.FileMetadataCache); err != nil {
+	if downloadOutputs {
+		if err := ec.client.GrpcClient.DownloadActionOutputs(ec.ctx, ec.resPb, execRoot, ec.client.FileMetadataCache); err != nil {
 			return command.NewRemoteErrorResult(err)
 		}
 	}
@@ -196,7 +196,7 @@ func (ec *Context) GetCachedResult() {
 	}
 	if ec.resPb != nil {
 		log.V(1).Infof("%s> Found cached result, downloading outputs...", ec.cmd.Identifiers.CommandID)
-		ec.Result = ec.downloadResults()
+		ec.Result = ec.downloadResults(ec.cmd.ExecRoot, ec.opt.DownloadOutputs)
 		if ec.Result.Err == nil {
 			ec.Result.Status = command.CacheHitResultStatus
 		}
@@ -303,7 +303,7 @@ func (ec *Context) ExecuteRemotely() {
 
 	if ec.resPb != nil {
 		log.V(1).Infof("%s> Downloading outputs...", cmdID)
-		ec.Result = ec.downloadResults()
+		ec.Result = ec.downloadResults(ec.cmd.ExecRoot, ec.opt.DownloadOutputs)
 		if resp.CachedResult && ec.Result.Err == nil {
 			ec.Result.Status = command.CacheHitResultStatus
 		}
@@ -319,6 +319,11 @@ func (ec *Context) ExecuteRemotely() {
 	if ec.resPb == nil {
 		ec.Result = command.NewRemoteErrorResult(fmt.Errorf("execute did not return action result"))
 	}
+}
+
+// DownloadResults downloads the result of the command in the context to the specified directory.
+func (ec *Context) DownloadResults(execRoot string) {
+	ec.Result = ec.downloadResults(execRoot, true)
 }
 
 func timeFromProto(tPb *tspb.Timestamp) time.Time {

--- a/go/pkg/rexec/rexec_test.go
+++ b/go/pkg/rexec/rexec_test.go
@@ -421,3 +421,51 @@ func TestUpdateRemoteCache(t *testing.T) {
 		t.Errorf("GetCachedResult() gave unexpected stdout: %v", oe.Stderr())
 	}
 }
+
+func TestDownloadResults(t *testing.T) {
+	e, cleanup := fakes.NewTestEnv(t)
+	defer cleanup()
+	fooPath := filepath.Join(e.ExecRoot, "foo")
+	fooBlob := []byte("hello")
+	if err := ioutil.WriteFile(fooPath, fooBlob, 0777); err != nil {
+		t.Fatalf("failed to write input file %s", fooBlob)
+	}
+	cmd := &command.Command{
+		Args:        []string{"tool"},
+		ExecRoot:    e.ExecRoot,
+		InputSpec:   &command.InputSpec{Inputs: []string{"foo"}},
+		OutputFiles: []string{"a/b/out"},
+	}
+	opt := &command.ExecutionOptions{AcceptCached: true, DownloadOutputs: false}
+	oe := outerr.NewRecordingOutErr()
+	ec, err := e.Client.NewContext(context.Background(), cmd, opt, oe)
+	if err != nil {
+		t.Fatalf("failed creating execution context: %v", err)
+	}
+	outPath := filepath.Join(e.ExecRoot, "a/b/out")
+	outBlob := []byte("out!")
+	wantRes := &command.Result{Status: command.CacheHitResultStatus}
+	e.Set(cmd, opt, wantRes, &fakes.OutputFile{Path: "a/b/out", Contents: string(outBlob)},
+		fakes.StdOut("stdout"), fakes.StdErrRaw("stderr"))
+	ec.GetCachedResult()
+	if diff := cmp.Diff(wantRes, ec.Result); diff != "" {
+		t.Errorf("GetCachedResult() gave result diff (-want +got):\n%s", diff)
+	}
+	if _, err := os.Stat(outPath); !os.IsNotExist(err) {
+		t.Errorf("expected output file %s to not be downloaded, but it was", outPath)
+	}
+	if len(oe.Stdout()) == 0 {
+		t.Errorf("GetCachedResult() gave unexpected stdout: %v", oe.Stdout())
+	}
+	if len(oe.Stderr()) == 0 {
+		t.Errorf("GetCachedResult() gave unexpected stderr: %v", oe.Stderr())
+	}
+	ec.DownloadResults(e.ExecRoot)
+	contents, err := ioutil.ReadFile(outPath)
+	if err != nil {
+		t.Errorf("error reading from %s: %v", outPath, err)
+	}
+	if !bytes.Equal(contents, outBlob) {
+		t.Errorf("expected %s to contain %q, got %v", outPath, string(outBlob), contents)
+	}
+}


### PR DESCRIPTION
DownloadResults will download the results of the action in the
execution context, regardless of the DownloadOutputs option set in
the context.

Test: unit tests