### PR TITLE
add link to godev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Remote Execution API SDKs
 CI status: [![Build Status](https://badge.buildkite.com/7aef818bbb87e72d81054de0d9151ffe4a4f6eb04b85eab106.svg?branch=master)](https://buildkite.com/bazel/remote-apis-sdks)
 
+[![PkgGoDev](https://pkg.go.dev/badge/mod/github.com/bazelbuild/remote-apis-sdks)](https://pkg.go.dev/mod/github.com/bazelbuild/remote-apis-sdks)
+
 This repository contains SDKs for the
 [Remote Execution API](https://github.com/bazelbuild/remote-apis).
 


### PR DESCRIPTION
I took this from
https://pkg.go.dev/badge/?path=https%3A%2F%2Fpkg.go.dev%2Fmod%2Fgithub.com%2Fbazelbuild%2Fremote-apis-sdks