### PR TITLE
Deduping concurrent write requests.

### DIFF
--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -25,6 +25,47 @@ import (
 	log "github.com/golang/glog"
 )
 
+func (c *Client) afterUpload(batch []digest.Digest, err error) {
+	for _, dg := range batch {
+		l, loaded := c.casUploadLocks.Load(dg)
+		lock, ok := l.(*sync.RWMutex)
+		if !ok {
+			log.Errorf("Unexpected type found in locks map")
+		}
+		if !loaded {
+			log.Errorf("Precondition failed: upload lock not found on %v.", dg)
+		}
+		if err != nil {
+			c.casUploadErrors.Store(dg, err)
+		}
+		lock.Unlock()
+	}
+}
+
+// Reset clears the Client state (e.g. makes it forget which blobs were
+// previously uploaded, or in the process of being uploaded).
+// This function is not thread safe, and should only be used outside of
+// ongoing client operations!
+func (c *Client) Reset() {
+	c.casUploadLocks = sync.Map{}
+	c.casUploadErrors = sync.Map{}
+}
+
+func (c *Client) getMissingPresent(ctx context.Context, dgs []digest.Digest) (missing []digest.Digest, present []digest.Digest, err error) {
+	dgMap := make(map[digest.Digest]bool)
+	for _, d := range dgs {
+		dgMap[d] = true
+	}
+	missing, err = c.MissingBlobs(ctx, dgs)
+	for _, d := range missing {
+		delete(dgMap, d)
+	}
+	for d := range dgMap {
+		present = append(present, d)
+	}
+	return missing, present, err
+}
+
 // UploadIfMissing stores a number of uploadable items.
 // It first queries the CAS to see which items are missing and only uploads those that are.
 // Returns a slice of the missing digests.
@@ -46,11 +87,38 @@ func (c *Client) UploadIfMissing(ctx context.Context, data ...*chunker.Chunker) 
 		}
 	}
 
-	missing, err := c.MissingBlobs(ctx, dgs)
+	// Separate the digests into two groups: new and previous.
+	// Previous have either been uploaded earlier, or are in the process of being
+	// uploaded by another thread.
+	var newUploads []digest.Digest
+	var previousUploads []digest.Digest
+	locks := make(map[digest.Digest]*sync.RWMutex)
+	for _, d := range dgs {
+		mu := &sync.RWMutex{}
+		mu.Lock()
+
+		l, loaded := c.casUploadLocks.LoadOrStore(d, mu)
+		lock, ok := l.(*sync.RWMutex)
+		if !ok {
+			return nil, fmt.Errorf("unexpected type found in lock map")
+		}
+		locks[d] = lock
+		if loaded {
+			previousUploads = append(previousUploads, d)
+		} else {
+			// We will unlock as soon as we finish uploading the digest.
+			newUploads = append(newUploads, d)
+		}
+	}
+
+	missing, present, err := c.getMissingPresent(ctx, newUploads)
 	if err != nil {
 		return nil, err
 	}
