### PR TITLE
rexec: Update to REAPI v2.2

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -63,7 +63,7 @@ http_archive(
 go_repository(
     name = "com_github_bazelbuild_remote_apis",
     importpath = "github.com/bazelbuild/remote-apis",
-    tag = "v2.0.0",
+    commit = "9e72daff42c941baaf43a4c370e2607a984c58a7", # 2020-12-09
 )
 
 load("@com_github_bazelbuild_remote_apis//:repository_rules.bzl", "switched_rules_by_language")

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,8 @@ require (
 	github.com/aclements/go-moremath v0.0.0-20190830160640-d16893ddf098 // indirect
 	github.com/ajstarks/deck v0.0.0-20191009173945-82d717002242 // indirect
 	github.com/ajstarks/svgo v0.0.0-20190826172357-de52242f3d65 // indirect
-	github.com/bazelbuild/remote-apis v0.0.0-20200904140912-1aeb39973178
+	github.com/bazelbuild/remote-apis v0.0.0-20201113154229-1e9ccef3705c
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b // indirect
-	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/cznic/cc v0.0.0-20181122101902-d673e9b70d4d // indirect
 	github.com/cznic/fileutil v0.0.0-20181122101858-4d67cfea8c87 // indirect
@@ -29,6 +28,7 @@ require (
 	github.com/godbus/dbus v4.1.0+incompatible // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.4.2
 	github.com/gonum/blas v0.0.0-20181208220705-f22b278b28ac // indirect
 	github.com/gonum/floats v0.0.0-20181209220543-c233463c7e82 // indirect
@@ -38,7 +38,6 @@ require (
 	github.com/google/go-cmp v0.5.1
 	github.com/google/uuid v1.1.2
 	github.com/googleapis/gax-go v2.0.2+incompatible // indirect
-	github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 // indirect
 	github.com/jung-kurt/gofpdf v1.13.0 // indirect
 	github.com/klauspost/compress v1.11.2
 	github.com/kylelemons/godebug v1.1.0
@@ -52,6 +51,7 @@ require (
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	golang.org/x/build v0.0.0-20191031202223-0706ea4fce0c // indirect
+	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 // indirect
 	golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 // indirect
 	golang.org/x/mobile v0.0.0-20191031020345-0945064e013a // indirect
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/bazelbuild/remote-apis v0.0.0-20200624085034-0afc3700d177 h1:JeDdP1Zs
 github.com/bazelbuild/remote-apis v0.0.0-20200812111343-5a7b1a472165 h1:2Wwz88RKomXNpY/Sqh0irk+lrQYhjJVR5lQvQc9PStQ=
 github.com/bazelbuild/remote-apis v0.0.0-20200904140912-1aeb39973178 h1:qDZ7lr7knlTckZgbKwWD1PHTY6WYe5V+DqILuzpMHPY=
 github.com/bazelbuild/remote-apis v0.0.0-20200904140912-1aeb39973178/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
+github.com/bazelbuild/remote-apis v0.0.0-20201113154229-1e9ccef3705c h1:rk6YYsIbLDZ/frDYZPANInvCUqAEjPitjRSyWTcsjiA=
+github.com/bazelbuild/remote-apis v0.0.0-20201113154229-1e9ccef3705c/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
 github.com/boombuler/barcode v1.0.0 h1:s1TvRnXwL2xJRaccrdcBQMZxq6X7DvsMogtmJeHDdrc=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625 h1:ckJgFhFWywOx+YLEMIJsTb+NV6NexWICk5+AMSuz3ss=

--- a/go/pkg/client/BUILD.bazel
+++ b/go/pkg/client/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "//go/pkg/retry:go_default_library",
         "//go/pkg/uploadinfo:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
+        "@com_github_bazelbuild_remote_apis//build/bazel/semver:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_google_go_cmp//cmp:go_default_library",

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -873,6 +873,48 @@ func (c *Client) GetBackendCapabilities(ctx context.Context, conn *grpc.ClientCo
 	return res, nil
 }
 
+// SupportsActionPlatformProperties returns whether the server's RE API version
+// supports the `Action.platform_properties` field.
+func (c *Client) SupportsActionPlatformProperties() bool {
+	return supportsActionPlatformProperties(c.serverCaps)
+}
+
+// SupportsCommandOutputPaths returns whether the server's RE API version
+// supports the `Command.action_paths` field.
+func (c *Client) SupportsCommandOutputPaths() bool {
+	return supportsCommandOutputPaths(c.serverCaps)
+}
+
+// HighAPIVersionNewerThanOrEqualTo returns whether the latest version reported
+// as supported in ServerCapabilities matches or is more recent than a
+// reference major/minor version.
+func highAPIVersionNewerThanOrEqualTo(serverCapabilities *repb.ServerCapabilities, major int32, minor int32) bool {
+	if serverCapabilities == nil {
+		return false
+	}
+
+	latestSupportedMajor := serverCapabilities.HighApiVersion.GetMajor()
+	latestSupportedMinor := serverCapabilities.HighApiVersion.GetMinor()
+
+	return (latestSupportedMajor > major || (latestSupportedMajor == major && latestSupportedMinor >= minor))
+}
+
+func supportsActionPlatformProperties(serverCapabilities *repb.ServerCapabilities) bool {
+	// According to the RE API spec:
+	// "New in version 2.2: clients SHOULD set these platform properties as well
+	// as those in the [Command][build.bazel.remote.execution.v2.Command].
+	// Servers SHOULD prefer those set here."
+	return highAPIVersionNewerThanOrEqualTo(serverCapabilities, 2, 2)
+}
+
+func supportsCommandOutputPaths(serverCapabilities *repb.ServerCapabilities) bool {
+	// According to the RE API spec:
+	// "[In v2.1 `output_paths`] supersedes the DEPRECATED `output_files` and
+	// `output_directories` fields. If `output_paths` is used, `output_files` and
+	// `output_directories` will be ignored!"
+	return highAPIVersionNewerThanOrEqualTo(serverCapabilities, 2, 1)
+}
+
 // GetOperation wraps the underlying call with specific client options.
 func (c *Client) GetOperation(ctx context.Context, req *oppb.GetOperationRequest) (res *oppb.Operation, err error) {
 	opts := c.RPCOpts()

--- a/go/pkg/command/command.go
+++ b/go/pkg/command/command.go
@@ -469,17 +469,29 @@ type Metadata struct {
 }
 
 // ToREProto converts the Command to an RE API Command proto.
-func (c *Command) ToREProto() *repb.Command {
+// `useOutputPathsField` selects what field/s to fill with the paths of outputs,
+// which will depend on the RE API version.
+func (c *Command) ToREProto(useOutputPathsField bool) *repb.Command {
 	cmdPb := &repb.Command{
-		Arguments:         c.Args,
-		OutputFiles:       make([]string, len(c.OutputFiles)),
-		OutputDirectories: make([]string, len(c.OutputDirs)),
-		WorkingDirectory:  c.WorkingDir,
+		Arguments:        c.Args,
+		WorkingDirectory: c.WorkingDir,
 	}
-	copy(cmdPb.OutputFiles, c.OutputFiles)
-	copy(cmdPb.OutputDirectories, c.OutputDirs)
-	sort.Strings(cmdPb.OutputFiles)
-	sort.Strings(cmdPb.OutputDirectories)
+
+	// In v2.1 of the RE API the `output_{files, directories}` fields were
+	// replaced by a single field: `output_paths`.
+	if useOutputPathsField {
+		cmdPb.OutputPaths = append(c.OutputFiles, c.OutputDirs...)
+		sort.Strings(cmdPb.OutputPaths)
+	} else {
+		cmdPb.OutputFiles = make([]string, len(c.OutputFiles))
+		copy(cmdPb.OutputFiles, c.OutputFiles)
+		sort.Strings(cmdPb.OutputFiles)
+
+		cmdPb.OutputDirectories = make([]string, len(c.OutputDirs))
+		copy(cmdPb.OutputDirectories, c.OutputDirs)
+		sort.Strings(cmdPb.OutputDirectories)
+	}
+
 	for name, val := range c.InputSpec.EnvironmentVariables {
 		cmdPb.EnvironmentVariables = append(cmdPb.EnvironmentVariables, &repb.Command_EnvironmentVariable{Name: name, Value: val})
 	}

--- a/go/pkg/fakes/server.go
+++ b/go/pkg/fakes/server.go
@@ -177,7 +177,7 @@ func (e *TestEnv) Set(cmd *command.Command, opt *command.ExecutionOptions, res *
 		e.Server.CAS.Put(bytes)
 	}
 
-	cmdPb := cmd.ToREProto()
+	cmdPb := cmd.ToREProto(false)
 	bytes, err := proto.Marshal(cmdPb)
 	if err != nil {
 		e.t.Fatalf("error inserting command digest blob into CAS %v", err)


### PR DESCRIPTION
Versions 2.1 and 2.2 of the [Remote Execution API](https://github.com/bazelbuild/remote-apis/blob/1e9ccef3705c2c41a447aee0ddbe6810ccb7949d/build/bazel/remote/execution/v2/remote_execution.proto) introduce two changes:

* The Platform properties list can now be also set in the `Action` message (allowing servers to read the properties without dereferencing the `Command` message), and
* the `Action.output_{files, directories}` fields are now combined into `Action.output_paths`.

This bumps up the required version of `github.com/bazelbuild/remote-apis` to use v2.2 of `remote_execution.proto` and updates `exec.go` to populate those fields following the most recent version of the spec.

This is a breaking change for older implementations, but I wasn't sure what the preferred way of addressing this would be. I'll be happy to address this PR with the necessary adjustments before merging.