### PR TITLE
Populate stat after err checking is complete

### DIFF
--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -20,7 +20,7 @@ import (
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/uploadinfo"
 	"github.com/golang/protobuf/proto"
 	"github.com/klauspost/compress/zstd"
-	"github.com/mostynb/zstdpool-syncpool"
+	syncpool "github.com/mostynb/zstdpool-syncpool"
 	"github.com/pborman/uuid"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
@@ -1473,10 +1473,10 @@ func (c *Client) downloadSingle(ctx context.Context, dg digest.Digest, reqs map[
 	path := filepath.Join(r.execRoot, r.output.Path)
 	LogContextInfof(ctx, log.Level(3), "Downloading single file with digest %s to %s", r.output.Digest, path)
 	stats, err := c.ReadBlobToFile(ctx, r.output.Digest, path)
-	bytesMoved[r.output.Digest] = stats
 	if err != nil {
 		return err
 	}
+	bytesMoved[r.output.Digest] = stats
 	if r.output.IsExecutable {
 		if err := os.Chmod(path, c.ExecutableMode); err != nil {
 			return err
@@ -1657,12 +1657,12 @@ func (c *Client) downloadNonUnified(ctx context.Context, execRoot string, output
 				path := filepath.Join(execRoot, out.Path)
 				LogContextInfof(ctx, log.Level(3), "Downloading single file with digest %s to %s", out.Digest, path)
 				stats, err := c.ReadBlobToFile(ctx, out.Digest, path)
-				statsMu.Lock()
-				fullStats.addFrom(stats)
-				statsMu.Unlock()
 				if err != nil {
 					return err
 				}
+				statsMu.Lock()
+				fullStats.addFrom(stats)
+				statsMu.Unlock()
 				if out.IsExecutable {
 					if err := os.Chmod(path, c.ExecutableMode); err != nil {
 						return err


### PR DESCRIPTION
Doing so before doing the err check results in segmentation fault when
the defered afterDownload() function is run.

Test: n/a, debugging / fixing it based on stack trace from user bugs.