### PR TITLE
Add more TLS config flags, and support remote caching mode

### DIFF
--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -3,6 +3,7 @@ package client
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"net/http"
 	"os"
@@ -251,6 +252,12 @@ type DialParams struct {
 	// This is not the same as NoSecurity, as transport credentials will still be set.
 	TransportCredsOnly bool
 
+	// CertPool supplies root certificates for the TLS session.
+	CertPool *x509.CertPool
+
+	// TLSServerName overrides the server name sent in TLS, if set to a non-empty string.
+	TLSServerName string
+
 	// DialOpts defines the set of gRPC DialOptions to apply, in addition to any used internally.
 	DialOpts []grpc.DialOption
 
@@ -316,7 +323,7 @@ func Dial(ctx context.Context, endpoint string, params DialParams) (*grpc.Client
 			opts = append(opts, grpc.WithPerRPCCredentials(rpcCreds))
 		}
 
-		tlsCreds := credentials.NewClientTLSFromCert(nil, "")
+		tlsCreds := credentials.NewClientTLSFromCert(params.CertPool, params.TLSServerName)
 		opts = append(opts, grpc.WithTransportCredentials(tlsCreds))
 	}
 	grpcInt := createGRPCInterceptor(params)

--- a/go/pkg/flags/flags.go
+++ b/go/pkg/flags/flags.go
@@ -3,10 +3,7 @@ package flags
 
 import (
 	"context"
-	"crypto/x509"
 	"flag"
-	"fmt"
-	"io/ioutil"
 	"time"
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/balancer"
@@ -85,16 +82,6 @@ func NewClientFromFlags(ctx context.Context, opts ...client.Opt) (*client.Client
 		}
 		opts = append(opts, client.RPCTimeouts(timeouts))
 	}
-	certPool := x509.NewCertPool()
-	if *TLSCACert != "" {
-		ca, err := ioutil.ReadFile(*TLSCACert)
-		if err != nil {
-			return nil, err
-		}
-		if ok := certPool.AppendCertsFromPEM(ca); !ok {
-			return nil, fmt.Errorf("failed to load TLS CA certificates from %s", *TLSCACert)
-		}
-	}
 	return client.NewClient(ctx, *Instance, client.DialParams{
 		Service:               *Service,
 		CASService:            *CASService,
@@ -103,7 +90,7 @@ func NewClientFromFlags(ctx context.Context, opts ...client.Opt) (*client.Client
 		UseComputeEngine:      *UseGCECredentials,
 		TransportCredsOnly:    !*UseRPCCredentials,
 		TLSServerName:         *TLSServerName,
-		CertPool:              certPool,
+		TLSCACertFile:         *TLSCACert,
 		MaxConcurrentRequests: uint32(*MaxConcurrentRequests),
 		MaxConcurrentStreams:  uint32(*MaxConcurrentStreams),
 	}, opts...)

--- a/go/pkg/tool/tool_test.go
+++ b/go/pkg/tool/tool_test.go
@@ -72,21 +72,31 @@ func TestTool_ShowAction(t *testing.T) {
 		t.Fatalf("ShowAction(%v) failed: %v", acDg.String(), err)
 	}
 	want := `Command
-========
+=======
 Command Digest: 76a608e419da9ed3673f59b8b903f21dbf7cc3178281029151a090cac02d9e4d/15
 	tool
+
+Platform
+========
 
 Inputs
 ======
 [Root directory digest: e23e10be0d14b5b2b1b7af32de78dea554a74df5bb22b31ae6c49583c1a8aa0e/75]
 a/b/input.txt: [File digest: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/0]
 
-Output Files:
-=============
+------------------------------------------------------------------------
+Action Result
+
+Exit code: 0
+stdout digest: 63d42d26156fcc761e57da4128e9881d5bdf3bf933f0f6e9c93d6e26b9b90ae7/6
+stderr digest: 7e6b710b765404cccbad9eedcff7615fc37b269d6db12cd81a58be541d93083c/6
+
+Output Files
+============
 a/b/out, digest: e0ee8bb50685e05fa0f47ed04203ae953fdfd055f5bd2892ea186504254f8c3a/6
 
-Output Files From Directories:
-=================
+Output Files From Directories
+=============================
 `
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("ShowAction(%v) returned diff (-want +got): %v\n\ngot: %v\n\nwant: %v\n", acDg.String(), diff, got, want)


### PR DESCRIPTION
These changes are sufficient to persuade remotetool to interact with
my remote caching setup. Notably:

* TLS wiring added
* In cache-only mode, bazel does not upload input roots, so tolerate errors
* Show actions without results, to handle actions which failed
* Render a few interesting fields that were previously skipped