### PR TITLE
[cas] Move file IO buffering deeper

### DIFF
--- a/go/pkg/cas/ioutil.go
+++ b/go/pkg/cas/ioutil.go
@@ -11,15 +11,15 @@ import (
 
 // This file contains various IO utility types and functions.
 
-// byteSource is a common interface to in-memory blobs and files.
+// uploadSource is a common interface to in-memory blobs and files.
 // SeekStart is like io.Seeker.Seek, but only supports io.SeekStart.
-type byteSource interface {
+type uploadSource interface {
 	io.Reader
 	io.Closer
 	SeekStart(offset int64) error
 }
 
-// byteSliceSource implements byteSource on top of []byte.
+// byteSliceSource implements uploadSource on top of []byte.
 type byteSliceSource struct {
 	io.Reader
 	content []byte
@@ -41,7 +41,7 @@ func (s *byteSliceSource) Close() error {
 	return nil
 }
 
-// fileSource implements byteSource on top of *os.File, with buffering.
+// fileSource implements uploadSource on top of *os.File, with buffering.
 //
 // Buffering is done using a reusable bufio.Reader.
 // When the fileSource is closed, the bufio.Reader is placed back to a pool.

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -298,7 +298,7 @@ func (u *uploader) visitRegularFile(ctx context.Context, absPath string, info os
 		// https://github.com/bazelbuild/remote-apis/blob/0cd22f7b466ced15d7803e8845d08d3e8d2c51bc/build/bazel/remote/execution/v2/remote_execution.proto#L250-L254
 
 		item.Open = func() (byteSource, error) {
-			return f, f.Rewind()
+			return f, f.SeekStart(0)
 		}
 		panic("not implemented")
 		// TODO(nodir): implement.

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -620,7 +620,7 @@ func uploadItemFromBlob(title string, blob []byte) *uploadItem {
 		Title:  title,
 		Digest: digest.NewFromBlob(blob).ToProto(),
 		Open: func() (byteSource, error) {
-			return newByteReader(blob), nil
+			return newByteSliceSource(blob), nil
 		},
 	}
 	if item.Title == "" {

--- a/go/pkg/digest/digest.go
+++ b/go/pkg/digest/digest.go
@@ -147,16 +147,8 @@ func NewFromFile(path string) (Digest, error) {
 // NewFromReader computes a file digest from a reader.
 // It returns an error if there was a problem reading the file.
 func NewFromReader(r io.Reader) (Digest, error) {
-	// 32KiB is the buffer size used by io.Copy.
-	return NewFromReaderWithBuffer(r, make([]byte, 32*1024))
-}
-
-// NewFromReaderWithBuffer computes a file digest from a reader, using the
-// given buffer.
-// It returns an error if there was a problem reading the file.
-func NewFromReaderWithBuffer(r io.Reader, buf []byte) (Digest, error) {
 	h := HashFn.New()
-	size, err := io.CopyBuffer(h, r, buf)
+	size, err := io.Copy(h, r)
 	if err != nil {
 		return Empty, err
 	}

--- a/go/pkg/digest/digest.go
+++ b/go/pkg/digest/digest.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/golang/protobuf/proto"
 
@@ -25,6 +26,13 @@ var (
 
 	// Empty is the digest of the empty blob.
 	Empty = NewFromBlob([]byte{})
+
+	// copyBufs is a pool of 32KiB []byte slices, used to compute hashes.
+	copyBufs = sync.Pool{
+		New: func() interface{} {
+			return make([]byte, 32*1024)
+		},
+	}
 )
 
 // Digest is a Go type to mirror the repb.Digest message.
@@ -148,7 +156,9 @@ func NewFromFile(path string) (Digest, error) {
 // It returns an error if there was a problem reading the file.
 func NewFromReader(r io.Reader) (Digest, error) {
 	h := HashFn.New()
-	size, err := io.Copy(h, r)
+	buf := copyBufs.Get().([]byte)
+	defer copyBufs.Put(buf)
+	size, err := io.CopyBuffer(h, r, buf)
 	if err != nil {
 		return Empty, err
 	}


### PR DESCRIPTION
Passing explicit []byte buffers to various functions does not guarantee
buffered reads from an io.Reader. In particular. io.CopyBuffer may
ignore the passed buffer. As a result, the file IO size might get
ignored.

Move buffering deeper by using bufio.Reader. Use it throughout.
Replace a sync.Pool of []byte with a pool of bufio.Readers.

Ungeneralize readSeekCloser since we no longer read from *os.File
directly. Still, preserve seeking (only relative to start) because streaming files must start
with the current-offset-on-the-server.