### PR TITLE
Fixing streamed RPC timeouts.

### DIFF
--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -598,14 +598,12 @@ func (c *Client) ResourceNameWrite(hash string, sizeBytes int64) string {
 func (c *Client) GetDirectoryTree(ctx context.Context, d *repb.Digest) (result []*repb.Directory, err error) {
 	pageTok := ""
 	result = []*repb.Directory{}
-	opts := c.RPCOpts()
 	closure := func() error {
-		// Use the low-level GetTree method to avoid retrying twice.
-		stream, err := c.cas.GetTree(ctx, &repb.GetTreeRequest{
+		stream, err := c.GetTree(ctx, &repb.GetTreeRequest{
 			InstanceName: c.InstanceName,
 			RootDigest:   d,
 			PageToken:    pageTok,
-		}, opts...)
+		})
 		if err != nil {
 			return err
 		}

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -435,8 +435,11 @@ var DefaultRPCTimeouts = map[string]time.Duration{
 	"BatchUpdateBlobs": time.Minute,
 	"BatchReadBlobs":   time.Minute,
 	"GetTree":          time.Minute,
-	"Execute":          0,
-	"WaitExecution":    0,
+	// Note: due to an implementation detail, WaitExecution will use the same
+	// per-RPC timeout as Execute. It is extremely ill-advised to set the Execute
+	// timeout at above 0; most users should use the Action Timeout instead.
+	"Execute":       0,
+	"WaitExecution": 0,
 }
 
 // RPCOpts returns the default RPC options that should be used for calls made with this client.

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -550,33 +550,19 @@ func (c *Client) UpdateActionResult(ctx context.Context, req *repb.UpdateActionR
 }
 
 // Read wraps the underlying call with specific client options.
+// The wrapper is here for completeness to provide access to the low-level
+// RPCs. Prefer using higher-level functions such as ReadBlob(ToFile) instead,
+// as they include retries/timeouts handling.
 func (c *Client) Read(ctx context.Context, req *bspb.ReadRequest) (res bsgrpc.ByteStream_ReadClient, err error) {
-	opts := c.RPCOpts()
-	err = c.Retrier.Do(ctx, func() (e error) {
-		return c.CallWithTimeout(ctx, "Read", func(ctx context.Context) (e error) {
-			res, e = c.byteStream.Read(ctx, req, opts...)
-			return e
-		})
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res, nil
+	return c.byteStream.Read(ctx, req, c.RPCOpts()...)
 }
 
 // Write wraps the underlying call with specific client options.
+// The wrapper is here for completeness to provide access to the low-level
+// RPCs. Prefer using higher-level functions such as WriteBlob(s) instead,
+// as they include retries/timeouts handling.
 func (c *Client) Write(ctx context.Context) (res bsgrpc.ByteStream_WriteClient, err error) {
-	opts := c.RPCOpts()
-	err = c.Retrier.Do(ctx, func() (e error) {
-		return c.CallWithTimeout(ctx, "Write", func(ctx context.Context) (e error) {
-			res, e = c.byteStream.Write(ctx, opts...)
-			return e
-		})
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res, nil
+	return c.byteStream.Write(ctx, c.RPCOpts()...)
 }
 
 // QueryWriteStatus wraps the underlying call with specific client options.
@@ -643,48 +629,27 @@ func (c *Client) BatchReadBlobs(ctx context.Context, req *repb.BatchReadBlobsReq
 }
 
 // GetTree wraps the underlying call with specific client options.
+// The wrapper is here for completeness to provide access to the low-level
+// RPCs. Prefer using higher-level GetDirectoryTree instead,
+// as it includes retries/timeouts handling.
 func (c *Client) GetTree(ctx context.Context, req *repb.GetTreeRequest) (res regrpc.ContentAddressableStorage_GetTreeClient, err error) {
-	opts := c.RPCOpts()
-	err = c.Retrier.Do(ctx, func() (e error) {
-		return c.CallWithTimeout(ctx, "GetTree", func(ctx context.Context) (e error) {
-			res, e = c.cas.GetTree(ctx, req, opts...)
-			return e
-		})
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res, nil
+	return c.cas.GetTree(ctx, req, c.RPCOpts()...)
 }
 
 // Execute wraps the underlying call with specific client options.
+// The wrapper is here for completeness to provide access to the low-level
+// RPCs. Prefer using higher-level ExecuteAndWait instead,
+// as it includes retries/timeouts handling.
 func (c *Client) Execute(ctx context.Context, req *repb.ExecuteRequest) (res regrpc.Execution_ExecuteClient, err error) {
-	opts := c.RPCOpts()
-	err = c.Retrier.Do(ctx, func() (e error) {
-		return c.CallWithTimeout(ctx, "Execute", func(ctx context.Context) (e error) {
-			res, e = c.execution.Execute(ctx, req, opts...)
-			return e
-		})
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res, nil
+	return c.execution.Execute(ctx, req, c.RPCOpts()...)
 }
 
 // WaitExecution wraps the underlying call with specific client options.
+// The wrapper is here for completeness to provide access to the low-level
+// RPCs. Prefer using higher-level ExecuteAndWait instead,
+// as it includes retries/timeouts handling.
 func (c *Client) WaitExecution(ctx context.Context, req *repb.WaitExecutionRequest) (res regrpc.Execution_ExecuteClient, err error) {
-	opts := c.RPCOpts()
-	err = c.Retrier.Do(ctx, func() (e error) {
-		return c.CallWithTimeout(ctx, "WaitExecution", func(ctx context.Context) (e error) {
-			res, e = c.execution.WaitExecution(ctx, req, opts...)
-			return e
-		})
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res, nil
+	return c.execution.WaitExecution(ctx, req, c.RPCOpts()...)
 }
 
 // GetBackendCapabilities returns the capabilities for a specific server connection

--- a/go/pkg/client/exec.go
+++ b/go/pkg/client/exec.go
@@ -236,14 +236,12 @@ func (c *Client) ExecuteAndWaitProgress(ctx context.Context, req *repb.ExecuteRe
 	wait := false    // Should we retry by calling WaitExecution instead of Execute?
 	opError := false // Are we propagating an Operation status as an error for the retrier's benefit?
 	lastOp := &oppb.Operation{}
-	opts := c.RPCOpts()
 	closure := func() (e error) {
 		var res regrpc.Execution_ExecuteClient
-		// In both cases, use the lower-level methods to avoid retrying twice.
 		if wait {
-			res, e = c.execution.WaitExecution(ctx, &repb.WaitExecutionRequest{Name: lastOp.Name}, opts...)
+			res, e = c.WaitExecution(ctx, &repb.WaitExecutionRequest{Name: lastOp.Name})
 		} else {
-			res, e = c.execution.Execute(ctx, req, opts...)
+			res, e = c.Execute(ctx, req)
 		}
 		if e != nil {
 			return e

--- a/go/pkg/flags/flags.go
+++ b/go/pkg/flags/flags.go
@@ -52,7 +52,8 @@ var (
 	TLSCACert = flag.String("tls_ca_cert", "", "Load TLS CA certificates from this file")
 	// StartupCapabilities specifies whether to self-configure based on remote server capabilities on startup.
 	StartupCapabilities = flag.Bool("startup_capabilities", true, "Whether to self-configure based on remote server capabilities on startup.")
-	RPCTimeouts         map[string]string
+	// RPCTimeouts stores the per-RPC timeout values.
+	RPCTimeouts map[string]string
 )
 
 func init() {


### PR DESCRIPTION
This will effectively set the timeouts at 1 minute for
Write/Read/GetTree.