### PR TITLE
[cas] Reuse file read buffers

### DIFF
--- a/go/pkg/cas/client.go
+++ b/go/pkg/cas/client.go
@@ -39,7 +39,8 @@ type Client struct {
 	// muLargeFile ensures only one large file is read/written at a time.
 	// TODO(nodir): ensure this doesn't hurt performance on SSDs.
 	muLargeFile sync.Mutex
-	fileIOBufs  sync.Pool
+	// Pools of []byte slices with the length of ClientConfig.FileIOSize.
+	fileIOBufs sync.Pool
 
 	// Mockable functions.
 

--- a/go/pkg/cas/client.go
+++ b/go/pkg/cas/client.go
@@ -33,11 +33,13 @@ type Client struct {
 	byteStream          bspb.ByteStreamClient
 	cas                 repb.ContentAddressableStorageClient
 	semBatchUpdateBlobs *semaphore.Weighted
+
 	// TODO(nodir): ensure it does not hurt streaming.
 	semFileIO *semaphore.Weighted
 	// muLargeFile ensures only one large file is read/written at a time.
 	// TODO(nodir): ensure this doesn't hurt performance on SSDs.
 	muLargeFile sync.Mutex
+	fileIOBufs  sync.Pool
 
 	// Mockable functions.
 
@@ -186,6 +188,9 @@ func NewClientWithConfig(ctx context.Context, conn *grpc.ClientConn, instanceNam
 func (c *Client) init() {
 	c.semBatchUpdateBlobs = semaphore.NewWeighted(int64(c.BatchUpdateBlobsConcurrency))
 	c.semFileIO = semaphore.NewWeighted(int64(c.FSConcurrency))
+	c.fileIOBufs.New = func() interface{} {
+		return make([]byte, c.FileIOSize)
+	}
 }
 
 func (c *Client) withRetries(ctx context.Context, f func() error) error {

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -265,9 +265,9 @@ func (u *uploader) visitRegularFile(ctx context.Context, absPath string, info os
 	// It is a medium or large file.
 
 	// Compute the hash.
-	// TODO(nodir): reuse the buffer.
-	buf := make([]byte, u.FileIOSize)
+	buf := u.fileIOBufs.Get().([]byte)
 	dig, err := digest.NewFromReaderWithBuffer(f, buf)
+	u.fileIOBufs.Put(buf)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to compute hash")
 	}


### PR DESCRIPTION
Put the buffers in a pool which is defined the Client level, such that
all uploaders (and downloads in the future) can reuse the same pool.

The pool is not global because the IO size is configured at the client
level.