### PR TITLE
upgrade zstd library version for earlier resource free'ing fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,10 +40,10 @@ require (
 	github.com/googleapis/gax-go v2.0.2+incompatible // indirect
 	github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 // indirect
 	github.com/jung-kurt/gofpdf v1.13.0 // indirect
-	github.com/klauspost/compress v1.11.4
+	github.com/klauspost/compress v1.11.6
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-sqlite3 v1.11.0 // indirect
-	github.com/mostynb/zstdpool-syncpool v0.0.2
+	github.com/mostynb/zstdpool-syncpool v0.0.3
 	github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d // indirect
 	github.com/pborman/uuid v1.2.1
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,8 @@ github.com/klauspost/compress v1.11.2 h1:MiK62aErc3gIiVEtyzKfeOHgW7atJb5g/KNX5m3
 github.com/klauspost/compress v1.11.2/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.4 h1:kz40R/YWls3iqT9zX9AHN3WoVsrAWVyui5sxuLqiXqU=
 github.com/klauspost/compress v1.11.4/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.11.6 h1:EgWPCW6O3n1D5n99Zq3xXBt9uCwRGvpwGOusOLNBRSQ=
+github.com/klauspost/compress v1.11.6/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3 h1:/Um6a/ZmD5tF7peoOJ5oN5KMQ0DrGVQSXLNwyckutPk=
@@ -248,6 +250,8 @@ github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mostynb/zstdpool-syncpool v0.0.2 h1:tSmtZSiSAfffEgy9ziKvOZOOlccUwF2Ar78+CeOH+8A=
 github.com/mostynb/zstdpool-syncpool v0.0.2/go.mod h1:j/I43b31x+jxmpN8j/o+jc9SdLDoTiDei95IvdCLWgA=
+github.com/mostynb/zstdpool-syncpool v0.0.3 h1:G1+LWTHSedQUaiW7V7wiGdufKk3Xyyot/6vjBDeugFs=
+github.com/mostynb/zstdpool-syncpool v0.0.3/go.mod h1:lC4L6zTmUc7cUKGiMn6aOuHmxzkL4mzpTg4wxpLBbuk=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d h1:AREM5mwr4u1ORQBMvzfzBgpsctsbQikCVpvC+tX285E=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/remote-apis-sdks-deps.bzl
+++ b/remote-apis-sdks-deps.bzl
@@ -104,11 +104,11 @@ def remote_apis_sdks_go_deps():
         go_repository,
         name = "com_github_klauspost_compress",
         importpath = "github.com/klauspost/compress",
-        tag = "v1.11.2",
+        tag = "v1.11.6",
     )
     _maybe(
         go_repository,
         name = "com_github_mostynb_zstdpool_syncpool",
         importpath = "github.com/mostynb/zstdpool-syncpool",
-        tag = "v0.0.2",
+        tag = "v0.0.3",
     )


### PR DESCRIPTION
github.com/klauspost/compress v1.11.16 has the following fix which
allows the syncpool implementation to free resources earlier:
https://github.com/klauspost/compress/commit/fa5ea64d60c615a664931521778e111b45a43dbc

Here's the corresponding syncpool update:
https://github.com/mostynb/zstdpool-syncpool/commit/66ec463a4df39aff4bd8ff888309877d3dce062e