### PR TITLE
revive c.RPCOpts in GetTree

### DIFF
--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -517,7 +517,7 @@ func (c *Client) GetDirectoryTree(ctx context.Context, d *repb.Digest) (result [
 			InstanceName: c.InstanceName,
 			RootDigest:   d,
 			PageToken:    pageTok,
-		})
+		}, c.RPCOpts()...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I think this is removed accidentaly in https://github.com/bazelbuild/remote-apis-sdks/commit/0dbc1039e6dad925ee9a461a66bbf1b2f35693f1 .