### PR TITLE
Revamp loadFiles for performance.

### DIFF
--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -4,7 +4,7 @@ package client
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -87,115 +87,128 @@ func shouldIgnore(inp string, t command.InputType, excl []*command.InputExclusio
 	return false
 }
 
-// getTargetRelPath returns the part of the target relative to the symlink's
-// directory, iff the target is under execRoot. Otherwise it returns an error.
-func getTargetRelPath(execRoot, symlinkNormDir, target string) (string, error) {
-	symlinkAbsDir := filepath.Clean(filepath.Join(execRoot, symlinkNormDir))
-	if !filepath.IsAbs(target) {
-		target = filepath.Clean(filepath.Join(symlinkAbsDir, target))
-	}
-	if _, err := getRelPath(execRoot, target); err != nil {
+func getRelPath(base, path string) (string, error) {
+	rel, err := filepath.Rel(base, path)
+	if err != nil {
 		return "", err
 	}
-	return filepath.Rel(symlinkAbsDir, target)
+	if strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf("path %v is not under %v", path, base)
+	}
+	return rel, nil
 }
 
-// preprocessSymlink returns two things: if the routine should continue, and if
-// there is an error to be reported back.
-func preprocessSymlink(execRoot, symlinkNormDir string, meta *filemetadata.SymlinkMetadata, opts *TreeSymlinkOpts) (bool, error) {
-	if meta.IsDangling {
-		// For now, we do not treat a dangling symlink as an error. In the case
-		// where the symlink is not preserved (i.e. needs to be converted to a
-		// file), we simply ignore this path in the finalized tree.
-		return opts.Preserved, nil
-	}
-	if !opts.Preserved {
-		// We will convert the symlink to a normal file, so it doesn't matter
-		// where target is under execRoot or not.
-		return true, nil
+// getTargetRelPath returns both the target's path relative to exec root
+// and relative to the symlink's dir, iff the target is under execRoot.
+// Otherwise it returns an error.
+func getTargetRelPath(execRoot, path string, symMeta *filemetadata.SymlinkMetadata) (relExecRoot string, relSymlinkDir string, err error) {
+	symlinkAbsDir := filepath.Join(execRoot, filepath.Dir(path))
+	target := symMeta.Target
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(symlinkAbsDir, target)
 	}
 
-	if _, err := getTargetRelPath(execRoot, symlinkNormDir, meta.Target); err != nil {
-		return false, err
+	relExecRoot, err = getRelPath(execRoot, target)
+	if err != nil {
+		return "", "", err
 	}
-	return true, nil
+
+	relSymlinkDir, err = filepath.Rel(symlinkAbsDir, target)
+	return relExecRoot, relSymlinkDir, err
 }
 
 // loadFiles reads all files specified by the given InputSpec (descending into subdirectories
 // recursively), and loads their contents into the provided map.
-func loadFiles(execRoot string, excl []*command.InputExclusion, path string, fs map[string]*fileSysNode, cache filemetadata.Cache, opts *TreeSymlinkOpts) error {
+func loadFiles(execRoot string, excl []*command.InputExclusion, filesToProcess []string, fs map[string]*fileSysNode, cache filemetadata.Cache, opts *TreeSymlinkOpts) error {
 	if opts == nil {
 		opts = DefaultTreeSymlinkOpts()
 	}
-	absPath := filepath.Clean(filepath.Join(execRoot, path))
-	meta := cache.Get(absPath)
-	isSymlink := meta.Symlink != nil
-	t := command.FileInputType
-	if isSymlink && opts.Preserved {
+
+	for len(filesToProcess) != 0 {
+		path := filesToProcess[0]
+		filesToProcess = filesToProcess[1:]
+
+		if path == "" {
+			return errors.New("empty Input, use \".\" for entire exec root")
+		}
+
+		absPath := filepath.Join(execRoot, path)
+
+		meta := cache.Get(absPath)
+
+		normPath, err := getRelPath(execRoot, absPath)
+		if err != nil {
+			return err
+		}
+
+		switch {
 		// An implication of this is that, if a path is a symlink to a
 		// directory, then the symlink attribute takes precedence.
-		t = command.SymlinkInputType
-	} else if meta.IsDirectory {
-		t = command.DirectoryInputType
-	}
-	if shouldIgnore(absPath, t, excl) {
-		return nil
-	}
-	normPath, err := getRelPath(execRoot, absPath)
-	if err != nil {
-		return err
-	}
-	symlinkNormDir := ""
-	if isSymlink {
-		symlinkNormDir = filepath.Dir(normPath)
-		cont, err := preprocessSymlink(execRoot, symlinkNormDir, meta.Symlink, opts)
-		if err != nil {
-			return err
-		}
-		if !cont {
-			return nil
-		}
-	} else if meta.Err != nil {
-		return meta.Err
-	}
-	if t == command.FileInputType {
-		fs[normPath] = &fileSysNode{
-			file: &fileNode{
-				ue:           uploadinfo.EntryFromFile(meta.Digest, absPath),
-				isExecutable: meta.IsExecutable,
-			},
-		}
-		return nil
-	} else if t == command.SymlinkInputType {
-		relTarget, err := getTargetRelPath(execRoot, symlinkNormDir, meta.Symlink.Target)
-		if err != nil {
-			return err
-		}
-		fs[normPath] = &fileSysNode{
-			// We cannot directly use meta.Symlink.Target, because it could be
-			// an absolute path. Since the remote worker will map the exec root
-			// to a different directory, we must strip away the local exec root.
-			// See https://github.com/bazelbuild/remote-apis-sdks/pull/229#discussion_r524830458
-			symlink: &symlinkNode{target: relTarget},
-		}
-		if meta.Symlink.IsDangling || !opts.FollowsTarget {
-			return nil
-		}
-		return loadFiles(execRoot, excl, filepath.Clean(filepath.Join(symlinkNormDir, relTarget)), fs, cache, opts)
-	}
-	// Directory
-	files, err := ioutil.ReadDir(absPath)
-	if err != nil {
-		return err
-	}
+		case meta.Symlink != nil && meta.Symlink.IsDangling && !opts.Preserved:
+			// For now, we do not treat a dangling symlink as an error. In the case
+			// where the symlink is not preserved (i.e. needs to be converted to a
+			// file), we simply ignore this path in the finalized tree.
+			continue
+		case meta.Symlink != nil && opts.Preserved:
+			if shouldIgnore(absPath, command.SymlinkInputType, excl) {
+				continue
+			}
+			targetExecRoot, targetSymDir, err := getTargetRelPath(execRoot, normPath, meta.Symlink)
+			if err != nil {
+				return err
+			}
 
-	if len(files) == 0 {
-		fs[normPath] = &fileSysNode{emptyDirectoryMarker: true}
-		return nil
-	}
-	for _, f := range files {
-		if e := loadFiles(execRoot, excl, filepath.Join(normPath, f.Name()), fs, cache, opts); e != nil {
-			return e
+			fs[normPath] = &fileSysNode{
+				// We cannot directly use meta.Symlink.Target, because it could be
+				// an absolute path. Since the remote worker will map the exec root
+				// to a different directory, we must strip away the local exec root.
+				// See https://github.com/bazelbuild/remote-apis-sdks/pull/229#discussion_r524830458
+				symlink: &symlinkNode{target: targetSymDir},
+			}
+
+			if !meta.Symlink.IsDangling && opts.FollowsTarget {
+				// getTargetRelPath validates this target is under execRoot,
+				// and the iteration loop will get the relative path to execRoot,
+				filesToProcess = append(filesToProcess, targetExecRoot)
+			}
+		case meta.IsDirectory:
+			if shouldIgnore(absPath, command.DirectoryInputType, excl) {
+				continue
+			} else if meta.Err != nil {
+				return meta.Err
+			}
+
+			f, err := os.Open(absPath)
+			if err != nil {
+				return err
+			}
+
+			files, err := f.Readdirnames(-1)
+			f.Close()
+			if err != nil {
+				return err
+			}
+
+			if len(files) == 0 {
+				fs[normPath] = &fileSysNode{emptyDirectoryMarker: true}
+				continue
+			}
+			for _, f := range files {
+				filesToProcess = append(filesToProcess, filepath.Join(normPath, f))
+			}
+		default:
+			if shouldIgnore(absPath, command.FileInputType, excl) {
+				continue
+			} else if meta.Err != nil {
+				return meta.Err
+			}
+
+			fs[normPath] = &fileSysNode{
+				file: &fileNode{
+					ue:           uploadinfo.EntryFromFile(meta.Digest, absPath),
+					isExecutable: meta.IsExecutable,
+				},
+			}
 		}
 	}
 	return nil
@@ -210,7 +223,7 @@ func (c *Client) ComputeMerkleTree(execRoot string, is *command.InputSpec, cache
 			return digest.Empty, nil, nil, errors.New("empty Path in VirtualInputs")
 		}
 		path := i.Path
-		absPath := filepath.Clean(filepath.Join(execRoot, path))
+		absPath := filepath.Join(execRoot, path)
 		normPath, err := getRelPath(execRoot, absPath)
 		if err != nil {
 			return digest.Empty, nil, nil, err
@@ -226,13 +239,9 @@ func (c *Client) ComputeMerkleTree(execRoot string, is *command.InputSpec, cache
 			},
 		}
 	}
-	for _, i := range is.Inputs {
-		if i == "" {
-			return digest.Empty, nil, nil, errors.New("empty Input, use \".\" for entire exec root")
-		}
-		if e := loadFiles(execRoot, is.InputExclusions, i, fs, cache, c.TreeSymlinkOpts); e != nil {
-			return digest.Empty, nil, nil, e
-		}
+
+	if e := loadFiles(execRoot, is.InputExclusions, is.Inputs, fs, cache, c.TreeSymlinkOpts); e != nil {
+		return digest.Empty, nil, nil, e
 	}
 	ft := buildTree(fs)
 	var blobs map[digest.Digest]*uploadinfo.Entry
@@ -453,14 +462,6 @@ func packageDirectories(t *treeNode) (root *repb.Directory, children map[digest.
 	return root, children, files, nil
 }
 
-func getRelPath(base, path string) (string, error) {
-	rel, err := filepath.Rel(base, path)
-	if err != nil || strings.HasPrefix(rel, "..") {
-		return "", fmt.Errorf("path %v is not under %v", path, base)
-	}
-	return rel, nil
-}
-
 // ComputeOutputsToUpload transforms the provided local output paths into uploadable Chunkers.
 // The paths have to be relative to execRoot.
 // It also populates the remote ActionResult, packaging output directories as trees where required.
@@ -468,7 +469,7 @@ func (c *Client) ComputeOutputsToUpload(execRoot string, paths []string, cache f
 	outs := make(map[digest.Digest]*uploadinfo.Entry)
 	resPb := &repb.ActionResult{}
 	for _, path := range paths {
-		absPath := filepath.Clean(filepath.Join(execRoot, path))
+		absPath := filepath.Join(execRoot, path)
 		normPath, err := getRelPath(execRoot, absPath)
 		if err != nil {
 			return nil, nil, err
@@ -489,7 +490,7 @@ func (c *Client) ComputeOutputsToUpload(execRoot string, paths []string, cache f
 		}
 		// A directory.
 		fs := make(map[string]*fileSysNode)
-		if e := loadFiles(absPath, nil, "", fs, cache, c.TreeSymlinkOpts); e != nil {
+		if e := loadFiles(absPath, nil, []string{"."}, fs, cache, c.TreeSymlinkOpts); e != nil {
 			return nil, nil, e
 		}
 		ft := buildTree(fs)

--- a/go/pkg/client/tree_whitebox_test.go
+++ b/go/pkg/client/tree_whitebox_test.go
@@ -1,75 +1,85 @@
 package client
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/filemetadata"
+)
 
 func TestGetTargetRelPath(t *testing.T) {
 	execRoot := "/execRoot"
-	defaultSymlinkNormDir := "symDir"
+	defaultSym := "symDir/sym"
 	tests := []struct {
-		desc           string
-		symlinkNormDir string
-		target         string
-		wantErr        bool
-		relTarget      string
+		desc            string
+		path            string
+		symMeta         *filemetadata.SymlinkMetadata
+		wantErr         bool
+		wantRelExecRoot string
+		wantRelSymDir   string
 	}{
 		{
-			desc:           "basic",
-			symlinkNormDir: defaultSymlinkNormDir,
-			target:         "foo",
-			relTarget:      "foo",
+			desc:            "basic",
+			path:            defaultSym,
+			symMeta:         &filemetadata.SymlinkMetadata{Target: "foo"},
+			wantRelExecRoot: "symDir/foo",
+			wantRelSymDir:   "foo",
 		},
 		{
-			desc:           "relative target path under exec root",
-			symlinkNormDir: defaultSymlinkNormDir,
+			desc: "relative target path under exec root",
+			path: defaultSym,
 			// /execRoot/symDir/../dir/foo ==> /execRoot/dir/foo
-			target:    "../dir/foo",
-			relTarget: "../dir/foo",
+			symMeta:         &filemetadata.SymlinkMetadata{Target: "../dir/foo"},
+			wantRelExecRoot: "dir/foo",
+			wantRelSymDir:   "../dir/foo",
 		},
 		{
-			desc:           "relative target path escaping exec root",
-			symlinkNormDir: defaultSymlinkNormDir,
+			desc: "relative target path escaping exec root",
+			path: defaultSym,
 			// /execRoot/symDir/../../foo ==> /foo
-			target:  "../../foo",
+			symMeta: &filemetadata.SymlinkMetadata{Target: "../../foo"},
 			wantErr: true,
 		},
 		{
-			desc:           "deeper relative target path",
-			symlinkNormDir: "base/sub",
+			desc: "deeper relative target path",
+			path: "base/sub/sym",
 			// /execRoot/base/sub/../../foo ==> /execRoot/foo
-			target:    "../../foo",
-			relTarget: "../../foo",
+			symMeta:         &filemetadata.SymlinkMetadata{Target: "../../foo"},
+			wantRelExecRoot: "foo",
+			wantRelSymDir:   "../../foo",
 		},
 		{
-			desc:           "absolute target path under exec root",
-			symlinkNormDir: "base",
-			target:         execRoot + "/base/foo",
-			relTarget:      "foo",
+			desc:            "absolute target path under exec root",
+			path:            "base/sym",
+			symMeta:         &filemetadata.SymlinkMetadata{Target: execRoot + "/base/foo"},
+			wantRelExecRoot: "base/foo",
+			wantRelSymDir:   "foo",
 		},
 		{
-			desc:           "abs target to rel target",
-			symlinkNormDir: "base/sub1/sub2",
-			target:         execRoot + "/dir/foo",
+			desc:    "abs target to rel target",
+			path:    "base/sub1/sub2/sym",
+			symMeta: &filemetadata.SymlinkMetadata{Target: execRoot + "/dir/foo"},
 			// symlinkAbsDir: /execRoot/base/sub1/sub2
 			// targetAbs: /execRoot/dir/foo
 			// target rel to symlink: ../../../dir/foo
-			relTarget: "../../../dir/foo",
+			wantRelExecRoot: "dir/foo",
+			wantRelSymDir:   "../../../dir/foo",
 		},
 		{
-			desc:           "absolute target path escaping exec root",
-			symlinkNormDir: defaultSymlinkNormDir,
-			target:         "/another/dir/foo",
-			wantErr:        true,
+			desc:    "absolute target path escaping exec root",
+			path:    defaultSym,
+			symMeta: &filemetadata.SymlinkMetadata{Target: "/another/dir/foo"},
+			wantErr: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			res, err := getTargetRelPath(execRoot, tc.symlinkNormDir, tc.target)
+			relExecRoot, relSymDir, err := getTargetRelPath(execRoot, tc.path, tc.symMeta)
 			if (err != nil) != tc.wantErr {
-				t.Errorf("getTargetRelPath(target=%q) error: expected=%v got=%v", tc.target, tc.wantErr, err)
+				t.Errorf("getTargetRelPath(path=%q) error: expected=%v got=%v", tc.path, tc.wantErr, err)
 			}
-			if err == nil && res != tc.relTarget {
-				t.Errorf("getTargetRelPath(target=%q) result: expected=%v got=%v", tc.target, tc.relTarget, res)
+			if err == nil && (relExecRoot != tc.wantRelExecRoot || relSymDir != tc.wantRelSymDir) {
+				t.Errorf("getTargetRelPath(path=%q) result: expected=(%v,%v) got=(%v,%v)", tc.path, tc.wantRelExecRoot, tc.wantRelSymDir, relExecRoot, relSymDir)
 			}
 		})
 	}

--- a/go/pkg/fakes/exec.go
+++ b/go/pkg/fakes/exec.go
@@ -38,13 +38,13 @@ type Exec struct {
 	// Number of Execute calls.
 	numExecCalls int
 	// Used for errors.
-	t *testing.T
+	t testing.TB
 	// The digest of the fake action.
 	adg digest.Digest
 }
 
 // NewExec returns a new empty Exec.
-func NewExec(t *testing.T, ac *ActionCache, cas *CAS) *Exec {
+func NewExec(t testing.TB, ac *ActionCache, cas *CAS) *Exec {
 	c := &Exec{t: t, ac: ac, cas: cas}
 	c.Clear()
 	return c

--- a/go/pkg/fakes/server.go
+++ b/go/pkg/fakes/server.go
@@ -40,7 +40,7 @@ type Server struct {
 }
 
 // NewServer creates a server that is ready to accept requests.
-func NewServer(t *testing.T) (s *Server, err error) {
+func NewServer(t testing.TB) (s *Server, err error) {
 	cas := NewCAS()
 	ac := NewActionCache()
 	s = &Server{Exec: NewExec(t, ac, cas), CAS: cas, ActionCache: ac}
@@ -84,13 +84,13 @@ type TestEnv struct {
 	Client   *rexec.Client
 	Server   *Server
 	ExecRoot string
-	t        *testing.T
+	t        testing.TB
 }
 
 // NewTestEnv initializes a TestEnv containing a fake server, a client connected to it,
 // and a temporary directory used as execution root for inputs and outputs.
 // It returns the new env and a cleanup function that should be called in the end of the test.
-func NewTestEnv(t *testing.T) (*TestEnv, func()) {
+func NewTestEnv(t testing.TB) (*TestEnv, func()) {
 	t.Helper()
 	// Set up temp directory.
 	execRoot, err := ioutil.TempDir("", strings.ReplaceAll(t.Name(), string(filepath.Separator), "_"))


### PR DESCRIPTION
This gets rid of a few bottlenecks:

1. Recursion -> iteration. I'm not sure how much of a bottleneck this is, 
but in practice recursion is much more expensive than iteration.                                                                                                                                                                                                                    
2. Replace ioutil.ReadDir, which will both sort and stat files, so
unnecessarily slow.                                                                                                                                                                                                                                                                 
3. Remove lots of filepath operations, including Cleans. All the Cleans
we called were redundant with filepath pkg which calls Clean
or a lot of its functions.

As a side note, for future improvements on loadFiles, it may be worth
it to skip on some filepath functions. Per pprof analysis, 20% of CPU
time is still spent on Clean functions which are automatically called.

I've also taken the chance to refactor loadFiles into something
more readable IMO. This does add a bit of code dupping (specifically,
shouldIgnore and meta.Err checks), but the different handlings
are more explicit.

I've tried this on GCP e2-standard-8 machines and these changes make
Compute a Merkle Tree for an entire chrome build take about ~50% of
the time (~50s instead of ~100s), working in a single thread. Weirdly,
changing pd-standard vs pd-ssd doesn't seem to make a difference.