### PR TITLE
Reading server capabilities at client startup.

### DIFF
--- a/go/pkg/client/BUILD.bazel
+++ b/go/pkg/client/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "bytestream.go",
+        "capabilities.go",
         "cas.go",
         "client.go",
         "client_context.go",

--- a/go/pkg/client/batch_retries_test.go
+++ b/go/pkg/client/batch_retries_test.go
@@ -136,7 +136,7 @@ func TestBatchUpdateBlobsIndividualRequestRetries(t *testing.T) {
 	client, err := client.NewClient(ctx, instance, client.DialParams{
 		Service:    listener.Addr().String(),
 		NoSecurity: true,
-	})
+	}, client.StartupCapabilities(false))
 	if err != nil {
 		t.Fatalf("Error connecting to server: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestBatchReadBlobsIndividualRequestRetries(t *testing.T) {
 	client, err := client.NewClient(ctx, instance, client.DialParams{
 		Service:    listener.Addr().String(),
 		NoSecurity: true,
-	})
+	}, client.StartupCapabilities(false))
 	if err != nil {
 		t.Fatalf("Error connecting to server: %v", err)
 	}
@@ -340,7 +340,7 @@ func TestBatchReadBlobsDeadlineExceededRetries(t *testing.T) {
 	client, err := client.NewClient(ctx, instance, client.DialParams{
 		Service:    listener.Addr().String(),
 		NoSecurity: true,
-	}, retrier, timeout100ms)
+	}, retrier, timeout100ms, client.StartupCapabilities(false))
 	if err != nil {
 		t.Fatalf("Error connecting to server: %v", err)
 	}
@@ -378,7 +378,7 @@ func TestBatchUpdateBlobsDeadlineExceededRetries(t *testing.T) {
 	client, err := client.NewClient(ctx, instance, client.DialParams{
 		Service:    listener.Addr().String(),
 		NoSecurity: true,
-	}, retrier, timeout100ms)
+	}, retrier, timeout100ms, client.StartupCapabilities(false))
 	if err != nil {
 		t.Fatalf("Error connecting to server: %v", err)
 	}

--- a/go/pkg/client/capabilities.go
+++ b/go/pkg/client/capabilities.go
@@ -1,0 +1,74 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
+
+	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+)
+
+// CheckCapabilities verifies that this client can work with the remote server
+// in terms of API version and digest function. It sets some client parameters
+// according to remote server preferences, like MaxBatchSize.
+func (c *Client) CheckCapabilities(ctx context.Context) (err error) {
+	// Only query the server once. There is no need for a lock, because we will
+	// usually make the call on startup.
+	if c.serverCaps == nil {
+		if c.serverCaps, err = c.GetCapabilities(ctx); err != nil {
+			return err
+		}
+	}
+	dgFn := digest.GetDigestFunction()
+	if c.serverCaps.ExecutionCapabilities != nil {
+		serverFn := c.serverCaps.ExecutionCapabilities.DigestFunction
+		if serverFn == repb.DigestFunction_UNKNOWN {
+			return fmt.Errorf("Server returned UNKNOWN digest function")
+		}
+		if serverFn != dgFn {
+			return fmt.Errorf("Digest function mismatch: server requires %v, client uses %v", serverFn, dgFn)
+		}
+	}
+	if c.serverCaps.CacheCapabilities != nil {
+		cc := c.serverCaps.CacheCapabilities
+		found := false
+		for _, serverFn := range cc.DigestFunction {
+			if serverFn == dgFn {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("Digest function mismatch: server requires one of %v, client uses %v", cc.DigestFunction, dgFn)
+		}
+		c.MaxBatchSize = MaxBatchSize(cc.MaxBatchTotalSizeBytes)
+	}
+	return nil
+}
+
+// GetCapabilities returns the capabilities for the targeted servers.
+// If the CAS URL was set differently to the execution server then the CacheCapabilities will
+// be determined from that; ExecutionCapabilities will always come from the main URL.
+func (c *Client) GetCapabilities(ctx context.Context) (res *repb.ServerCapabilities, err error) {
+	return c.GetCapabilitiesForInstance(ctx, c.InstanceName)
+}
+
+// GetCapabilitiesForInstance returns the capabilities for the targeted servers.
+// If the CAS URL was set differently to the execution server then the CacheCapabilities will
+// be determined from that; ExecutionCapabilities will always come from the main URL.
+func (c *Client) GetCapabilitiesForInstance(ctx context.Context, instance string) (res *repb.ServerCapabilities, err error) {
+	req := &repb.GetCapabilitiesRequest{InstanceName: instance}
+	caps, err := c.GetBackendCapabilities(ctx, c.Connection, req)
+	if err != nil {
+		return nil, err
+	}
+	if c.CASConnection != c.Connection {
+		casCaps, err := c.GetBackendCapabilities(ctx, c.CASConnection, req)
+		if err != nil {
+			return nil, err
+		}
+		caps.CacheCapabilities = casCaps.CacheCapabilities
+	}
+	return caps, nil
+}

--- a/go/pkg/client/cas_test.go
+++ b/go/pkg/client/cas_test.go
@@ -64,7 +64,7 @@ func TestSplitEndpoints(t *testing.T) {
 		Service:    l1.Addr().String(),
 		CASService: l2.Addr().String(),
 		NoSecurity: true,
-	})
+	}, client.StartupCapabilities(false))
 	if err != nil {
 		t.Fatalf("Error connecting to server: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestRead(t *testing.T) {
 	c, err := client.NewClient(ctx, instance, client.DialParams{
 		Service:    listener.Addr().String(),
 		NoSecurity: true,
-	})
+	}, client.StartupCapabilities(false))
 	if err != nil {
 		t.Fatalf("Error connecting to server: %v", err)
 	}
