### PR TITLE
Revert "Surfacing error details of the gRPC status"

### DIFF
--- a/go/pkg/client/BUILD.bazel
+++ b/go/pkg/client/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "@com_github_pkg_errors//:go_default_library",
         "@go_googleapis//google/bytestream:bytestream_go_proto",
         "@go_googleapis//google/longrunning:longrunning_go_proto",
-        "@go_googleapis//google/rpc:errdetails_go_proto",
         "@io_bazel_rules_go//proto/wkt:empty_go_proto",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",

--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -28,7 +28,6 @@ import (
 
 	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	log "github.com/golang/glog"
-	_ "google.golang.org/genproto/googleapis/rpc/errdetails"
 )
 
 // DefaultCompressedBytestreamThreshold is the default threshold, in bytes, for
@@ -102,28 +101,6 @@ type uploadState struct {
 	mu      sync.Mutex
 	clients []chan<- *uploadResponse
 	cancel  func()
-}
-
-// StatusDetailsString returns the error details of the status as a text string.
-func StatusDetailsString(st *status.Status) string {
-	var details []string
-	for _, d := range st.Details() {
-		s := fmt.Sprintf("%+v", d)
-		if pb, ok := d.(proto.Message); ok {
-			s = proto.MarshalTextString(pb)
-		}
-		details = append(details, s)
-	}
-	return strings.Join(details, "; ")
-}
-
-func StatusDetailedError(st *status.Status) error {
-	e := st.Err()
-	details := StatusDetailsString(st)
-	if details != "" {
-		e = fmt.Errorf("%w error details =  %s", e, details)
-	}
-	return e
 }
 
 func (c *Client) findBlobState(ctx context.Context, dgs []digest.Digest) (missing []digest.Digest, present []digest.Digest, err error) {
@@ -680,7 +657,7 @@ func (c *Client) BatchWriteBlobs(ctx context.Context, blobs map[digest.Digest][]
 				}
 				numErrs++
 				errDg = r.Digest
-				errMsg = StatusDetailedError(status.FromProto(r.Status)).Error()
+				errMsg = r.Status.Message
 			}
 		}
 		reqs = failedReqs

--- a/go/pkg/rexec/rexec.go
+++ b/go/pkg/rexec/rexec.go
@@ -343,7 +343,7 @@ func (ec *Context) ExecuteRemotely() {
 		return
 	}
 	if st.Code() != codes.OK {
-		ec.Result = command.NewRemoteErrorResult(rc.StatusDetailedError(st))
+		ec.Result = command.NewRemoteErrorResult(st.Err())
 		return
 	}
 	if ec.resPb == nil {


### PR DESCRIPTION
Reverts bazelbuild/remote-apis-sdks#272

This doesn't work internally (error code is not properly wrapped). Will need to debug more.