### PR TITLE
[cas] Add cas package skeleton

### DIFF
--- a/go/pkg/cas/client.go
+++ b/go/pkg/cas/client.go
@@ -1,4 +1,4 @@
-// Package cas implements efficient client for Content Addressable Storage.
+// Package cas implements an efficient client for Content Addressable Storage.
 package cas
 
 import (

--- a/go/pkg/cas/client.go
+++ b/go/pkg/cas/client.go
@@ -1,0 +1,96 @@
+// Package cas implements efficient client for Content Addressable Storage.
+package cas
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	bspb "google.golang.org/genproto/googleapis/bytestream"
+	"google.golang.org/grpc"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/client"
+	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+)
+
+// Client is a client for Content Addressable Storage.
+// Create one using NewClient.
+//
+// Goroutine-safe.
+//
+// All fields are considered immutable, and should not be changed.
+type Client struct {
+	// InstanceName is the full name of the RBE instance.
+	InstanceName string
+
+	// ClientConfig is the configuration that the client was created with.
+	ClientConfig
+
+	conn       *grpc.ClientConn
+	byteStream bspb.ByteStreamClient
+	cas        repb.ContentAddressableStorageClient
+}
+
+// ClientConfig is a config for Client.
+// See DefaultClientConfig() for the default values.
+type ClientConfig struct {
+	DialParams client.DialParams
+
+	// TODO(nodir): add conifg values here.
+	// TODO(nodir): add per-RPC timeouts.
+	// TODO(nodir): add retries.
+}
+
+// DefaultClientConfig returns the default config.
+//
+// To override a specific value:
+//   cfg := DefaultClientConfig()
+//   ... mutate cfg ...
+//   client, err := NewClientWithConfig(ctx, cfg)
+func DefaultClientConfig() ClientConfig {
+	return ClientConfig{
+		DialParams: client.DialParams{
+			Service: "remotebuildexecution.googleapis.com:443",
+		},
+	}
+}
+
+// Validate returns a non-nil error if the config is invalid.
+func (c *ClientConfig) Validate() error {
+	if c.DialParams.Service == "" {
+		return errors.Errorf("DialParams.Service is unspecified")
+	}
+
+	return nil
+}
+
+// NewClient creates a new client with the default configuration.
+func NewClient(ctx context.Context, instanceName string) (*Client, error) {
+	return NewClientWithConfig(ctx, instanceName, DefaultClientConfig())
+}
+
+// NewClientWithConfig creates a new client and accepts a configuration.
+func NewClientWithConfig(ctx context.Context, instanceName string, config ClientConfig) (*Client, error) {
+	if instanceName == "" {
+		return nil, fmt.Errorf("instance name is unspecified")
+	}
+	if err := config.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid config")
+	}
+
+	conn, err := client.Dial(ctx, config.DialParams.Service, config.DialParams)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to dial")
+	}
+
+	client := &Client{
+		InstanceName: instanceName,
+		ClientConfig: config,
+		conn:         conn,
+		byteStream:   bspb.NewByteStreamClient(conn),
+		cas:          repb.NewContentAddressableStorageClient(conn),
+	}
+
+	// TODO(nodir): Check capabilities.
+	return client, nil
+}

--- a/go/pkg/cas/client.go
+++ b/go/pkg/cas/client.go
@@ -20,10 +20,10 @@ import (
 //
 // All fields are considered immutable, and should not be changed.
 type Client struct {
-	// InstanceName is the full name of the RBE instance.
+	// The full name of the RBE instance.
 	InstanceName string
 
-	// ClientConfig is the configuration that the client was created with.
+	// The configuration that the client was created with.
 	ClientConfig
 
 	conn       *grpc.ClientConn

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -1,0 +1,42 @@
+package cas
+
+import "context"
+
+// Upload uploads all inputs. It exits when inputC is closed or ctx is canceled.
+func (c *Client) Upload(ctx context.Context, inputC <-chan *UploadInput) (stats *TransferStats, err error) {
+	// TODO(nodir): implement.
+	panic("not implemented")
+}
+
+// UploadInput is one of inputs to Client.Upload function.
+//
+// It can be either a reference to a file (see Path) or an in-memory blob (see
+// Content).
+type UploadInput struct {
+	// Path is the file or a directory to upload.
+	// If empty, the Content is uploaded instead.
+	Path string
+
+	// Content is the contents to upload.
+	// Ignored if Path is not empty.
+	Content []byte
+
+	// TODO(nodir): add Predicate.
+	// TODO(nodir): add AllowDanglingSymlinks
+	// TODO(nodir): add PreserveSymlinks.
+}
+
+// TransferStats is upload/download statistics.
+type TransferStats struct {
+	CacheHits   DigestStat
+	CacheMisses DigestStat
+
+	Streamed DigestStat // streamed transfers
+	Batched  DigestStat // batched transfers
+}
+
+// DigestStat is aggregated statistics over a set of digests.
+type DigestStat struct {
+	Digests int64 // number of unique digests
+	Bytes   int64 // total sum of of digest sizes
+}

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -10,8 +10,8 @@ func (c *Client) Upload(ctx context.Context, inputC <-chan *UploadInput) (stats 
 
 // UploadInput is one of inputs to Client.Upload function.
 //
-// It can be either a reference to a file (see Path) or an in-memory blob (see
-// Content).
+// It can be either a reference to a file/dir (see Path) or it can be an
+// in-memory blob (see Content).
 type UploadInput struct {
 	// Path is the file or a directory to upload.
 	// If empty, the Content is uploaded instead.

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -13,11 +13,11 @@ func (c *Client) Upload(ctx context.Context, inputC <-chan *UploadInput) (stats 
 // It can be either a reference to a file/dir (see Path) or it can be an
 // in-memory blob (see Content).
 type UploadInput struct {
-	// Path is the file or a directory to upload.
+	// Path to the file or a directory to upload.
 	// If empty, the Content is uploaded instead.
 	Path string
 
-	// Content is the contents to upload.
+	// Contents to upload.
 	// Ignored if Path is not empty.
 	Content []byte
 


### PR DESCRIPTION
[cas] Add cas package skeleton

Add cas.Client with a structure, but without actual implementation.
The TODOs will be implemented in subsequent CLs and in parallel.

Unlike client package, NewClient() function in this package does not
option. Rationale:
- the "options" approach pollutes the godoc page: a new type,
  its Apply() function, the DefaultXXX constant.
  In contrast, a simple Config struct is much more compact and has
  minimal footprint on the number of symbols in the godoc page.
- GCP libraries use the approach used in this package
  - https://pkg.go.dev/cloud.google.com/go/spanner#NewClientWithConfig
  - https://pkg.go.dev/cloud.google.com/go/bigtable#NewClientWithConfig
  - the options approach is used only for common options