### PR TITLE
cas: utilize locality when writing files to disk in DownloadFiles

### DIFF
--- a/go/pkg/client/cas_test.go
+++ b/go/pkg/client/cas_test.go
@@ -524,8 +524,8 @@ func TestWriteBlobsBatching(t *testing.T) {
 		{
 			name:      "large and small blobs hitting max exactly",
 			sizes:     []int{338, 338, 338, 1, 1, 1},
-			batchReqs: 3,
-			writeReqs: 0,
+			batchReqs: 2,
+			writeReqs: 2,
 		},
 		{
 			name:      "small batches of big blobs",
@@ -884,7 +884,7 @@ func TestDownloadActionOutputsBatching(t *testing.T) {
 		{
 			name:      "large and small blobs hitting max exactly",
 			sizes:     []int{338, 338, 338, 1, 1, 1},
-			batchReqs: 3,
+			batchReqs: 2,
 		},
 		{
 			name:      "small batches of big blobs",


### PR DESCRIPTION
This improves time of DownloadFiles in n1-standard-8 Windows GCE with standard disk when downloading 14k+ files from 125s to 75s (14s to 11s in one time measure on Linux).