### PR TITLE
Renaming test_util to testutil

### DIFF
--- a/go/pkg/filemetadata/BUILD.bazel
+++ b/go/pkg/filemetadata/BUILD.bazel
@@ -30,7 +30,7 @@ go_test(
     deps = [
         "//go/pkg/cache:go_default_library",
         "//go/pkg/digest:go_default_library",
-        "//go/pkg/test_util:go_default_library",
+        "//go/pkg/testutil:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
     ],

--- a/go/pkg/filemetadata/cache_posix_test.go
+++ b/go/pkg/filemetadata/cache_posix_test.go
@@ -7,13 +7,13 @@ import (
 	"os"
 	"testing"
 
-	"github.com/bazelbuild/remote-apis-sdks/go/pkg/test_util"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestExecutableCacheLoad(t *testing.T) {
 	c := NewSingleFlightCache()
-	filename, err := test_util.CreateFile(t, true, "")
+	filename, err := testutil.CreateFile(t, true, "")
 	if err != nil {
 		t.Fatalf("Failed to create tmp file for testing digests: %v", err)
 	}

--- a/go/pkg/filemetadata/cache_test.go
+++ b/go/pkg/filemetadata/cache_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
-	"github.com/bazelbuild/remote-apis-sdks/go/pkg/test_util"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -17,7 +17,7 @@ var (
 
 func TestSimpleCacheLoad(t *testing.T) {
 	c := NewSingleFlightCache()
-	filename, err := test_util.CreateFile(t, false, "")
+	filename, err := testutil.CreateFile(t, false, "")
 	if err != nil {
 		t.Fatalf("Failed to create tmp file for testing digests: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestSimpleCacheLoad(t *testing.T) {
 
 func TestCacheOnceLoadMultiple(t *testing.T) {
 	c := NewSingleFlightCache()
-	filename, err := test_util.CreateFile(t, false, "")
+	filename, err := testutil.CreateFile(t, false, "")
 	if err != nil {
 		t.Fatalf("Failed to create tmp file for testing digests: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestCacheOnceLoadMultiple(t *testing.T) {
 
 func TestLoadAfterChangeWithoutValidation(t *testing.T) {
 	c := NewSingleFlightCache()
-	filename, err := test_util.CreateFile(t, false, "")
+	filename, err := testutil.CreateFile(t, false, "")
 	if err != nil {
 		t.Fatalf("Failed to create tmp file for testing digests: %v", err)
 	}

--- a/go/pkg/filemetadata/filemetadata_test.go
+++ b/go/pkg/filemetadata/filemetadata_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
-	"github.com/bazelbuild/remote-apis-sdks/go/pkg/test_util"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -33,7 +33,7 @@ func TestComputeFiles(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			filename, err := test_util.CreateFile(t, tc.executable, tc.contents)
+			filename, err := testutil.CreateFile(t, tc.executable, tc.contents)
 			if err != nil {
 				t.Fatalf("Failed to create tmp file for testing digests: %v", err)
 			}
@@ -160,7 +160,7 @@ func TestComputeSymlinksToDirectory(t *testing.T) {
 
 func createSymlinkToFile(t *testing.T, symlinkPath string, executable bool, contents string) (string, error) {
 	t.Helper()
-	targetPath, err := test_util.CreateFile(t, executable, contents)
+	targetPath, err := testutil.CreateFile(t, executable, contents)
 	if err != nil {
 		return "", err
 	}

--- a/go/pkg/reader/BUILD.bazel
+++ b/go/pkg/reader/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
     srcs = ["reader_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//go/pkg/test_util:go_default_library",
+        "//go/pkg/testutil:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
     ],
 )

--- a/go/pkg/reader/reader_test.go
+++ b/go/pkg/reader/reader_test.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/bazelbuild/remote-apis-sdks/go/pkg/test_util"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -39,7 +39,7 @@ func TestFileReaderSeeks(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			path, err := test_util.CreateFile(t, false, tc.blob)
+			path, err := testutil.CreateFile(t, false, tc.blob)
 			if err != nil {
 				t.Fatalf("Failed to make temp file: %v", err)
 			}
@@ -94,7 +94,7 @@ func TestFileReaderSeeks(t *testing.T) {
 
 func TestFileReaderSeeksPastOffset(t *testing.T) {
 	t.Parallel()
-	path, err := test_util.CreateFile(t, false, "12345")
+	path, err := testutil.CreateFile(t, false, "12345")
 	if err != nil {
 		t.Fatalf("Failed to make temp file: %v", err)
 	}

--- a/go/pkg/testutil/BUILD.bazel
+++ b/go/pkg/testutil/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["test_util.go"],
-    importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/test_util",
+    srcs = ["testutil.go"],
+    importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/testutil",
     visibility = ["//visibility:public"],
 )

--- a/go/pkg/testutil/testutil.go
+++ b/go/pkg/testutil/testutil.go
@@ -1,4 +1,4 @@
-package test_util
+package testutil
 
 import (
 	"io/ioutil"


### PR DESCRIPTION
Internal Gazelle doesn't like it when packages have underscores in their names.