### PR TITLE
Refactor where IsDirectory is stored in the file metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,5 +61,6 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d
 	google.golang.org/grpc v1.31.1
+	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 // indirect
 )

--- a/go/pkg/filemetadata/filemetadata_test.go
+++ b/go/pkg/filemetadata/filemetadata_test.go
@@ -59,8 +59,11 @@ func TestComputeDirectory(t *testing.T) {
 		t.Fatalf("Failed to create temp directory")
 	}
 	got := Compute(tmpDir)
-	if fe, ok := got.Err.(*FileError); !ok || !fe.IsDirectory {
-		t.Errorf("Compute(%v).Err = %v, want FileError{IsDirectory:true}", tmpDir, got.Err)
+	if got.Err != nil {
+		t.Errorf("Compute(%v).Err = %v, expected nil", tmpDir, got.Err)
+	}
+	if !got.IsDirectory {
+		t.Errorf("Compute(%v).IsDirectory = false, want true", tmpDir)
 	}
 	if got.Digest != digest.Empty {
 		t.Errorf("Compute(%v).Digest = %v, want %v", tmpDir, got.Digest, digest.Empty)
@@ -146,8 +149,11 @@ func TestComputeSymlinksToDirectory(t *testing.T) {
 	}
 
 	got := Compute(symlinkPath)
-	if fe, ok := got.Err.(*FileError); !ok || !fe.IsDirectory {
-		t.Errorf("Compute(%v).Err = %v, want FileError{IsDirectory:true}", symlinkPath, got.Err)
+	if got.Err != nil {
+		t.Errorf("Compute(%v).Err = %v, expected nil", symlinkPath, got.Err)
+	}
+	if !got.IsDirectory {
+		t.Errorf("Compute(%v).IsDirectory = false, want true", symlinkPath)
 	}
 }
 


### PR DESCRIPTION
This is a prep step to address https://github.com/bazelbuild/remote-apis-sdks/pull/229#issuecomment-722923295. I find the code to handle symlinks a bit too complicated when `IsDirectory` is put inside the `FileError`, especially when symlink and directory are both true.