### PR TITLE
Customizing RPC timeouts per RPC via flags.

### DIFF
--- a/go/pkg/balancer/BUILD.bazel
+++ b/go/pkg/balancer/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     deps = [
         "@com_github_google_uuid//:go_default_library",
         "@org_golang_google_grpc//balancer:go_default_library",
+        "@org_golang_google_grpc//connectivity:go_default_library",
         "@org_golang_google_grpc//resolver:go_default_library",
     ],
 )

--- a/go/pkg/client/batch_retries_test.go
+++ b/go/pkg/client/batch_retries_test.go
@@ -23,6 +23,8 @@ import (
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 )
 
+var timeout100ms = client.RPCTimeouts(map[string]time.Duration{"default": 100 * time.Millisecond})
+
 type flakyBatchServer struct {
 	numErrors      int // A counter of errors the server has returned thus far.
 	updateRequests []*repb.BatchUpdateBlobsRequest
@@ -338,7 +340,7 @@ func TestBatchReadBlobsDeadlineExceededRetries(t *testing.T) {
 	client, err := client.NewClient(ctx, instance, client.DialParams{
 		Service:    listener.Addr().String(),
 		NoSecurity: true,
-	}, retrier, client.RPCTimeout(100*time.Millisecond))
+	}, retrier, timeout100ms)
 	if err != nil {
 		t.Fatalf("Error connecting to server: %v", err)
 	}
@@ -376,7 +378,7 @@ func TestBatchUpdateBlobsDeadlineExceededRetries(t *testing.T) {
 	client, err := client.NewClient(ctx, instance, client.DialParams{
 		Service:    listener.Addr().String(),
 		NoSecurity: true,
-	}, retrier, client.RPCTimeout(100*time.Millisecond))
+	}, retrier, timeout100ms)
 	if err != nil {
 		t.Fatalf("Error connecting to server: %v", err)
 	}

--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -161,7 +161,7 @@ func (c *Client) BatchWriteBlobs(ctx context.Context, blobs map[digest.Digest][]
 	opts := c.RPCOpts()
 	closure := func() error {
 		var resp *repb.BatchUpdateBlobsResponse
-		err := c.CallWithTimeout(ctx, func(ctx context.Context) (e error) {
+		err := c.CallWithTimeout(ctx, "BatchUpdateBlobs", func(ctx context.Context) (e error) {
 			resp, e = c.cas.BatchUpdateBlobs(ctx, &repb.BatchUpdateBlobsRequest{
 				InstanceName: c.InstanceName,
 				Requests:     reqs,
@@ -235,7 +235,7 @@ func (c *Client) BatchDownloadBlobs(ctx context.Context, dgs []digest.Digest) (m
 	opts := c.RPCOpts()
 	closure := func() error {
 		var resp *repb.BatchReadBlobsResponse
-		err := c.CallWithTimeout(ctx, func(ctx context.Context) (e error) {
+		err := c.CallWithTimeout(ctx, "BatchReadBlobs", func(ctx context.Context) (e error) {
 			resp, e = c.cas.BatchReadBlobs(ctx, req, opts...)
 			return e
 		})

--- a/go/pkg/client/retries_test.go
+++ b/go/pkg/client/retries_test.go
@@ -216,7 +216,7 @@ func setup(t *testing.T) *flakyFixture {
 	f.client, err = client.NewClient(f.ctx, instance, client.DialParams{
 		Service:    f.listener.Addr().String(),
 		NoSecurity: true,
-	}, client.ChunkMaxSize(2), client.RPCTimeout(time.Second))
+	}, client.ChunkMaxSize(2), client.RPCTimeouts(map[string]time.Duration{"default": time.Second}))
 	if err != nil {
 		t.Fatalf("Error connecting to server: %v", err)
 	}

--- a/go/pkg/flags/BUILD.bazel
+++ b/go/pkg/flags/BUILD.bazel
@@ -8,5 +8,6 @@ go_library(
     deps = [
         "//go/pkg/balancer:go_default_library",
         "//go/pkg/client:go_default_library",
+        "//go/pkg/moreflag:go_default_library",
     ],
 )


### PR DESCRIPTION
Also tightening up the existing default values.