### PR TITLE
fake: follow spec around empty blob

### DIFF
--- a/go/pkg/client/cas_test.go
+++ b/go/pkg/client/cas_test.go
@@ -1235,6 +1235,9 @@ func TestDownloadDirectory(t *testing.T) {
 		Files: []*repb.FileNode{
 			{Name: "foo", Digest: fooDigest.ToProto(), IsExecutable: true},
 		},
+		Directories: []*repb.DirectoryNode{
+			{Name: "empty", Digest: digest.Empty.ToProto()},
+		},
 	}
 	dirBlob, err := proto.Marshal(dir)
 	if err != nil {
@@ -1250,11 +1253,17 @@ func TestDownloadDirectory(t *testing.T) {
 		t.Errorf("error in DownloadActionOutputs: %s", err)
 	}
 
-	if diff := cmp.Diff(outputs, map[string]*client.TreeOutput{"foo": {
-		Digest:       fooDigest,
-		Path:         "foo",
-		IsExecutable: true,
-	}}); diff != "" {
+	if diff := cmp.Diff(outputs, map[string]*client.TreeOutput{
+		"empty": {
+			Digest:           digest.Empty,
+			Path:             "empty",
+			IsEmptyDirectory: true,
+		},
+		"foo": {
+			Digest:       fooDigest,
+			Path:         "foo",
+			IsExecutable: true,
+		}}); diff != "" {
 		t.Fatalf("DownloadDirectory() mismatch (-want +got):\n%s", diff)
 	}
 

--- a/go/pkg/fakes/cas.go
+++ b/go/pkg/fakes/cas.go
@@ -290,7 +290,10 @@ func NewCAS() *CAS {
 func (f *CAS) Clear() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.blobs = make(map[digest.Digest][]byte)
+	f.blobs = map[digest.Digest][]byte{
+		// For https://github.com/bazelbuild/remote-apis/blob/6345202a036a297b22b0a0e7531ef702d05f2130/build/bazel/remote/execution/v2/remote_execution.proto#L249
+		digest.Empty: {},
+	}
 	f.reads = make(map[digest.Digest]int)
 	f.writes = make(map[digest.Digest]int)
 	f.missingReqs = make(map[digest.Digest]int)


### PR DESCRIPTION
This is follow up CL for
https://github.com/bazelbuild/remote-apis-sdks/pull/184