### PR TITLE
Make Store() and Delete() mutually exclusive

### DIFF
--- a/go/pkg/cache/singleflightcache/singleflightcache_test.go
+++ b/go/pkg/cache/singleflightcache/singleflightcache_test.go
@@ -167,7 +167,9 @@ func TestLoadDelete(t *testing.T) {
 func TestStore(t *testing.T) {
 	c := &Cache{}
 	wg := &sync.WaitGroup{}
+	var mu sync.Mutex
 	load := func() {
+		mu.Lock()
 		if err := c.Store(key3, val3); err != nil {
 			t.Errorf("Store(%v) failed: %v", key3, err)
 		}
@@ -177,13 +179,16 @@ func TestStore(t *testing.T) {
 		if err != nil {
 			t.Errorf("LoadOrStore(%v) failed: %v", key3, err)
 		}
+		mu.Unlock()
 		if val != val3 {
 			t.Errorf("LoadOrStore(%v) = %v, want %v", key3, val, val3)
 		}
 		wg.Done()
 	}
 	del := func() {
+		mu.Lock()
 		c.Delete(key3)
+		mu.Unlock()
 		wg.Done()
 	}
 	wg.Add(100)


### PR DESCRIPTION
There's a race condition where we might sometimes delete a value after
Store() and before LoadOrStore(), so the test fails flakily. Making them
mutually exclusive so they don't fail anymore.

Test: bazelisk test --runs_per_test 200 --features race  //go/pkg/cache/singleflightcache:go_default_test --test_output=streamed --test_filter="TestStore" (this failed 4/200 without the fix and 0/400 with the fix).