### PR TITLE
Optimise out uploading the empty blob in a couple of places

### DIFF
--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -601,6 +601,9 @@ func (c *Client) ResourceNameWrite(hash string, sizeBytes int64) string {
 // GetDirectoryTree returns the entire directory tree rooted at the given digest (which must target
 // a Directory stored in the CAS).
 func (c *Client) GetDirectoryTree(ctx context.Context, d *repb.Digest) (result []*repb.Directory, err error) {
+	if d.SizeBytes == 0 && d.Hash == digest.Empty.Hash {
+		return nil, nil
+	}
 	pageTok := ""
 	result = []*repb.Directory{}
 	closure := func(ctx context.Context) error {


### PR DESCRIPTION
Per https://github.com/bazelbuild/remote-apis/pull/131 there is no longer any requirement to upload the empty blob since the server must provide it. This optimises it out in a couple of places to make callers' life a bit easier.