### PR TITLE
Add DownloadDirectory function

### DIFF
--- a/go/pkg/client/cas_test.go
+++ b/go/pkg/client/cas_test.go
@@ -883,7 +883,12 @@ func TestDownloadDirectory(t *testing.T) {
 	fake.Put(dirBlob)
 
 	d := digest.TestNewFromMessage(dir)
-	execRoot := t.TempDir()
+	execRoot, err := ioutil.TempDir("", "DownloadDirectory")
+	if err != nil {
+		t.Fatalf("failed to make temp dir: %v", err)
+	}
+	defer os.RemoveAll(execRoot)
+
 	err = c.DownloadDirectory(ctx, d, execRoot, cache)
 	if err != nil {
 		t.Errorf("error in DownloadActionOutputs: %s", err)

--- a/go/pkg/client/cas_test.go
+++ b/go/pkg/client/cas_test.go
@@ -862,6 +862,42 @@ func TestDownloadActionOutputs(t *testing.T) {
 	}
 }
 
+func TestDownloadDirectory(t *testing.T) {
+	ctx := context.Background()
+	e, cleanup := fakes.NewTestEnv(t)
+	defer cleanup()
+	fake := e.Server.CAS
+	c := e.Client.GrpcClient
+	cache := filemetadata.NewSingleFlightCache()
+
+	fooDigest := fake.Put([]byte("foo"))
+	dir := &repb.Directory{
+		Files: []*repb.FileNode{
+			{Name: "foo", Digest: fooDigest.ToProto(), IsExecutable: true},
+		},
+	}
+	dirBlob, err := proto.Marshal(dir)
+	if err != nil {
+		t.Fatalf("failed marshalling Tree: %s", err)
+	}
+	fake.Put(dirBlob)
+
+	d := digest.TestNewFromMessage(dir)
+	execRoot := t.TempDir()
+	err = c.DownloadDirectory(ctx, d, execRoot, cache)
+	if err != nil {
+		t.Errorf("error in DownloadActionOutputs: %s", err)
+	}
+
+	b, err := ioutil.ReadFile(filepath.Join(execRoot, "foo"))
+	if err != nil {
+		t.Fatalf("failed to read foo: %s", err)
+	}
+	if want, got := []byte("foo"), b; !bytes.Equal(want, got) {
+		t.Errorf("want %s, got %s", want, got)
+	}
+}
+
 func TestDownloadActionOutputsBatching(t *testing.T) {
 	ctx := context.Background()
 	e, cleanup := fakes.NewTestEnv(t)


### PR DESCRIPTION
I'd like to re-use most of sdks' [DownloadActionOutputs](https://github.com/bazelbuild/remote-apis-sdks/blob/daf8fa09cc33/go/pkg/client/cas.go#L585) function in our client.
But we use digest of Directory instead of Tree, so let me add function to download Directory from digest.
