### PR TITLE
Closing the reader in the end of a read.

### DIFF
--- a/go/pkg/reader/reader.go
+++ b/go/pkg/reader/reader.go
@@ -15,6 +15,7 @@ type Initializable interface {
 
 type ReadSeeker interface {
 	io.Reader
+	io.Closer
 	Initializable
 	SeekOffset(offset int64)
 }
@@ -40,6 +41,17 @@ func NewFileReadSeeker(path string, buffsize int) ReadSeeker {
 		seekOffset:  0,
 		initialized: false,
 	}
+}
+
+// Close closes the reader. It still can be reopened with Initialize().
+func (fio *fileSeeker) Close() (err error) {
+	fio.initialized = false
+	if fio.f != nil {
+		err = fio.f.Close()
+	}
+	fio.f = nil
+	fio.reader = nil
+	return err
 }
 
 // Read implements io.Reader.

--- a/go/pkg/reader/reader_test.go
+++ b/go/pkg/reader/reader_test.go
@@ -47,6 +47,7 @@ func TestFileReaderSeeks(t *testing.T) {
 			data := make([]byte, tc.dataBuffSize)
 
 			r := NewFileReadSeeker(path, tc.IOBuffSize)
+			defer r.Close()
 			if _, err := r.Read(data); err == nil {
 				t.Errorf("Read() = should have err'd on unitialized reader")
 			}


### PR DESCRIPTION
Bugfix: this should fix the broken Windows unit test.