### PR TITLE
Read lock before looping through scStates in regeneratePicker()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/gonum/lapack v0.0.0-20181123203213-e4cdc5a0bff9 // indirect
 	github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9 // indirect
 	github.com/google/go-cmp v0.5.1
-	github.com/google/uuid v1.1.2 // indirect
+	github.com/google/uuid v1.1.2
 	github.com/googleapis/gax-go v2.0.2+incompatible // indirect
 	github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 // indirect
 	github.com/jung-kurt/gofpdf v1.13.0 // indirect

--- a/go/pkg/balancer/BUILD.bazel
+++ b/go/pkg/balancer/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -16,6 +16,17 @@ go_library(
         "@org_golang_google_grpc//balancer:go_default_library",
         "@org_golang_google_grpc//connectivity:go_default_library",
         "@org_golang_google_grpc//grpclog:go_default_library",
+        "@org_golang_google_grpc//resolver:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["gcp_balancer_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "@com_github_google_uuid//:go_default_library",
+        "@org_golang_google_grpc//balancer:go_default_library",
         "@org_golang_google_grpc//resolver:go_default_library",
     ],
 )

--- a/go/pkg/balancer/gcp_balancer_test.go
+++ b/go/pkg/balancer/gcp_balancer_test.go
@@ -1,0 +1,85 @@
+package balancer
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	grpcbalancer "google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/resolver"
+)
+
+func TestGCPBalancer_UpdatingConnectionStateIsMutuallyExclusive(t *testing.T) {
+	builder := newBuilder()
+	var subconns []*fakeSubConn
+	for i := 0; i < MinConnections; i++ {
+		subconns = append(subconns, &fakeSubConn{id: uuid.New().String()})
+	}
+
+	cc := fakeClientConn{subconns: subconns}
+	balancer := builder.Build(cc, grpcbalancer.BuildOptions{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Invoke both UpdateClientConnState() and UpdatesubConnState() simultaneously
+	// and make sure that it doesn't result in a race condition. The test would fail
+	// if there's a race condition.
+	go func() {
+		balancer.UpdateClientConnState(grpcbalancer.ClientConnState{})
+		wg.Done()
+	}()
+	go func() {
+		for i := 0; i < MinConnections; i++ {
+			// Sending a connectivity.Ready state will actually trigger regenerating the picker
+			// which is where we expect the race condition to occur.
+			balancer.UpdateSubConnState(subconns[i], grpcbalancer.SubConnState{ConnectivityState: connectivity.Ready})
+		}
+		wg.Done()
+	}()
+	wg.Wait()
+}
+
+type fakeClientConn struct {
+	subconns []*fakeSubConn
+}
+
+var (
+	// Note: These cannot be moved to fakeClientConn since gRPC Builder() interface
+	// does not accept a pointer to fakeClientConn and so the mutex will be copied if
+	// passed by value.
+	// https://godoc.org/google.golang.org/grpc/balancer#Builder
+	idx int
+	mu  sync.Mutex
+)
+
+func (f fakeClientConn) NewSubConn([]resolver.Address, grpcbalancer.NewSubConnOptions) (grpcbalancer.SubConn, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	idx++
+	idx = idx % MinConnections
+	return f.subconns[idx], nil
+}
+
+func (f fakeClientConn) RemoveSubConn(grpcbalancer.SubConn) {}
+
+func (f fakeClientConn) UpdateState(grpcbalancer.State) {}
+
+func (f fakeClientConn) ResolveNow(resolver.ResolveNowOptions) {}
+
+func (f fakeClientConn) Target() string {
+	return ""
+}
+
+type fakeSubConn struct {
+	id string
+}
+
+func (fakeSubConn) UpdateAddresses([]resolver.Address) {}
+
+func (fakeSubConn) Connect() {
+	// Sleep to simulate connecting to an actual server.
+	time.Sleep(100 * time.Millisecond)
+}


### PR DESCRIPTION
Not read locking this results in a race condition in writing / reading
to balancer.scStates map variable.

Test: Ran
bazelisk test --features race //go/pkg/balancer/... --test_output=streamed --test_timeout=10
and it fails without the fix to regeneratePicker().