### PR TITLE
[cas] Implement per-request timeouts in a stream

### DIFF
--- a/go/pkg/cas/client_test.go
+++ b/go/pkg/cas/client_test.go
@@ -1,0 +1,35 @@
+package cas
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestPerCallTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ctx, cancel, withTimeout := withPerCallTimeout(ctx, time.Millisecond)
+	defer cancel()
+
+	t.Run("succeeded", func(t *testing.T) {
+		withTimeout(func() {})
+		if ctx.Err() != nil {
+			t.Fatalf("want nil, got %s", ctx.Err())
+		}
+	})
+
+	t.Run("canceled", func(t *testing.T) {
+		withTimeout(func() {
+			select {
+			case <-ctx.Done():
+			case <-time.After(time.Second):
+			}
+		})
+
+		if ctx.Err() != context.Canceled {
+			t.Fatalf("want %s, got %s", context.Canceled, ctx.Err())
+		}
+	})
+}

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/uuid"
@@ -899,22 +898,4 @@ func marshalledRequestSize(d *repb.Digest) int64 {
 		reqSize += marshalledFieldSize(int64(d.SizeBytes))
 	}
 	return marshalledFieldSize(reqSize)
-}
-
-// withPerCallTimeout returns a function wrapper that cancels the context if
-// fn does not return within the timeout.
-func withPerCallTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc, func(fn func())) {
-	ctx, cancel := context.WithCancel(ctx)
-	return ctx, cancel, func(fn func()) {
-		stop := make(chan struct{})
-		defer close(stop)
-		go func() {
-			select {
-			case <-time.After(timeout):
-				cancel()
-			case <-stop:
-			}
-		}()
-		fn()
-	}
 }

--- a/go/pkg/cas/upload_test.go
+++ b/go/pkg/cas/upload_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
@@ -473,4 +474,32 @@ func putSymlink(t *testing.T, path, target string) {
 	if err := os.Symlink(target, path); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestPerCallTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ctx, cancel, withTimeout := withPerCallTimeout(ctx, time.Millisecond)
+	defer cancel()
+
+	t.Run("succeeded", func(t *testing.T) {
+		withTimeout(func() {})
+		if ctx.Err() != nil {
+			t.Fatalf("want nil, got %s", ctx.Err())
+		}
+	})
+
+	t.Run("canceled", func(t *testing.T) {
+		withTimeout(func() {
+			select {
+			case <-ctx.Done():
+			case <-time.After(time.Second):
+			}
+		})
+
+		if ctx.Err() != context.Canceled {
+			t.Fatalf("want %s, got %s", context.Canceled, ctx.Err())
+		}
+	})
 }

--- a/go/pkg/cas/upload_test.go
+++ b/go/pkg/cas/upload_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
@@ -474,32 +473,4 @@ func putSymlink(t *testing.T, path, target string) {
 	if err := os.Symlink(target, path); err != nil {
 		t.Fatal(err)
 	}
-}
-
-func TestPerCallTimeout(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	ctx, cancel, withTimeout := withPerCallTimeout(ctx, time.Millisecond)
-	defer cancel()
-
-	t.Run("succeeded", func(t *testing.T) {
-		withTimeout(func() {})
-		if ctx.Err() != nil {
-			t.Fatalf("want nil, got %s", ctx.Err())
-		}
-	})
-
-	t.Run("canceled", func(t *testing.T) {
-		withTimeout(func() {
-			select {
-			case <-ctx.Done():
-			case <-time.After(time.Second):
-			}
-		})
-
-		if ctx.Err() != context.Canceled {
-			t.Fatalf("want %s, got %s", context.Canceled, ctx.Err())
-		}
-	})
 }


### PR DESCRIPTION
grpc package does not have native support for per-request timeouts for
streaming RPC. Add a helper function to accomodate that.

The func is not specific to CAS, but it wasn't obvious which package
is a better place for it.