### PR TITLE
[cas] Add RPCConfig

### DIFF
--- a/go/pkg/cas/client.go
+++ b/go/pkg/cas/client.go
@@ -123,7 +123,7 @@ func DefaultClientConfig() ClientConfig {
 		FindMissingBlobs: RPCConfig{
 			Concurrency: 64,
 			MaxItems:    1000,
-			Timeout:     time.Second,
+			Timeout:     time.Minute,
 		},
 		BatchUpdateBlobs: RPCConfig{
 			Concurrency: 256,
@@ -134,7 +134,7 @@ func DefaultClientConfig() ClientConfig {
 			MaxItems: 4000,
 			// 4MiB is the default gRPC request size limit.
 			MaxSizeBytes: 4 * 1024 * 1024,
-			Timeout:      time.Second,
+			Timeout:      time.Minute,
 		},
 
 		RetryPolicy: retry.ExponentialBackoff(225*time.Millisecond, 2*time.Second, retry.Attempts(6)),

--- a/go/pkg/cas/client.go
+++ b/go/pkg/cas/client.go
@@ -86,7 +86,7 @@ type ClientConfig struct {
 // RPCConfig is configuration for a particular CAS RPC.
 // Some of the fields might not apply to certain RPCs.
 type RPCConfig struct {
-	// Concurrency is the maximum number of RPCs at a time.
+	// Concurrency is the maximum number of RPCs in flight.
 	Concurrency int
 
 	// MaxSizeBytes is the maximum size of the request/response, in bytes.

--- a/go/pkg/cas/client.go
+++ b/go/pkg/cas/client.go
@@ -31,8 +31,9 @@ type Client struct {
 	// ClientConfig is the configuration that the client was created with.
 	ClientConfig
 
-	byteStream bspb.ByteStreamClient
-	cas        repb.ContentAddressableStorageClient
+	byteStream          bspb.ByteStreamClient
+	cas                 repb.ContentAddressableStorageClient
+	semBatchUpdateBlobs *semaphore.Weighted
 
 	// TODO(nodir): ensure it does not hurt streaming.
 	semFileIO *semaphore.Weighted
@@ -97,12 +98,6 @@ type RPCConfig struct {
 
 	// Timeout is the maximum duration of the RPC.
 	Timeout time.Duration
-
-	sem *semaphore.Weighted
-}
-
-func (c *RPCConfig) init() {
-	c.sem = semaphore.NewWeighted(int64(c.Concurrency))
 }
 
 // DefaultClientConfig returns the default config.
@@ -231,13 +226,11 @@ func NewClientWithConfig(ctx context.Context, conn *grpc.ClientConn, instanceNam
 // creating a real gRPC connection. This function exists purely to aid testing,
 // and is tightly coupled with NewClientWithConfig.
 func (c *Client) init() {
+	c.semBatchUpdateBlobs = semaphore.NewWeighted(int64(c.BatchUpdateBlobs.Concurrency))
 	c.semFileIO = semaphore.NewWeighted(int64(c.FSConcurrency))
 	c.fileIOBufs.New = func() interface{} {
 		return make([]byte, c.FileIOSize)
 	}
-
-	c.FindMissingBlobs.init()
-	c.BatchUpdateBlobs.init()
 }
 
 // unaryRPC calls f with retries, and with per-RPC timeouts.

--- a/go/pkg/cas/client.go
+++ b/go/pkg/cas/client.go
@@ -233,9 +233,10 @@ func (c *Client) init() {
 	}
 }
 
-// rpc calls f with retries, and with per-RPC timeouts.
+// unaryRPC calls f with retries, and with per-RPC timeouts.
 // Does not limit concurrency.
-func (c *Client) rpc(ctx context.Context, cfg *RPCConfig, f func(context.Context) error) error {
+// It is useful when f calls an unary RPC.
+func (c *Client) unaryRPC(ctx context.Context, cfg *RPCConfig, f func(context.Context) error) error {
 	return retry.WithPolicy(ctx, retry.TransientOnly, c.RetryPolicy, func() error {
 		ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 		defer cancel()

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -499,7 +499,7 @@ func (u *uploader) check(ctx context.Context, items []*uploadItem) error {
 	}
 
 	var res *repb.FindMissingBlobsResponse
-	err := u.rpc(ctx, &u.FindMissingBlobs, func(ctx context.Context) (err error) {
+	err := u.unaryRPC(ctx, &u.FindMissingBlobs, func(ctx context.Context) (err error) {
 		res, err = u.cas.FindMissingBlobs(ctx, req)
 		return
 	})
@@ -555,7 +555,7 @@ func (u *uploader) uploadBatch(ctx context.Context, reqs []*repb.BatchUpdateBlob
 		InstanceName: u.InstanceName,
 		Requests:     reqs,
 	}
-	return u.rpc(ctx, &u.BatchUpdateBlobs, func(ctx context.Context) error {
+	return u.unaryRPC(ctx, &u.BatchUpdateBlobs, func(ctx context.Context) error {
 		res, err := u.cas.BatchUpdateBlobs(ctx, req)
 		if err != nil {
 			return err

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -486,6 +486,11 @@ func (u *uploader) scheduleCheck(ctx context.Context, item *uploadItem) error {
 // check checks which items are present on the server, and schedules upload for
 // the missing ones.
 func (u *uploader) check(ctx context.Context, items []*uploadItem) error {
+	if err := u.FindMissingBlobs.sem.Acquire(ctx, 1); err != nil {
+		return err
+	}
+	defer u.FindMissingBlobs.sem.Release(1)
+
 	req := &repb.FindMissingBlobsRequest{
 		InstanceName: u.InstanceName,
 		BlobDigests:  make([]*repb.Digest, len(items)),
@@ -541,10 +546,10 @@ func (u *uploader) scheduleUpload(ctx context.Context, item *uploadItem) error {
 
 // uploadBatch uploads blobs in using BatchUpdateBlobs RPC.
 func (u *uploader) uploadBatch(ctx context.Context, reqs []*repb.BatchUpdateBlobsRequest_Request) error {
-	if err := u.semBatchUpdateBlobs.Acquire(ctx, 1); err != nil {
+	if err := u.BatchUpdateBlobs.sem.Acquire(ctx, 1); err != nil {
 		return err
 	}
-	defer u.semBatchUpdateBlobs.Release(1)
+	defer u.BatchUpdateBlobs.sem.Release(1)
 
 	reqMap := make(map[digest.Digest]*repb.BatchUpdateBlobsRequest_Request, len(reqs))
 	for _, r := range reqs {

--- a/go/pkg/cas/upload_test.go
+++ b/go/pkg/cas/upload_test.go
@@ -215,7 +215,7 @@ func TestSmallBlobs(t *testing.T) {
 		ClientConfig: DefaultClientConfig(),
 		cas:          cas,
 	}
-	client.FindMissingBlobsBatchSize = 2
+	client.FindMissingBlobs.MaxItems = 2
 	client.init()
 
 	inputC := inputChanFrom(


### PR DESCRIPTION
First of all, this CL fixes a bug that max-bytes was confused with
max-count, in (*Client).Upload().

Stepping back, the reason is that the RPC config fields are long and
confusing. Earlier version of the code attempted to deal with this by
partially following a rule that a per-RPC config fields starts with the RPC
name, but clearly this wasn't enough.

Introduce RPCConfig struct which contains RPC-specific configuration,
namely concurrency, max-size, max-count and timeout. Use the struct
as a type of two new fields: ClientConfig.FindMissingBlobs and
ClientConfig.BatchUpdateBlobs, which match RPC names exactly.

This is different from client package's approach, which is having a
map[string]RPCConfig. It was considered, but it causes non-type-safe
code, e.g. using string literals to refer to configuration of a
particular RPC, in multiple places. This could be mitigated by adding constant strings, but
this is no better than having strongly-typed fields instead of the map.

Also it seems like the main reason to use map in the client package is
to have defaults that apply to all RPCs, e.g. it is reasonable to have
1s as the default timeout. In contrast, the cas package defines more
than timeout, namely max-size and max-count, and those values
are rather different from RPC to RPC. So the wildcard approach used
in the client package provides less value to the cas package.

Along all of this, this CL implements per-RPC timeouts, but it is a
rather small part of this CL.
