### PR TITLE
Extract NewClientFromConnection() from NewClient()

### DIFF
--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -600,6 +600,11 @@ func NewClient(ctx context.Context, instanceName string, params DialParams, opts
 	if err != nil {
 		return nil, err
 	}
+	return NewClientFromConnection(ctx, instanceName, conn, casConn, opts...)
+}
+
+// NewClientFromConnection creates a client from gRPC connections to a remote execution service and a cas service.
+func NewClientFromConnection(ctx context.Context, instanceName string, conn, casConn *grpc.ClientConn, opts ...Opt) (*Client, error) {
 	client := &Client{
 		InstanceName:                  instanceName,
 		actionCache:                   regrpc.NewActionCacheClient(casConn),


### PR DESCRIPTION
This change will allow us create a client with custom gRPC connections.
I simply extracted the logic from `NewClient()`. 