### PR TITLE
Make max concurrent requests and streams as flags

### DIFF
--- a/go/pkg/balancer/gcp_balancer.go
+++ b/go/pkg/balancer/gcp_balancer.go
@@ -19,10 +19,12 @@ const (
 	healthCheckEnabled = true
 )
 
-// MinConnections is the minimum number of gRPC sub-connections the gRPC balancer
-// should create during SDK initialization.
-// It is initialized in flags package.
-var MinConnections int
+var (
+	// MinConnections is the minimum number of gRPC sub-connections the gRPC balancer
+	// should create during SDK initialization.
+	// It is initialized in flags package.
+	MinConnections = 1
+)
 
 func init() {
 	balancer.Register(newBuilder())

--- a/go/pkg/client/cas_test.go
+++ b/go/pkg/client/cas_test.go
@@ -27,7 +27,8 @@ import (
 )
 
 const (
-	instance = "instance"
+	instance              = "instance"
+	defaultCASConcurrency = 500
 )
 
 func TestSplitEndpoints(t *testing.T) {
@@ -405,7 +406,7 @@ func TestUpload(t *testing.T) {
 		// and the test verifies no attempt was made to upload them.
 		present [][]byte
 		// concurrency is the CAS concurrency with which we should be uploading the blobs. If not
-		// specified, it uses client.DefaultCASConcurrency.
+		// specified, it uses defaultCASConcurrency.
 		concurrency client.CASConcurrency
 	}{
 		{
@@ -489,8 +490,8 @@ func TestUpload(t *testing.T) {
 							t.Errorf("Stats said that blob %v with digest %s was present in the CAS", blob, dg)
 						}
 					}
-					if fake.MaxConcurrency() > client.DefaultCASConcurrency {
-						t.Errorf("CAS concurrency %v was higher than max %v", fake.MaxConcurrency(), client.DefaultCASConcurrency)
+					if fake.MaxConcurrency() > defaultCASConcurrency {
+						t.Errorf("CAS concurrency %v was higher than max %v", fake.MaxConcurrency(), defaultCASConcurrency)
 					}
 				})
 			}
@@ -995,8 +996,8 @@ func TestDownloadActionOutputsConcurrency(t *testing.T) {
 					t.Errorf("expected %s to contain %v, got %v", path, contents, data)
 				}
 			}
-			if fake.MaxConcurrency() > client.DefaultCASConcurrency {
-				t.Errorf("CAS concurrency %v was higher than max %v", fake.MaxConcurrency(), client.DefaultCASConcurrency)
+			if fake.MaxConcurrency() > defaultCASConcurrency {
+				t.Errorf("CAS concurrency %v was higher than max %v", fake.MaxConcurrency(), defaultCASConcurrency)
 			}
 		})
 	}

