### PR TITLE
[cas] Add cas package

### DIFF
--- a/go/pkg/cas/client.go
+++ b/go/pkg/cas/client.go
@@ -9,7 +9,6 @@ import (
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	"google.golang.org/grpc"
 
-	"github.com/bazelbuild/remote-apis-sdks/go/pkg/client"
 	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 )
 
@@ -20,13 +19,13 @@ import (
 //
 // All fields are considered immutable, and should not be changed.
 type Client struct {
+	conn *grpc.ClientConn
 	// The full name of the RBE instance.
 	InstanceName string
 
 	// The configuration that the client was created with.
 	ClientConfig
 
-	conn       *grpc.ClientConn
 	byteStream bspb.ByteStreamClient
 	cas        repb.ContentAddressableStorageClient
 }
@@ -34,16 +33,6 @@ type Client struct {
 // ClientConfig is a config for Client.
 // See DefaultClientConfig() for the default values.
 type ClientConfig struct {
-	// The connection to RBE to use.
-	//
-	// WARNING: setting this field overrides DialParams completely - DialParams
-	// will be ignored.
-	Conn *grpc.ClientConn
-
-	// Parameters to create a connection.
-	// Ignored if Conn is not nill.
-	DialParams *client.DialParams
-
 	// TODO(nodir): add conifg values here.
 	// TODO(nodir): add per-RPC timeouts.
 	// TODO(nodir): add retries.
@@ -56,52 +45,29 @@ type ClientConfig struct {
 //   ... mutate cfg ...
 //   client, err := NewClientWithConfig(ctx, cfg)
 func DefaultClientConfig() ClientConfig {
-	return ClientConfig{
-		DialParams: &client.DialParams{
-			Service: "remotebuildexecution.googleapis.com:443",
-		},
-	}
+	return ClientConfig{}
 }
 
 // Validate returns a non-nil error if the config is invalid.
 func (c *ClientConfig) Validate() error {
-	if c.Conn == nil {
-		// Validate DialParams only if Conn is not specified.
-		switch {
-		case c.DialParams == nil:
-			return errors.Errorf("DialParams is unspecified")
-		case c.DialParams.Service == "":
-			return errors.Errorf("DialParams.Service is unspecified")
-		}
-	}
-
 	return nil
 }
 
 // NewClient creates a new client with the default configuration.
-func NewClient(ctx context.Context, instanceName string) (*Client, error) {
-	return NewClientWithConfig(ctx, instanceName, DefaultClientConfig())
+// Use client.Dial to create a connection.
+func NewClient(ctx context.Context, conn *grpc.ClientConn, instanceName string) (*Client, error) {
+	return NewClientWithConfig(ctx, conn, instanceName, DefaultClientConfig())
 }
 
 // NewClientWithConfig creates a new client and accepts a configuration.
-func NewClientWithConfig(ctx context.Context, instanceName string, config ClientConfig) (*Client, error) {
-	if instanceName == "" {
-		return nil, fmt.Errorf("instance name is unspecified")
-	}
-	if err := config.Validate(); err != nil {
+func NewClientWithConfig(ctx context.Context, conn *grpc.ClientConn, instanceName string, config ClientConfig) (*Client, error) {
+	switch err := config.Validate(); {
+	case err != nil:
 		return nil, errors.Wrap(err, "invalid config")
-	}
-
-	conn := config.Conn
-	if conn != nil {
-		// Forcefully clear DialParams to avoid possible confusion in runtime
-		// by having both Conn and DialParams set in Client.ClientConfig.
-		config.DialParams = nil
-	} else {
-		var err error
-		if conn, err = client.Dial(ctx, config.DialParams.Service, *config.DialParams); err != nil {
-			return nil, errors.Wrap(err, "failed to dial")
-		}
+	case conn == nil:
+		return nil, fmt.Errorf("conn is unspecified")
+	case instanceName == "":
+		return nil, fmt.Errorf("instance name is unspecified")
 	}
 
 	client := &Client{

--- a/go/pkg/cas/client.go
+++ b/go/pkg/cas/client.go
@@ -1,0 +1,96 @@
+// Package cas implements an efficient client for Content Addressable Storage.
+package cas
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	bspb "google.golang.org/genproto/googleapis/bytestream"
+	"google.golang.org/grpc"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/client"
+	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+)
+
+// Client is a client for Content Addressable Storage.
+// Create one using NewClient.
+//
+// Goroutine-safe.
+//
+// All fields are considered immutable, and should not be changed.
+type Client struct {
+	// The full name of the RBE instance.
+	InstanceName string
+
+	// The configuration that the client was created with.
+	ClientConfig
+
+	conn       *grpc.ClientConn
+	byteStream bspb.ByteStreamClient
+	cas        repb.ContentAddressableStorageClient
+}
+
+// ClientConfig is a config for Client.
+// See DefaultClientConfig() for the default values.
+type ClientConfig struct {
+	DialParams client.DialParams
+
+	// TODO(nodir): add conifg values here.
+	// TODO(nodir): add per-RPC timeouts.
+	// TODO(nodir): add retries.
+}
+
+// DefaultClientConfig returns the default config.
+//
+// To override a specific value:
+//   cfg := DefaultClientConfig()
+//   ... mutate cfg ...
+//   client, err := NewClientWithConfig(ctx, cfg)
+func DefaultClientConfig() ClientConfig {
+	return ClientConfig{
+		DialParams: client.DialParams{
+			Service: "remotebuildexecution.googleapis.com:443",
+		},
+	}
+}
+
+// Validate returns a non-nil error if the config is invalid.
+func (c *ClientConfig) Validate() error {
+	if c.DialParams.Service == "" {
+		return errors.Errorf("DialParams.Service is unspecified")
+	}
+
+	return nil
+}
+
+// NewClient creates a new client with the default configuration.
+func NewClient(ctx context.Context, instanceName string) (*Client, error) {
+	return NewClientWithConfig(ctx, instanceName, DefaultClientConfig())
+}
+
+// NewClientWithConfig creates a new client and accepts a configuration.
+func NewClientWithConfig(ctx context.Context, instanceName string, config ClientConfig) (*Client, error) {
+	if instanceName == "" {
+		return nil, fmt.Errorf("instance name is unspecified")
+	}
+	if err := config.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid config")
+	}
+
+	conn, err := client.Dial(ctx, config.DialParams.Service, config.DialParams)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to dial")
+	}
+
+	client := &Client{
+		InstanceName: instanceName,
+		ClientConfig: config,
+		conn:         conn,
+		byteStream:   bspb.NewByteStreamClient(conn),
+		cas:          repb.NewContentAddressableStorageClient(conn),
+	}
+
+	// TODO(nodir): Check capabilities.
+	return client, nil
+}

--- a/go/pkg/cas/client.go
+++ b/go/pkg/cas/client.go
@@ -35,7 +35,9 @@ type Client struct {
 // See DefaultClientConfig() for the default values.
 type ClientConfig struct {
 	// The connection to RBE to use.
-	// Overrides DialParams.
+	//
+	// WARNING: setting this field overrides DialParams completely - DialParams
+	// will be ignored.
 	Conn *grpc.ClientConn
 
 	// Parameters to create a connection.

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -1,0 +1,42 @@
+package cas
+
+import "context"
+
+// Upload uploads all inputs. It exits when inputC is closed or ctx is canceled.
+func (c *Client) Upload(ctx context.Context, inputC <-chan *UploadInput) (stats *TransferStats, err error) {
+	// TODO(nodir): implement.
+	panic("not implemented")
+}
+
+// UploadInput is one of inputs to Client.Upload function.
+//
+// It can be either a reference to a file/dir (see Path) or it can be an
+// in-memory blob (see Content).
+type UploadInput struct {
+	// Path to the file or a directory to upload.
+	// If empty, the Content is uploaded instead.
+	Path string
+
+	// Contents to upload.
+	// Ignored if Path is not empty.
+	Content []byte
+
+	// TODO(nodir): add Predicate.
+	// TODO(nodir): add AllowDanglingSymlinks
+	// TODO(nodir): add PreserveSymlinks.
+}
+
+// TransferStats is upload/download statistics.
+type TransferStats struct {
+	CacheHits   DigestStat
+	CacheMisses DigestStat
+
+	Streamed DigestStat // streamed transfers
+	Batched  DigestStat // batched transfers
+}
+
+// DigestStat is aggregated statistics over a set of digests.
+type DigestStat struct {
+	Digests int64 // number of unique digests
+	Bytes   int64 // total sum of of digest sizes
+}

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -9,6 +9,8 @@ import "context"
 type UploadInput struct {
 	// Path to the file or a directory to upload.
 	// If empty, the Content is uploaded instead.
+	//
+	// Must be absolute or relative to CWD.
 	Path string
 
 	// Contents to upload.

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -2,12 +2,6 @@ package cas
 
 import "context"
 
-// Upload uploads all inputs. It exits when inputC is closed or ctx is canceled.
-func (c *Client) Upload(ctx context.Context, inputC <-chan *UploadInput) (stats *TransferStats, err error) {
-	// TODO(nodir): implement.
-	panic("not implemented")
-}
-
 // UploadInput is one of inputs to Client.Upload function.
 //
 // It can be either a reference to a file/dir (see Path) or it can be an
@@ -39,4 +33,10 @@ type TransferStats struct {
 type DigestStat struct {
 	Digests int64 // number of unique digests
 	Bytes   int64 // total sum of of digest sizes
+}
+
+// Upload uploads all inputs. It exits when inputC is closed or ctx is canceled.
+func (c *Client) Upload(ctx context.Context, inputC <-chan *UploadInput) (stats *TransferStats, err error) {
+	// TODO(nodir): implement.
+	panic("not implemented")
 }


### PR DESCRIPTION
Add cas.Client with a structure, but without actual implementation.
The TODOs will be implemented in subsequence CLs and in parallel.

Unlike client package, NewClient() function in this package does not
option. Rationale:
- the "options" approach pollutes the godoc page: a new type,
  its Apply() function, the DefaultXXX constant.
  In contrast, a simple Config struct is much more compact and has
  minimal footprint on the number of symbols in the godoc page.
- GCP libraries use the approach used in this package
  - https://pkg.go.dev/cloud.google.com/go/spanner#NewClientWithConfig
  - https://pkg.go.dev/cloud.google.com/go/bigtable#NewClientWithConfig
  - the options approach is used only for common options