### PR TITLE
write batch downloaded files in sorted order by path

### DIFF
--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -1192,7 +1192,8 @@ func (c *Client) downloadBatch(ctx context.Context, batch []digest.Digest, reqs 
 		afterDownload(batch, reqs, err)
 		return
 	}
-	for dg, data := range bchMap {
+	for _, dg := range batch {
+		data := bchMap[dg]
 		for _, r := range reqs[dg] {
 			perm := c.RegularMode
 			if r.output.IsExecutable {

--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -1372,7 +1372,8 @@ func (c *Client) downloadNonUnified(ctx context.Context, execRoot string, output
 				if err != nil {
 					return err
 				}
-				for dg, data := range bchMap {
+				for _, dg := range batch {
+					data := bchMap[dg]
 					out := outputs[dg]
 					perm := c.RegularMode
 					if out.IsExecutable {


### PR DESCRIPTION
This is follow up of https://github.com/bazelbuild/remote-apis-sdks/pull/200

With this change, time of DownloadFiles improved from 46.4s to 37.7s on Windows for our dataset.
wihtout this PR: https://chromium-swarm.appspot.com/task?id=501c7e37a9526d10
with this PR:       https://chromium-swarm.appspot.com/task?id=501c93af586df010