### PR TITLE
Fix compressed read retries in compressed blobs.

### DIFF
--- a/go/pkg/client/BUILD.bazel
+++ b/go/pkg/client/BUILD.bazel
@@ -72,6 +72,7 @@ go_test(
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
+        "@com_github_klauspost_compress//zstd:go_default_library",
         "@go_googleapis//google/bytestream:bytestream_go_proto",
         "@go_googleapis//google/longrunning:longrunning_go_proto",
         "@go_googleapis//google/rpc:status_go_proto",


### PR DESCRIPTION
The current configuration will try to use the offset of the _compressed_
blob as the new offset for retrying reads. However, the compressed RE
API wants the offset to refer to the _uncompressed_ blobs. Since the
compressed offset will usually be a lower number than the uncompressed
offset, we generally end up with a bigger blob than expected.

Since this Read interruptions are mostly transient (eg context deadlines
exceeded), our higher level retries have been mostly hiding the issue.

Also took the chance to beef up some comments around the thread tricky
compression code.

I'll _eventually_ add retries tests to compressed blobs writes retry tests :)