### PR TITLE
Fix the way to compute the target path relative to the symlink

### DIFF
--- a/go/pkg/client/tree_whitebox_test.go
+++ b/go/pkg/client/tree_whitebox_test.go
@@ -3,43 +3,68 @@ package client
 import "testing"
 
 func TestGetTargetRelPath(t *testing.T) {
-	execRoot := "/execRoot/dir"
+	execRoot := "/execRoot"
+	defaultSymlinkNormDir := "symDir"
 	tests := []struct {
-		desc      string
-		target    string
-		wantErr   bool
-		relTarget string
+		desc           string
+		symlinkNormDir string
+		target         string
+		wantErr        bool
+		relTarget      string
 	}{
 		{
-			desc:      "basic",
-			target:    "foo",
-			relTarget: "foo",
+			desc:           "basic",
+			symlinkNormDir: defaultSymlinkNormDir,
+			target:         "foo",
+			relTarget:      "foo",
 		},
 		{
-			desc:      "there and back again",
-			target:    "../dir/sub/foo",
-			relTarget: "sub/foo",
+			desc:           "relative target path under exec root",
+			symlinkNormDir: defaultSymlinkNormDir,
+			// /execRoot/symDir/../dir/foo ==> /execRoot/dir/foo
+			target:    "../dir/foo",
+			relTarget: "../dir/foo",
 		},
 		{
-			desc:    "relative target path escaping exec root",
-			target:  "../foo",
+			desc:           "relative target path escaping exec root",
+			symlinkNormDir: defaultSymlinkNormDir,
+			// /execRoot/symDir/../../foo ==> /foo
+			target:  "../../foo",
 			wantErr: true,
 		},
 		{
-			desc:      "absolute target path under exec root",
-			target:    execRoot + "/sub/foo",
-			relTarget: "sub/foo",
+			desc:           "deeper relative target path",
+			symlinkNormDir: "base/sub",
+			// /execRoot/base/sub/../../foo ==> /execRoot/foo
+			target:    "../../foo",
+			relTarget: "../../foo",
 		},
 		{
-			desc:    "absolute target path escaping exec root",
-			target:  "/another/dir/foo",
-			wantErr: true,
+			desc:           "absolute target path under exec root",
+			symlinkNormDir: "base",
+			target:         execRoot + "/base/foo",
+			relTarget:      "foo",
+		},
+		{
+			desc:           "abs target to rel target",
+			symlinkNormDir: "base/sub1/sub2",
+			target:         execRoot + "/dir/foo",
+			// symlinkAbsDir: /execRoot/base/sub1/sub2
+			// targetAbs: /execRoot/dir/foo
+			// target rel to symlink: ../../../dir/foo
+			relTarget: "../../../dir/foo",
+		},
+		{
+			desc:           "absolute target path escaping exec root",
+			symlinkNormDir: defaultSymlinkNormDir,
+			target:         "/another/dir/foo",
+			wantErr:        true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			res, err := getTargetRelPath(execRoot, tc.target)
+			res, err := getTargetRelPath(execRoot, tc.symlinkNormDir, tc.target)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("getTargetRelPath(target=%q) error: expected=%v got=%v", tc.target, tc.wantErr, err)
 			}


### PR DESCRIPTION
I believe what I did in #229 was wrong when handling the symlink target.

1. When we construct the `SymlinkNode`, `Target` should be relative to **the directory of the symlink**. #229 computed the path relative to `execRoot` instead. This is problematic when the target is an absolute path in the filesystem.
2. When we recursively call `loadFiles()` on the target, this time `path` should still be the part of target relative to `execRoot`.