### PR TITLE
[cas] Add UploadOptions

### DIFF
--- a/go/pkg/cas/client.go
+++ b/go/pkg/cas/client.go
@@ -79,16 +79,6 @@ type ClientConfig struct {
 	// RetryPolicy specifies how to retry requests on transient errors.
 	RetryPolicy retry.BackoffPolicy
 
-	// PreserveSymlinks specifies whether to preserve symlinks or convert them
-	// to regular files.
-	PreserveSymlinks bool
-
-	// AllowDanglingSymlinks specifies whether to upload dangling links or halt
-	// the upload with an error.
-	//
-	// This field is ignored if PreserveSymlinks is false, which is the default.
-	AllowDanglingSymlinks bool
-
 	// TODO(nodir): add per-RPC timeouts.
 }
 


### PR DESCRIPTION
Add UploadOptions which is optional configuration for Upload() func.
Move PreserveSymlinks and AllowDanglingSymlinks there. This way the
same Client can be reused with different options, i.e. the callsite
can reuse caches.

This slightly simplifies tests too.

In the next CL, predicate will be added to UploadOptions.