### PR TITLE
[cas] Update BUILD.bazel

### DIFF
--- a/go/pkg/cas/BUILD.bazel
+++ b/go/pkg/cas/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//go/pkg/cache:go_default_library",
         "//go/pkg/digest:go_default_library",
+        "//go/pkg/retry:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_pkg_errors//:go_default_library",


### PR DESCRIPTION
Include the `retry` package. This CL should fix the CI.

This change should have been a part of https://github.com/bazelbuild/remote-apis-sdks/commit/fd877b05ba2ed611f6d34e711da05917b729eff9