### PR TITLE
client: deprecate DefaultRPCTimeout

### DIFF
--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -618,7 +618,6 @@ func NewClientFromConnection(ctx context.Context, instanceName string, conn, cas
 		cas:                           regrpc.NewContentAddressableStorageClient(casConn),
 		execution:                     regrpc.NewExecutionClient(conn),
 		operations:                    opgrpc.NewOperationsClient(conn),
-		rpcTimeouts:                   DefaultRPCTimeouts,
 		Connection:                    conn,
 		CASConnection:                 casConn,
 		CompressedBytestreamThreshold: DefaultCompressedBytestreamThreshold,
@@ -665,6 +664,9 @@ func (d RPCTimeouts) Apply(c *Client) {
 	c.rpcTimeouts = map[string]time.Duration(d)
 }
 
+// DefaultRPCTimeouts are timeouts for each RPCs.
+//
+// Deprecated: specify appropriate timeout in each application.
 var DefaultRPCTimeouts = map[string]time.Duration{
 	"default":          20 * time.Second,
 	"GetCapabilities":  5 * time.Second,


### PR DESCRIPTION
Appropriate DefaultRPCTimeout depends how user uses this SDK.
So instead of provide that here, recommend user to specify their own
timeout if it is necessary.

context: http://b/183669037 and https://crbug.com/1189349#c19