### PR TITLE
Produce chunks for individual dir protos as well

### DIFF
--- a/go/pkg/tree/tree.go
+++ b/go/pkg/tree/tree.go
@@ -397,6 +397,13 @@ func ComputeOutputsToUpload(execRoot string, paths []string, chunkSize int, cach
 			outs[ch.Digest()] = ch
 		}
 		resPb.OutputDirectories = append(resPb.OutputDirectories, &repb.OutputDirectory{Path: normPath, TreeDigest: ch.Digest().ToProto()})
+		// Upload the child directories individually as well
+		chRoot, _ := chunker.NewFromProto(treePb.Root, chunkSize)
+		outs[chRoot.Digest()] = chRoot
+		for _, child := range treePb.Children {
+			chChild, _ := chunker.NewFromProto(child, chunkSize)
+			outs[chChild.Digest()] = chChild
+		}
 	}
 	return outs, resPb, nil
 }

--- a/go/pkg/tree/tree_test.go
+++ b/go/pkg/tree/tree_test.go
@@ -1220,7 +1220,7 @@ func TestComputeOutputsToUploadDirectories(t *testing.T) {
 				{path: "a/b/fooDir/dir1/foo", fileContents: fooBlob, isExecutable: true},
 				{path: "a/b/fooDir/dir2/foo", fileContents: fooBlob, isExecutable: true},
 			},
-			wantBlobs: [][]byte{fooBlob},
+			wantBlobs: [][]byte{fooBlob, fooDirBlob},
 			wantTreeRoot: &repb.Directory{Directories: []*repb.DirectoryNode{
 				{Name: "dir1", Digest: fooDirDgPb},
 				{Name: "dir2", Digest: fooDirDgPb},


### PR DESCRIPTION
This is useful for some things - for example we've found Buildbarn's browser to be very helpful, but it requires the individual directory protos in an output to be uploaded in order to browse them, and the client doesn't have access to the Tree any more to construct this themselves.