### PR TITLE
Support symlinks when constructing a Merkle tree.

### DIFF
--- a/go/pkg/client/BUILD.bazel
+++ b/go/pkg/client/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "exec_test.go",
         "retries_test.go",
         "tree_test.go",
+        "tree_whitebox_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -85,7 +85,9 @@ type Client struct {
 	// UtilizeLocality is to specify whether client downloads files utilizing disk access locality.
 	UtilizeLocality UtilizeLocality
 	// UnifiedCASOps specifies whether the client uploads/downloads files in the background
-	UnifiedCASOps       UnifiedCASOps
+	UnifiedCASOps UnifiedCASOps
+	// TreeSymlinkOpts controls how symlinks are handled when constructing a tree.
+	TreeSymlinkOpts     TreeSymlinkOpts
 	serverCaps          *repb.ServerCapabilities
 	useBatchOps         UseBatchOps
 	casConcurrency      int64

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -173,7 +173,9 @@ func (s UnifiedCASOps) Apply(c *Client) {
 }
 
 func (o *TreeSymlinkOpts) Apply(c *Client) {
-	c.TreeSymlinkOpts = *o
+	if o != nil {
+		c.TreeSymlinkOpts = *o
+	}
 }
 
 // MaxBatchDigests is maximum amount of digests to batch in batched operations.

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -87,7 +87,7 @@ type Client struct {
 	// UnifiedCASOps specifies whether the client uploads/downloads files in the background
 	UnifiedCASOps UnifiedCASOps
 	// TreeSymlinkOpts controls how symlinks are handled when constructing a tree.
-	TreeSymlinkOpts     TreeSymlinkOpts
+	TreeSymlinkOpts     *TreeSymlinkOpts
 	serverCaps          *repb.ServerCapabilities
 	useBatchOps         UseBatchOps
 	casConcurrency      int64
@@ -173,9 +173,7 @@ func (s UnifiedCASOps) Apply(c *Client) {
 }
 
 func (o *TreeSymlinkOpts) Apply(c *Client) {
-	if o != nil {
-		c.TreeSymlinkOpts = *o
-	}
+	c.TreeSymlinkOpts = o
 }
 
 // MaxBatchDigests is maximum amount of digests to batch in batched operations.

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -172,6 +172,10 @@ func (s UnifiedCASOps) Apply(c *Client) {
 	c.UnifiedCASOps = s
 }
 
+func (o *TreeSymlinkOpts) Apply(c *Client) {
+	c.TreeSymlinkOpts = *o
+}
+
 // MaxBatchDigests is maximum amount of digests to batch in batched operations.
 type MaxBatchDigests int
 

--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -165,7 +165,7 @@ func loadFiles(execRoot string, excl []*command.InputExclusion, path string, fs 
 		if err != nil {
 			return err
 		}
-		fs[path] = &fileSysNode{
+		fs[normPath] = &fileSysNode{
 			// We cannot directly use meta.Symlink.Target, because it could be
 			// an absolute path. Since the remote worker will map the exec root
 			// to a different directory, we must strip away the local exec root.

--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -89,7 +89,7 @@ func shouldIgnore(inp string, t command.InputType, excl []*command.InputExclusio
 
 // getTargetRelPath returns the part of target that is relative to execRoot,
 // iff target is under execRoot. Otherwise it returns an error.
-func getTargetRelPath(execRoot, symlink, target string) (string, error) {
+func getTargetRelPath(execRoot, target string) (string, error) {
 	if !filepath.IsAbs(target) {
 		target = filepath.Clean(filepath.Join(execRoot, target))
 	}
@@ -111,7 +111,7 @@ func preprocessSymlink(execRoot, symlink string, meta *filemetadata.SymlinkMetad
 		return true, nil
 	}
 
-	if _, err := getTargetRelPath(execRoot, symlink, meta.Target); err != nil {
+	if _, err := getTargetRelPath(execRoot, meta.Target); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -161,7 +161,7 @@ func loadFiles(execRoot string, excl []*command.InputExclusion, path string, fs 
 		}
 		return nil
 	} else if t == command.SymlinkInputType {
-		relTarget, err := getTargetRelPath(execRoot, path, meta.Symlink.Target)
+		relTarget, err := getTargetRelPath(execRoot, meta.Symlink.Target)
 		if err != nil {
 			return err
 		}

--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -93,13 +93,16 @@ func loadFiles(execRoot string, excl []*command.InputExclusion, path string, fs 
 			return nil
 		}
 		// Right now we never treat a dangling symlink as an error. If we
-		// choose not to preserve the symlink, it is simply skipped. Otherwise
-		// we will create a corresponding symlink node in the tree.
+		// choose not to preserve the symlink, the path is simply skipped.
+		// Otherwise we will create a corresponding symlink node in the tree
+		// (even if the target does not exist).
 	} else if meta.Err != nil {
 		return meta.Err
 	}
 	t := command.FileInputType
 	if isSymlink && opts.Preserved {
+		// An implication of this is that, if a path is a symlink to a
+		// directory, then the symlink attribute takes precedence.
 		t = command.SymlinkInputType
 	} else if meta.IsDirectory {
 		t = command.DirectoryInputType
@@ -121,9 +124,8 @@ func loadFiles(execRoot string, excl []*command.InputExclusion, path string, fs 
 			symlink: &symlinkNode{target: meta.Symlink.Target},
 		}
 		// NOTE: The target is not followed. It is the users' responsibility
-		// to explicitly list the target in their InputSpec. Also note that if
-		// a directory containing the target is specified, the entirety of that
-		// directory will be followed.
+		// to explicitly list the target in their InputSpec. This applies to
+		// symlinks to either a file or a directory.
 		return nil
 	}
 	// Directory

--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -80,7 +80,10 @@ func shouldIgnore(inp string, t command.InputType, excl []*command.InputExclusio
 
 // loadFiles reads all files specified by the given InputSpec (descending into subdirectories
 // recursively), and loads their contents into the provided map.
-func loadFiles(execRoot string, excl []*command.InputExclusion, path string, fs map[string]*fileSysNode, chunkSize int, cache filemetadata.Cache, opts TreeSymlinkOpts) error {
+func loadFiles(execRoot string, excl []*command.InputExclusion, path string, fs map[string]*fileSysNode, chunkSize int, cache filemetadata.Cache, opts *TreeSymlinkOpts) error {
+	if opts == nil {
+		opts = &TreeSymlinkOpts{}
+	}
 	absPath := filepath.Clean(filepath.Join(execRoot, path))
 	normPath, err := getRelPath(execRoot, absPath)
 	if err != nil {

--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -80,7 +80,7 @@ func shouldIgnore(inp string, t command.InputType, excl []*command.InputExclusio
 }
 
 // getTargetRelPath returns the part of target that is relative to execRoot,
-// iff. target is under execRoot. Otherwise it returns an error.
+// iff target is under execRoot. Otherwise it returns an error.
 func getTargetRelPath(execRoot, symlink, target string) (string, error) {
 	if !filepath.IsAbs(target) {
 		target = filepath.Clean(filepath.Join(execRoot, target))

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -547,7 +547,7 @@ func TestComputeMerkleTree(t *testing.T) {
 			},
 		},
 		{
-			desc: "Allow dangling symlink",
+			desc: "Dangling symlink is preserved",
 			input: []*inputPath{
 				{path: "fooDir/foo", fileContents: fooBlob, isExecutable: true},
 				{path: "invalidSym", isSymlink: true, symlinkTarget: "fooDir/invalid"},
@@ -573,8 +573,7 @@ func TestComputeMerkleTree(t *testing.T) {
 				TotalInputBytes:  fooDg.Size + fooDirDg.Size,
 			},
 			treeOpts: &client.TreeSymlinkOpts{
-				Preserved:            true,
-				AllowDanglingSymlink: true,
+				Preserved: true,
 			},
 		},
 		{
@@ -1030,7 +1029,7 @@ func TestComputeMerkleTree(t *testing.T) {
 			}
 			gotRootDg, inputs, stats, err := e.Client.GrpcClient.ComputeMerkleTree(root, tc.spec, chunker.DefaultChunkSize, cache)
 			if err != nil {
-				t.Errorf("ComputeMerkleTree(...) = gave error %v, want success", err)
+				t.Errorf("ComputeMerkleTree(...) = gave error %q, want success", err)
 			}
 			for _, ch := range inputs {
 				blob, err := ch.FullData()

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -531,6 +531,33 @@ func TestComputeMerkleTree(t *testing.T) {
 				TotalInputBytes:  fooDg.Size + fooDirDg.Size,
 			},
 			treeOpts: &client.TreeSymlinkOpts{
+				Preserved:     true,
+				FollowsTarget: true,
+			},
+		},
+		{
+			desc: "File relative symlink (preserved but not followed)",
+			input: []*inputPath{
+				{path: "fooDir/foo", fileContents: fooBlob, isExecutable: true},
+				{path: "fooSym", isSymlink: true, symlinkTarget: "fooDir/foo"},
+			},
+			spec: &command.InputSpec{
+				Inputs: []string{"fooSym"},
+			},
+			rootDir: &repb.Directory{
+				Directories: nil,
+				Symlinks:    []*repb.SymlinkNode{{Name: "fooSym", Target: "fooDir/foo"}},
+			},
+			wantCacheCalls: map[string]int{
+				"fooSym": 1,
+			},
+			wantStats: &client.TreeStats{
+				InputDirectories: 1,
+				InputFiles:       0,
+				InputSymlinks:    1,
+				TotalInputBytes:  0,
+			},
+			treeOpts: &client.TreeSymlinkOpts{
 				Preserved: true,
 			},
 		},
@@ -560,7 +587,8 @@ func TestComputeMerkleTree(t *testing.T) {
 				TotalInputBytes:  fooDg.Size + fooDirDg.Size,
 			},
 			treeOpts: &client.TreeSymlinkOpts{
-				Preserved: true,
+				Preserved:     true,
+				FollowsTarget: true,
 			},
 		},
 		{
@@ -702,7 +730,8 @@ func TestComputeMerkleTree(t *testing.T) {
 				TotalInputBytes:  fooDg.Size + barDg.Size + foobarDirDg.Size,
 			},
 			treeOpts: &client.TreeSymlinkOpts{
-				Preserved: true,
+				Preserved:     true,
+				FollowsTarget: true,
 			},
 		},
 		{
@@ -734,7 +763,8 @@ func TestComputeMerkleTree(t *testing.T) {
 				TotalInputBytes:  fooDg.Size + barDg.Size + foobarDirDg.Size,
 			},
 			treeOpts: &client.TreeSymlinkOpts{
-				Preserved: true,
+				Preserved:     true,
+				FollowsTarget: true,
 			},
 		},
 		{

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -688,7 +688,7 @@ func TestComputeMerkleTree(t *testing.T) {
 			},
 		},
 		{
-			desc: "Directory absoluate symlink (preserved)",
+			desc: "Directory absolute symlink (preserved)",
 			input: []*inputPath{
 				{path: "foobarDir/foo", fileContents: fooBlob, isExecutable: true},
 				{path: "foobarDir/bar", fileContents: barBlob},

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -1024,9 +1024,8 @@ func TestComputeMerkleTree(t *testing.T) {
 
 			e, cleanup := fakes.NewTestEnv(t)
 			defer cleanup()
-			if tc.treeOpts != nil {
-				tc.treeOpts.Apply(e.Client.GrpcClient)
-			}
+			tc.treeOpts.Apply(e.Client.GrpcClient)
+
 			gotRootDg, inputs, stats, err := e.Client.GrpcClient.ComputeMerkleTree(root, tc.spec, chunker.DefaultChunkSize, cache)
 			if err != nil {
 				t.Errorf("ComputeMerkleTree(...) = gave error %q, want success", err)

--- a/go/pkg/client/tree_whitebox_test.go
+++ b/go/pkg/client/tree_whitebox_test.go
@@ -8,7 +8,7 @@ func TestGetTargetRelPath(t *testing.T) {
 	tests := []struct {
 		desc      string
 		target    string
-		isError   bool
+		wantErr   bool
 		relTarget string
 	}{
 		{
@@ -24,7 +24,7 @@ func TestGetTargetRelPath(t *testing.T) {
 		{
 			desc:    "relative target path escaping exec root",
 			target:  "../foo",
-			isError: true,
+			wantErr: true,
 		},
 		{
 			desc:      "absolute target path under exec root",
@@ -34,15 +34,15 @@ func TestGetTargetRelPath(t *testing.T) {
 		{
 			desc:    "absolute target path escaping exec root",
 			target:  "/another/dir/foo",
-			isError: true,
+			wantErr: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			res, err := getTargetRelPath(execRoot, symlink, tc.target)
-			if (err != nil) != tc.isError {
-				t.Errorf("getTargetRelPath(target=%q) error: expected=%v got=%v", tc.target, tc.isError, err)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("getTargetRelPath(target=%q) error: expected=%v got=%v", tc.target, tc.wantErr, err)
 			}
 			if err == nil && res != tc.relTarget {
 				t.Errorf("getTargetRelPath(target=%q) result: expected=%v got=%v", tc.target, tc.relTarget, res)

--- a/go/pkg/client/tree_whitebox_test.go
+++ b/go/pkg/client/tree_whitebox_test.go
@@ -1,0 +1,52 @@
+package client
+
+import "testing"
+
+func TestGetTargetRelPath(t *testing.T) {
+	execRoot := "/execRoot/dir"
+	symlink := "sym"
+	tests := []struct {
+		desc      string
+		target    string
+		isError   bool
+		relTarget string
+	}{
+		{
+			desc:      "basic",
+			target:    "foo",
+			relTarget: "foo",
+		},
+		{
+			desc:      "there and back again",
+			target:    "../dir/sub/foo",
+			relTarget: "sub/foo",
+		},
+		{
+			desc:    "relative target path escaping exec root",
+			target:  "../foo",
+			isError: true,
+		},
+		{
+			desc:      "absolute target path under exec root",
+			target:    execRoot + "/sub/foo",
+			relTarget: "sub/foo",
+		},
+		{
+			desc:    "absolute target path escaping exec root",
+			target:  "/another/dir/foo",
+			isError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			res, err := getTargetRelPath(execRoot, symlink, tc.target)
+			if (err != nil) != tc.isError {
+				t.Errorf("getTargetRelPath(target=%q) error: expected=%v got=%v", tc.target, tc.isError, err)
+			}
+			if err == nil && res != tc.relTarget {
+				t.Errorf("getTargetRelPath(target=%q) result: expected=%v got=%v", tc.target, tc.relTarget, res)
+			}
+		})
+	}
+}

--- a/go/pkg/client/tree_whitebox_test.go
+++ b/go/pkg/client/tree_whitebox_test.go
@@ -4,7 +4,6 @@ import "testing"
 
 func TestGetTargetRelPath(t *testing.T) {
 	execRoot := "/execRoot/dir"
-	symlink := "sym"
 	tests := []struct {
 		desc      string
 		target    string
@@ -40,7 +39,7 @@ func TestGetTargetRelPath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			res, err := getTargetRelPath(execRoot, symlink, tc.target)
+			res, err := getTargetRelPath(execRoot, tc.target)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("getTargetRelPath(target=%q) error: expected=%v got=%v", tc.target, tc.wantErr, err)
 			}

--- a/go/pkg/command/command.go
+++ b/go/pkg/command/command.go
@@ -31,6 +31,9 @@ const (
 
 	// FileInputType means only files match.
 	FileInputType
+
+	// SymlinkInputType means only symlink match.
+	SymlinkInputType
 )
 
 var inputTypes = [...]string{"UnspecifiedInputType", "DirectoryInputType", "FileInputType"}


### PR DESCRIPTION
Added `TreeSymlinkOpts` to control the behavior of tree construction.

To be backward compatible, symlink is preserved only when `TreeSymlinkOpts.Preserved` is explicitly set to `true`. By default, symlinks are converted into files.

Issue: #146 