### PR TITLE
Update RE dependency to get latest go bindings.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.65.0 // indirect
-	github.com/bazelbuild/remote-apis v0.0.0-20210309154856-0943dc4e70e1
+	github.com/bazelbuild/remote-apis v0.0.0-20210430163111-3b7a4b50d27b
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.4.2
 	github.com/google/go-cmp v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/bazelbuild/remote-apis v0.0.0-20210309154856-0943dc4e70e1 h1:uo4qhIV+4gbJ3NY6/4nRCE4AS70xy/wgknQ2bPZS4+k=
 github.com/bazelbuild/remote-apis v0.0.0-20210309154856-0943dc4e70e1/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
+github.com/bazelbuild/remote-apis v0.0.0-20210430163111-3b7a4b50d27b h1:rtTXbQ8Eoom5y7+J33vCbTal0XSlxxUnZmDpPBEbTDk=
+github.com/bazelbuild/remote-apis v0.0.0-20210430163111-3b7a4b50d27b/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/remote-apis-sdks-deps.bzl
+++ b/remote-apis-sdks-deps.bzl
@@ -87,7 +87,7 @@ def remote_apis_sdks_go_deps():
         go_repository,
         name = "com_github_bazelbuild_remote_apis",
         importpath = "github.com/bazelbuild/remote-apis",
-        commit = "0943dc4e70e1414735a85a3167557392c177ff45",  # 2021-03-09,
+        commit = "3b7a4b50d27bb040fc4139bf69b4489377b89136",  # 2021-04-30,
     )
     _maybe(
         go_repository,


### PR DESCRIPTION
We have to figure out the bazel-foolness to recompile these protos,
instead of using the pb.go available. On the meanwhile, this updates
it to the latest version where the .go is in sync with the .pb.