@@ -260,7 +260,7 @@ func TestWrite(t *testing.T) {
 	c, err := client.NewClient(ctx, instance, client.DialParams{
 		Service:    listener.Addr().String(),
 		NoSecurity: true,
-	}, client.ChunkMaxSize(20)) // Use small write chunk size for tests.
+	}, client.StartupCapabilities(false), client.ChunkMaxSize(20)) // Use small write chunk size for tests.
 	if err != nil {
 		t.Fatalf("Error connecting to server: %v", err)
 	}

--- a/go/pkg/client/retries_test.go
+++ b/go/pkg/client/retries_test.go
@@ -216,7 +216,7 @@ func setup(t *testing.T) *flakyFixture {
 	f.client, err = client.NewClient(f.ctx, instance, client.DialParams{
 		Service:    f.listener.Addr().String(),
 		NoSecurity: true,
-	}, client.ChunkMaxSize(2), client.RPCTimeouts(map[string]time.Duration{"default": time.Second}))
+	}, client.StartupCapabilities(false), client.ChunkMaxSize(2), client.RPCTimeouts(map[string]time.Duration{"default": time.Second}))
 	if err != nil {
 		t.Fatalf("Error connecting to server: %v", err)
 	}

--- a/go/pkg/fakes/exec.go
+++ b/go/pkg/fakes/exec.go
@@ -1,9 +1,11 @@
 package fakes
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/client"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
@@ -104,6 +106,26 @@ func (s *Exec) fakeExecution(dg digest.Digest, skipCacheLookup bool) (*oppb.Oper
 		Done:   true,
 		Result: &oppb.Operation_Response{Response: any},
 	}, nil
+}
+
+// GetCapabilities returns the fake capabilities.
+func (c *Exec) GetCapabilities(ctx context.Context, req *repb.GetCapabilitiesRequest) (res *repb.ServerCapabilities, err error) {
+	dgFn := digest.GetDigestFunction()
+	res = &repb.ServerCapabilities{
+		ExecutionCapabilities: &repb.ExecutionCapabilities{
+			DigestFunction: dgFn,
+			ExecEnabled:    true,
+		},
+		CacheCapabilities: &repb.CacheCapabilities{
+			DigestFunction: []repb.DigestFunction_Value{dgFn},
+			ActionCacheUpdateCapabilities: &repb.ActionCacheUpdateCapabilities{
+				UpdateEnabled: true,
+			},
+			MaxBatchTotalSizeBytes:      client.DefaultMaxBatchSize,
+			SymlinkAbsolutePathStrategy: repb.SymlinkAbsolutePathStrategy_DISALLOWED,
+		},
+	}
+	return res, nil
 }
 
 // Execute returns the saved result ActionResult, or a Status. It also puts it in the action cache

--- a/go/pkg/fakes/server.go
+++ b/go/pkg/fakes/server.go
@@ -52,6 +52,7 @@ func NewServer(t *testing.T) (s *Server, err error) {
 	bsgrpc.RegisterByteStreamServer(s.srv, s.CAS)
 	regrpc.RegisterContentAddressableStorageServer(s.srv, s.CAS)
 	regrpc.RegisterActionCacheServer(s.srv, s.ActionCache)
+	regrpc.RegisterCapabilitiesServer(s.srv, s.Exec)
 	regrpc.RegisterExecutionServer(s.srv, s.Exec)
 	go s.srv.Serve(s.listener)
 	return s, nil


### PR DESCRIPTION
For now, only check digest function compatibility and set MaxBatchSize
accordingly. Fixes #99.
Still TODO: check API version compatibility, cache and execution
priorities once we implement those.