-	log.V(2).Infof("%d items to store", len(missing))
+	log.V(2).Infof("%d new items to store", len(missing))
+	for _, d := range present {
+		locks[d].Unlock()
+	}
 	var batches [][]digest.Digest
 	if c.useBatchOps {
 		batches = c.makeBatches(missing)
@@ -66,8 +134,9 @@ func (c *Client) UploadIfMissing(ctx context.Context, data ...*chunker.Chunker) 
 	for i, batch := range batches {
 		i, batch := i, batch   // https://golang.org/doc/faq#closures_and_goroutines
 		c.casUploaders <- true // Reserve an uploader thread.
-		eg.Go(func() error {
+		eg.Go(func() (err error) {
 			defer func() { <-c.casUploaders }()
+			defer func() { c.afterUpload(batch, err) }()
 			if i%logInterval == 0 {
 				log.V(2).Infof("%d batches left to store", len(batches)-i)
 			}
@@ -99,9 +168,27 @@ func (c *Client) UploadIfMissing(ctx context.Context, data ...*chunker.Chunker) 
 		})
 	}
 
-	log.V(2).Info("Waiting for remaining jobs")
+	log.V(2).Info("Waiting for remaining new uploads")
 	err = eg.Wait()
-	log.V(2).Info("Done")
+	log.V(2).Info("Done new uploads.")
+	log.V(2).Infof("Waiting for remaining %v previous uploads", len(previousUploads))
+	for _, dg := range previousUploads {
+		// Wait on all uploads, but return the first error.
+		mu := locks[dg]
+		mu.RLock()
+		defer mu.RUnlock()
+		if err != nil {
+			continue
+		}
+		if v, _ := c.casUploadErrors.Load(dg); v != nil {
+			e, ok := v.(error)
+			if !ok {
+				err = fmt.Errorf("unexpected type found in error map")
+			}
+			err = e
+		}
+	}
+	log.V(2).Info("Done waiting on previous uploads.")
 
 	return missing, err
 }

--- a/go/pkg/client/cas_test.go
+++ b/go/pkg/client/cas_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/chunker"
@@ -375,6 +376,88 @@ func TestMissingBlobs(t *testing.T) {
 	}
 }
 
+func TestUploadConcurrent(t *testing.T) {
+	ctx := context.Background()
+	e, cleanup := fakes.NewTestEnv(t)
+	defer cleanup()
+	fake := e.Server.CAS
+	c := e.Client.GrpcClient
+	client.CASConcurrency(defaultCASConcurrency).Apply(c)
+
+	blobs := make([][]byte, 1000)
+	for i := range blobs {
+		blobs[i] = []byte(fmt.Sprint(i))
+	}
+	tests := []struct {
+		name string
+		// Whether to use batching.
+		batching client.UseBatchOps
+		// The batch size.
+		maxBatchDigests client.MaxBatchDigests
+		// The CAS concurrency for uploading the blobs.
+		concurrency client.CASConcurrency
+	}{
+		{
+			name:        "no_batching_low_conc",
+			batching:    client.UseBatchOps(false),
+			concurrency: client.CASConcurrency(3),
+		},
+		{
+			name:        "no_batching_high_conc",
+			batching:    client.UseBatchOps(false),
+			concurrency: client.CASConcurrency(100),
+		},
+		{
+			name:            "batching_low_conc",
+			batching:        client.UseBatchOps(true),
+			maxBatchDigests: client.MaxBatchDigests(9),
+			concurrency:     client.CASConcurrency(3),
+		},
+		{
+			name:            "batching_high_conc",
+			batching:        client.UseBatchOps(true),
+			maxBatchDigests: client.MaxBatchDigests(9),
+			concurrency:     client.CASConcurrency(100),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fake.Clear()
+			c.Reset()
+			for _, opt := range []client.Opt{tc.batching, tc.maxBatchDigests, tc.concurrency} {
+				opt.Apply(c)
+			}
+
+			var wg sync.WaitGroup
+			for i := 0; i < 100; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					var input []*chunker.Chunker
+					for _, blob := range blobs {
+						input = append(input, chunker.NewFromBlob(blob, 10))
+					}
+					_, err := c.UploadIfMissing(ctx, input...)
+					if err != nil {
+						t.Errorf("c.UploadIfMissing(ctx, input) gave error %v, expected nil", err)
+					}
+				}()
+			}
+			wg.Wait()
+			// Verify everything was written exactly once.
+			for i, blob := range blobs {
+				dg := digest.NewFromBlob(blob)
+				if fake.BlobWrites(dg) != 1 {
+					t.Errorf("wanted 1 write for blob %v: %v, got %v", i, dg, fake.BlobWrites(dg))
+				}
+				if fake.BlobMissingReqs(dg) != 1 {
+					t.Errorf("wanted 1 missing request for blob %v: %v, got %v", i, dg, fake.BlobMissingReqs(dg))
+				}
+			}
+		})
+	}
+}
+
 func TestUpload(t *testing.T) {
 	ctx := context.Background()
 	e, cleanup := fakes.NewTestEnv(t)
@@ -444,6 +527,8 @@ func TestUpload(t *testing.T) {
 			for _, tc := range tests {
 				t.Run(tc.name, func(t *testing.T) {
 					fake.Clear()
+					c.Reset()
+
 					if tc.concurrency > 0 {
 						tc.concurrency.Apply(c)
 					}
@@ -552,6 +637,7 @@ func TestWriteBlobsBatching(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			fake.Clear()
+			c.Reset()
 			blobs := make(map[digest.Digest][]byte)
 			for i, sz := range tc.sizes {
 				blob := make([]byte, int(sz))

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/user"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/actas"
@@ -73,12 +74,14 @@ type Client struct {
 	// ExecutableMode is mode used to create executable files.
 	ExecutableMode os.FileMode
 	// RegularMode is mode used to create non-executable files.
-	RegularMode    os.FileMode
-	useBatchOps    UseBatchOps
-	casUploaders   chan bool
-	casDownloaders chan bool
-	rpcTimeouts    RPCTimeouts
-	creds          credentials.PerRPCCredentials
+	RegularMode     os.FileMode
+	useBatchOps     UseBatchOps
+	casUploaders    chan bool
+	casDownloaders  chan bool
+	casUploadLocks  sync.Map
+	casUploadErrors sync.Map
+	rpcTimeouts     RPCTimeouts
+	creds           credentials.PerRPCCredentials
 }
 
 const (
@@ -364,6 +367,8 @@ func NewClient(ctx context.Context, instanceName string, params DialParams, opts
 		useBatchOps:     true,
 		casUploaders:    make(chan bool, DefaultCASConcurrency),
 		casDownloaders:  make(chan bool, DefaultCASConcurrency),
+		casUploadLocks:  sync.Map{},
+		casUploadErrors: sync.Map{},
 		Retrier:         RetryTransient(),
 	}
 	for _, o := range opts {


### PR DESCRIPTION
Fixes #43 and #44, because this also doesn't query GetMissingBlobs for
previously uploaded blobs.