### PR TITLE
Deflaking,improving performance,refactoring.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -11,7 +11,7 @@ tasks:
       - "//..."
     test_targets:
       - "//..."
-# Check that "go build / test" works, too.
+  # Check that "go build / test" works, too.
   ubuntu1804_gobuild:
     platform: ubuntu1804
     name: "go build / test"

--- a/go/pkg/client/batch_retries_test.go
+++ b/go/pkg/client/batch_retries_test.go
@@ -124,6 +124,7 @@ func (f *flakyBatchServer) BatchUpdateBlobs(ctx context.Context, req *repb.Batch
 }
 
 func TestBatchUpdateBlobsIndividualRequestRetries(t *testing.T) {
+	t.Parallel()
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
@@ -197,6 +198,7 @@ func TestBatchUpdateBlobsIndividualRequestRetries(t *testing.T) {
 }
 
 func TestBatchReadBlobsIndividualRequestRetries(t *testing.T) {
+	t.Parallel()
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
@@ -325,6 +327,7 @@ func (s *sleepyBatchServer) BatchUpdateBlobs(ctx context.Context, req *repb.Batc
 }
 
 func TestBatchReadBlobsDeadlineExceededRetries(t *testing.T) {
+	t.Parallel()
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
@@ -363,6 +366,7 @@ func TestBatchReadBlobsDeadlineExceededRetries(t *testing.T) {
 }
 
 func TestBatchUpdateBlobsDeadlineExceededRetries(t *testing.T) {
+	t.Parallel()
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -182,12 +182,18 @@ func (s UtilizeLocality) Apply(c *Client) {
 type UnifiedUploads bool
 
 func (c *Client) restartUploader() {
+	if c.casUploadRequests == nil {
+		return
+	}
 	close(c.casUploadRequests)
 	c.casUploadRequests = make(chan *uploadRequest, c.UnifiedUploadBufferSize)
 	go c.uploadProcessor()
 }
 
 func (c *Client) restartDownloader() {
+	if c.casDownloadRequests == nil {
+		return
+	}
 	close(c.casDownloadRequests)
 	c.casDownloadRequests = make(chan *downloadRequest, c.UnifiedDownloadBufferSize)
 	go c.downloadProcessor()

--- a/go/pkg/retry/retry.go
+++ b/go/pkg/retry/retry.go
@@ -75,7 +75,10 @@ func WithPolicy(ctx context.Context, shouldRetry ShouldRetry, bp BackoffPolicy, 
 			return err
 		}
 
-		log.V(1).Infof("call failed with err=%v, retrying.", err)
+		if log.V(1) {
+			// This log depth is custom-tailored to the SDK usage, which always calls the retrier from within client.CallWithTimeout.
+			log.InfoDepth(3, fmt.Sprintf("call failed with err=%v, retrying.", err))
+		}
 
 		if attempts+1 == int(bp.maxAttempts) {
 			// Annotates the error message to indicate the retry budget was exhausted.


### PR DESCRIPTION
Also improving retry logging. Includes adding race/deflakes to presubmit
-- decided to make that two separate jobs for efficiency -- gorace detects
different kinds of errors than runs_per_test; combining them is too
costly (currently, impossible because we spawn too many goroutines for
gorace to work).