--- a/go/pkg/client/cas_test.go
+++ b/go/pkg/client/cas_test.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	instance              = "instance"
-	defaultCASConcurrency = 500
+	defaultCASConcurrency = 50
 )
 
 func TestSplitEndpoints(t *testing.T) {

--- a/go/pkg/fakes/server.go
+++ b/go/pkg/fakes/server.go
@@ -73,8 +73,11 @@ func (s *Server) Stop() {
 // NewTestClient returns a new in-process Client connected to this server.
 func (s *Server) NewTestClient(ctx context.Context) (*rc.Client, error) {
 	return rc.NewClient(ctx, "instance", rc.DialParams{
-		Service:    s.listener.Addr().String(),
-		NoSecurity: true,
+		Service:               s.listener.Addr().String(),
+		NoSecurity:            true,
+		MaxCASConcurrency:     50,
+		MaxConcurrentRequests: 500,
+		MaxConcurrentStreams:  100,
 	})
 }
 

--- a/go/pkg/flags/BUILD.bazel
+++ b/go/pkg/flags/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["flags.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/flags",
     visibility = ["//visibility:public"],
-    deps = ["//go/pkg/client:go_default_library"],
+    deps = [
+        "//go/pkg/balancer:go_default_library",
+        "//go/pkg/client:go_default_library",
+    ],
 )

--- a/go/pkg/flags/flags.go
+++ b/go/pkg/flags/flags.go
@@ -5,7 +5,25 @@ import (
 	"context"
 	"flag"
 
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/balancer"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/client"
+)
+
+const (
+	// defaultMaxConcurrentRequests specifies the default maximum number of concurrent requests on a single connection
+	// that the GRPC balancer can perform.
+	defaultMaxConcurrentRequests = 25
+
+	// defaultConcurrentStreamsThreshold specifies the default threshold value at which the GRPC balancer should create
+	// new sub-connections.
+	defaultConcurrentStreamsThreshold = 25
+
+	// defaultCASConcurrency is the default maximum number of concurrent upload and download operations.
+	defaultCASConcurrency = 500
+
+	// defaultMinConnections is the default minimum number of gRPC sub-connections the gRPC balancer
+	// should create during SDK initialization.
+	defaultMinConnections = 5
 )
 
 var (
@@ -35,7 +53,18 @@ var (
 	// Instance gives the instance of remote execution to test (in
 	// projects/[PROJECT_ID]/instances/[INSTANCE_NAME] format for Google RBE).
 	Instance = flag.String("instance", "", "The instance ID to target when calling remote execution via gRPC (e.g., projects/$PROJECT/instances/default_instance for Google RBE).")
+	// CASConcurrency specifies the maximum number of concurrent upload & download RPCs that can be in flight.
+	CASConcurrency = flag.Int("cas_concurrency", defaultCASConcurrency, "Num concurrent upload / download RPCs that the SDK is allowed to do.")
+	// MaxConcurrentRequests denotes the maximum number of concurrent RPCs on a single gRPC connection.
+	MaxConcurrentRequests = flag.Uint("max_concurrent_requests_per_conn", defaultMaxConcurrentRequests, "Maximum number of concurrent RPCs on a single gRPC connection.")
+	// MaxConcurrentStreams denotes the maximum number of concurrent stream RPCs on a single gRPC connection.
+	MaxConcurrentStreams = flag.Uint("max_concurrent_streams_per_conn", defaultConcurrentStreamsThreshold, "Maximum number of concurrent stream RPCs on a single gRPC connection.")
 )
+
+func init() {
+	// MinConnections denotes the minimum number of gRPC sub-connections the gRPC balancer should create during SDK initialization.
+	flag.IntVar(&balancer.MinConnections, "min_grpc_connections", defaultMinConnections, "Minimum number of gRPC sub-connections the gRPC balancer should create during SDK initialization.")
+}
 
 // NewClientFromFlags connects to a remote execution service and returns a client suitable for higher-level
 // functionality. It uses the flags from above to configure the connection to remote execution.
@@ -46,5 +75,8 @@ func NewClientFromFlags(ctx context.Context, opts ...client.Opt) (*client.Client
 		CredFile:              *CredFile,
 		UseApplicationDefault: *UseApplicationDefaultCreds,
 		UseComputeEngine:      *UseGCECredentials,
+		MaxCASConcurrency:     client.CASConcurrency(*CASConcurrency),
+		MaxConcurrentRequests: uint32(*MaxConcurrentRequests),
+		MaxConcurrentStreams:  uint32(*MaxConcurrentStreams),
 	}, opts...)
 }


### PR DESCRIPTION
Also changed the default values of these parameters to reflect our
experiments with them from asia region.
1. We need to be able to do more than 50 concurrent CAS RPCs if we are
running a build at 500 parallelism for example.
2. In long-haul links like from asia-east <-> us-central, fewer stream
RPCs per connection is better than more stream RPCs per stream. Even at
50 stream RPCs per conn, we see a 3x latecy increase.