### PR TITLE
Further write compression patch.

### DIFF
--- a/go/pkg/fakes/server.go
+++ b/go/pkg/fakes/server.go
@@ -41,10 +41,7 @@ type Server struct {
 
 // NewServer creates a server that is ready to accept requests.
 func NewServer(t *testing.T) (s *Server, err error) {
-	cas, err := NewCAS()
-	if err != nil {
-		return nil, err
-	}
+	cas := NewCAS()
 	ac := NewActionCache()
 	s = &Server{Exec: NewExec(t, ac, cas), CAS: cas, ActionCache: ac}
 	s.listener, err = net.Listen("tcp", ":0")


### PR DESCRIPTION
The existing code had a couple issues:
1) An EOF from the underlying uncompressed data would trigger finalizing
a read of the compressed data - even though the compressed data itself
wasn't ready or finalized reading.
2) *After* the `Close` call on the encoder, which triggers the
compressed data to be available for reading, is when you have to
actually read the final chunks and pieces of data.

The test code was also faulty as it checked the bytes up to the length
of the code compressed data (instead of the test compressed data), which
was 0.

This issue never arove on the fakes servers as cas_test doesn't seem to
have File tests - this compression issue wouldn't show up on in memory
blob tests. Just in case, I also added further checks on fake CAS to
ensure compressed calls were actually being made.