### PR TITLE
Turn off compression by default.

### DIFF
--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -30,7 +30,7 @@ import (
 
 // DefaultCompressedBytestreamThreshold is the default threshold, in bytes, for
 // transferring blobs compressed on ByteStream.Write RPCs.
-const DefaultCompressedBytestreamThreshold = 1024 * 1024
+const DefaultCompressedBytestreamThreshold = -1
 
 const logInterval = 25
 

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -73,7 +73,7 @@ type Client struct {
 	// ChunkMaxSize is maximum chunk size to use for CAS uploads/downloads.
 	ChunkMaxSize ChunkMaxSize
 	// CompressedBytestreamThreshold is the threshold in bytes for which blobs are read and written
-	// compressed. Use 0 for all writes being compressed, and a negative number for all writes being
+	// compressed. Use 0 for all writes being compressed, and a negative number for all operations being
 	// uncompressed. TODO(rubensf): Make sure this will throw an error if the server doesn't support compression,
 	// pending https://github.com/bazelbuild/remote-apis/pull/168 being submitted.
 	CompressedBytestreamThreshold CompressedBytestreamThreshold


### PR DESCRIPTION
While the RE API addition of the API isn't ready, we can't
check for server Capabilities whether compression is supported.