### PR TITLE
Simplify caching packages

### DIFF
--- a/go/pkg/cache/cache.go
+++ b/go/pkg/cache/cache.go
@@ -25,11 +25,6 @@ func (c *Cache) Reset(ns string) {
 	c.caches.Delete(ns)
 }
 
-// ResetAll resets the cache.
-func (c *Cache) ResetAll() {
-	*c = Cache{}
-}
-
 func (c *Cache) getNSCache(ns string) *singleflightcache.Cache {
 	// Load first to avoid instantiating a new cache for LoadOrStore.
 	nsCache, ok := c.caches.Load(ns)

--- a/go/pkg/cache/cache.go
+++ b/go/pkg/cache/cache.go
@@ -2,7 +2,6 @@
 package cache
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/cache/singleflightcache"
@@ -10,31 +9,34 @@ import (
 
 // Cache is a cache backend.
 type Cache struct {
-	mu     *sync.RWMutex
-	caches *sync.Map
+	caches sync.Map
 }
 
-var (
-	instance *Cache
-	once     sync.Once
-)
+var instance Cache
 
 // GetInstance retrieves the singleton instance of the cache backend. This is useful in the
 // future to enforce memory bounds on the entire cache usage of a program.
 func GetInstance() *Cache {
-	once.Do(func() {
-		instance = &Cache{
-			mu:     &sync.RWMutex{},
-			caches: &sync.Map{},
-		}
-	})
-	return instance
+	return &instance
 }
 
-// Reset resets the cache.
-func (c *Cache) Reset() {
-	c.mu = &sync.RWMutex{}
-	c.caches = &sync.Map{}
+// Reset resets the cache in one namespace.
+func (c *Cache) Reset(ns string) {
+	c.caches.Delete(ns)
+}
+
+// ResetAll resets the cache.
+func (c *Cache) ResetAll() {
+	*c = Cache{}
+}
+
+func (c *Cache) getNSCache(ns string) *singleflightcache.Cache {
+	// Load first to avoid instantiating a new cache for LoadOrStore.
+	nsCache, ok := c.caches.Load(ns)
+	if !ok {
+		nsCache, _ = c.caches.LoadOrStore(ns, &singleflightcache.Cache{})
+	}
+	return nsCache.(*singleflightcache.Cache)
 }
 
 // LoadOrStore attempts to first read a value from the corresponding cache namespace. If no entry
@@ -42,45 +44,17 @@ func (c *Cache) Reset() {
 // callers of LoadOrStore on the same namespace and key will execute fn once. This is to avoid
 // costly redundant work to compute the value to store in cache.
 func (c *Cache) LoadOrStore(ns string, key interface{}, fn func() (interface{}, error)) (interface{}, error) {
-	// Load first to avoid instantiating a new cache for LoadOrStore.
-	nsCache, ok := c.caches.Load(ns)
-	if !ok {
-		nsCache, _ = c.caches.LoadOrStore(ns, &singleflightcache.Cache{})
-	}
-	cache, ok := nsCache.(*singleflightcache.Cache)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type in namespace cache map")
-	}
-	return cache.LoadOrStore(key, fn)
+	return c.getNSCache(ns).LoadOrStore(key, fn)
 }
 
 // Store is similar to LoadOrStore, except it does not check if a cache entry
 // already exists for the given key and simply overwrites the value of the key
 // in the cache with the given value.
-func (c *Cache) Store(ns string, key interface{}, val interface{}) error {
-	// Load first to avoid instantiating a new cache for LoadOrStore.
-	nsCache, ok := c.caches.Load(ns)
-	if !ok {
-		nsCache, _ = c.caches.LoadOrStore(ns, &singleflightcache.Cache{})
-	}
-	cache, ok := nsCache.(*singleflightcache.Cache)
-	if !ok {
-		return fmt.Errorf("unexpected type in namespace cache map")
-	}
-	return cache.Store(key, val)
+func (c *Cache) Store(ns string, key interface{}, val interface{}) {
+	c.getNSCache(ns).Store(key, val)
 }
 
 // Delete deletes a value corresponding to the given namespace and key.
-func (c *Cache) Delete(ns string, key interface{}) error {
-	// Load first to avoid instantiating a new cache for LoadOrStore.
-	nsCache, ok := c.caches.Load(ns)
-	if !ok {
-		nsCache, _ = c.caches.LoadOrStore(ns, &singleflightcache.Cache{})
-	}
-	cache, ok := nsCache.(*singleflightcache.Cache)
-	if !ok {
-		return fmt.Errorf("unexpected type in namespace cache map")
-	}
-	cache.Delete(key)
-	return nil
+func (c *Cache) Delete(ns string, key interface{}) {
+	c.getNSCache(ns).Delete(key)
 }

--- a/go/pkg/cache/cache_test.go
+++ b/go/pkg/cache/cache_test.go
@@ -15,7 +15,7 @@ const (
 
 func TestMultipleNamespaces(t *testing.T) {
 	c := GetInstance()
-	defer c.Reset()
+	defer c.ResetAll()
 
 	got1, err := c.LoadOrStore(ns1, key1, func() (interface{}, error) { return val1, nil })
 	if err != nil {
@@ -42,7 +42,7 @@ func TestMultipleNamespaces(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	c := GetInstance()
-	defer c.Reset()
+	defer c.ResetAll()
 
 	got1, err := c.LoadOrStore(ns1, key1, func() (interface{}, error) { return val1, nil })
 	if err != nil {
@@ -59,10 +59,7 @@ func TestDelete(t *testing.T) {
 		t.Fatalf("LoadOrStore(%v,%v) loaded wrong value: got %v, want %v", ns2, key1, got2, val2)
 	}
 
-	err = c.Delete(ns1, key1)
-	if err != nil {
-		t.Errorf("Delete(%v,%v) returned error: %v", ns1, key1, err)
-	}
+	c.Delete(ns1, key1)
 
 	got1, err = c.LoadOrStore(ns1, key1, func() (interface{}, error) { return val2, nil })
 	if err != nil {

--- a/go/pkg/cache/cache_test.go
+++ b/go/pkg/cache/cache_test.go
@@ -14,8 +14,7 @@ const (
 )
 
 func TestMultipleNamespaces(t *testing.T) {
-	c := GetInstance()
-	defer c.ResetAll()
+	var c Cache
 
 	got1, err := c.LoadOrStore(ns1, key1, func() (interface{}, error) { return val1, nil })
 	if err != nil {
@@ -41,8 +40,7 @@ func TestMultipleNamespaces(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	c := GetInstance()
-	defer c.ResetAll()
+	var c Cache
 
 	got1, err := c.LoadOrStore(ns1, key1, func() (interface{}, error) { return val1, nil })
 	if err != nil {

--- a/go/pkg/cache/singleflightcache/singleflightcache.go
+++ b/go/pkg/cache/singleflightcache/singleflightcache.go
@@ -5,86 +5,42 @@
 package singleflightcache
 
 import (
-	"fmt"
 	"sync"
 )
 
 // Cache is a cache that supports single-flight value computation.
 type Cache struct {
-	// store is the actual cache where data is stored.
 	store sync.Map
-	// locks is a map of locks per key. This map is used to ensure only one reader/writer of
-	// the key can have write access.
-	locks sync.Map
-	// mu is a mutex to ensure exclusive access to the locks map in the case of Delete.
-	mu sync.RWMutex
+}
+
+type entry struct {
+	compute sync.Once
+	val     interface{}
+	err     error
 }
 
 // LoadOrStore is similar to a sync.Map except that it receives a function that computes the value
 // to store instead of the value directly. It ensures that the function is only executed once for
 // concurrent callers of the LoadOrStore function.
 func (c *Cache) LoadOrStore(key interface{}, valFn func() (interface{}, error)) (interface{}, error) {
-	val, ok := c.store.Load(key)
-	if ok {
-		return val, nil
-	}
-	// Lock the cache for reading to avoid a race condition with Delete.
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	mu := &sync.RWMutex{}
-	mu.Lock()
-	defer mu.Unlock()
-
-	l, loaded := c.locks.LoadOrStore(key, mu)
-	lock, ok := l.(*sync.RWMutex)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type found in lock map")
-	}
-	if loaded {
-		lock.RLock()
-		val, ok := c.store.Load(key)
-		lock.RUnlock()
-		if ok {
-			return val, nil
-		}
-		// If no value is in the cache, then the lock creator failed to set a value. Upgrade
-		// the lock to a write lock and re-attempt to compute the value.
-		lock.Lock()
-		defer lock.Unlock()
-	}
-	val, err := valFn()
-	if err != nil {
-		return nil, err
-	}
-	c.store.Store(key, val)
-	return val, nil
+	eUntyped, _ := c.store.LoadOrStore(key, &entry{})
+	e := eUntyped.(*entry)
+	e.compute.Do(func() {
+		e.val, e.err = valFn()
+	})
+	return e.val, e.err
 }
 
 // Store forcefully updates the given cache key with val. Note that unlike LoadOrStore,
 // Store accepts a value instead of a valFn since it is intended to be only used in
 // cases where updates are lightweight and do not involve computing the cache value.
-func (c *Cache) Store(key interface{}, val interface{}) error {
-	// Lock the cache for reading to avoid a race condition with Delete.
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	l, _ := c.locks.LoadOrStore(key, &sync.RWMutex{})
-	lock, ok := l.(*sync.RWMutex)
-	if !ok {
-		return fmt.Errorf("unexpected type found in lock map")
-	}
-	lock.Lock()
-	defer lock.Unlock()
-	c.store.Store(key, val)
-	return nil
+func (c *Cache) Store(key interface{}, val interface{}) {
+	e := &entry{val: val}
+	e.compute.Do(func() {}) // mark as computed
+	c.store.Store(key, e)
 }
 
 // Delete removes a key from the cache.
 func (c *Cache) Delete(key interface{}) {
-	if _, exists := c.locks.Load(key); exists {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-		c.locks.Delete(key)
-		c.store.Delete(key)
-	}
+	c.store.Delete(key)
 }

--- a/go/pkg/filemetadata/cache.go
+++ b/go/pkg/filemetadata/cache.go
@@ -51,7 +51,8 @@ func (c *fmCache) Delete(filename string) error {
 	if err != nil {
 		return err
 	}
-	return c.Backend.Delete(namespace, abs)
+	c.Backend.Delete(namespace, abs)
+	return nil
 }
 
 // Update updates the cache entry for the filename with the given value.
@@ -60,12 +61,13 @@ func (c *fmCache) Update(filename string, cacheEntry *Metadata) error {
 	if err != nil {
 		return err
 	}
-	return c.Backend.Store(namespace, absFilename, cacheEntry)
+	c.Backend.Store(namespace, absFilename, cacheEntry)
+	return nil
 }
 
 // Reset clears the cache.
 func (c *fmCache) Reset() {
-	c.Backend.Reset()
+	c.Backend.Reset(namespace)
 }
 
 // GetCacheHits returns the number of cache hits.


### PR DESCRIPTION
Simplify and optimize singleflightcache implementation: replace two
sync.Maps and an N+1 sync.RWMutexes, with one sync.Map and N sync.Once.
Do other simplifications as well.

Remove dead code / impossible conditions, e.g. "unexpected type found in
lock map". Use that to simplify the function signatures, e.g. don't
return an error (and thus simplify callsites and tests) when an error
is impossible.

In filemetadata/cache.go, fix the bug that it resets all namespaces.

`cache.Cache.Reset` was inherently racy because it was overwriting a mutex (without holding another mutex).
Replace with safe ns-level resetting.