### PR TITLE
Revert "cas: utilize locality when writing files to disk in DownloadFiles"

### DIFF
--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -290,9 +290,12 @@ func (c *Client) BatchDownloadBlobs(ctx context.Context, dgs []digest.Digest) (m
 func (c *Client) makeBatches(dgs []digest.Digest) [][]digest.Digest {
 	var batches [][]digest.Digest
 	log.V(2).Infof("Batching %d digests", len(dgs))
+	sort.Slice(dgs, func(i, j int) bool {
+		return dgs[i].Size < dgs[j].Size
+	})
 	for len(dgs) > 0 {
-		batch := []digest.Digest{dgs[0]}
-		dgs = dgs[1:]
+		batch := []digest.Digest{dgs[len(dgs)-1]}
+		dgs = dgs[:len(dgs)-1]
 		requestOverhead := marshalledFieldSize(int64(len(c.InstanceName)))
 		sz := requestOverhead + marshalledRequestSize(batch[0])
 		var nextSize int64
@@ -677,19 +680,9 @@ func (c *Client) DownloadFiles(ctx context.Context, execRoot string, outputs map
 		logInterval = 25
 	)
 
-	paths := make([]*tree.Output, 0, len(outputs))
-	for _, output := range outputs {
-		paths = append(paths, output)
-	}
-
-	// This is to utilize locality in disk when writing files.
-	sort.Slice(paths, func(i, j int) bool {
-		return paths[i].Path < paths[j].Path
-	})
-
 	var dgs []digest.Digest
-	for _, path := range paths {
-		dgs = append(dgs, path.Digest)
+	for dg := range outputs {
+		dgs = append(dgs, dg)
 	}
 
 	log.V(2).Infof("%d items to download", len(dgs))

--- a/go/pkg/client/cas_test.go
+++ b/go/pkg/client/cas_test.go
@@ -526,8 +526,8 @@ func TestWriteBlobsBatching(t *testing.T) {
 		{
 			name:      "large and small blobs hitting max exactly",
 			sizes:     []int{338, 338, 338, 1, 1, 1},
-			batchReqs: 2,
-			writeReqs: 2,
+			batchReqs: 3,
+			writeReqs: 0,
 		},
 		{
 			name:      "small batches of big blobs",
@@ -886,7 +886,7 @@ func TestDownloadActionOutputsBatching(t *testing.T) {
 		{
 			name:      "large and small blobs hitting max exactly",
 			sizes:     []int{338, 338, 338, 1, 1, 1},
-			batchReqs: 2,
+			batchReqs: 3,
 		},
 		{
 			name:      "small batches of big blobs",


### PR DESCRIPTION
Reverts bazelbuild/remote-apis-sdks#164

This might cause download latency in Android. We need more recent changes than this for our next release, so reverting it now and fixing it later.