### PR TITLE
Update golang, rules_go and gazelle.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,21 +2,22 @@ workspace(name = "bazel_remote_apis_sdks")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# Go rules.
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "08c3cd71857d58af3cda759112437d9e63339ac9c6e0042add43f4d94caf632d",
+    sha256 = "69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.2/rules_go-v0.24.2.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.2/rules_go-v0.24.2.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
     ],
 )
 
-# Gazelle.
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "41bff2a0b32b02f20c227d234aa25ef3783998e5453f7eade929704dcff7cd4b",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.0/bazel-gazelle-v0.19.0.tar.gz"],
+    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+    ],
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
@@ -24,7 +25,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains()
+go_register_toolchains(version = "1.15.8")
 
 gazelle_dependencies()
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bazelbuild/remote-apis-sdks
 
-go 1.13
+go 1.15
 
 require (
 	cloud.google.com/go v0.65.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/bazelbuild/remote-apis v0.0.0-20210309154856-0943dc4e70e1 h1:uo4qhIV+4gbJ3NY6/4nRCE4AS70xy/wgknQ2bPZS4+k=
-github.com/bazelbuild/remote-apis v0.0.0-20210309154856-0943dc4e70e1/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
 github.com/bazelbuild/remote-apis v0.0.0-20210430163111-3b7a4b50d27b h1:rtTXbQ8Eoom5y7+J33vCbTal0XSlxxUnZmDpPBEbTDk=
 github.com/bazelbuild/remote-apis v0.0.0-20210430163111-3b7a4b50d27b/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -118,8 +116,6 @@ github.com/mostynb/zstdpool-syncpool v0.0.3 h1:G1+LWTHSedQUaiW7V7wiGdufKk3Xyyot/
 github.com/mostynb/zstdpool-syncpool v0.0.3/go.mod h1:lC4L6zTmUc7cUKGiMn6aOuHmxzkL4mzpTg4wxpLBbuk=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/go/api/command/BUILD.bazel
+++ b/go/api/command/BUILD.bazel
@@ -17,7 +17,7 @@ go_proto_library(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "command",
     embed = [":command_go_proto"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/api/command",
     visibility = ["//visibility:public"],

--- a/go/cmd/remotetool/BUILD.bazel
+++ b/go/cmd/remotetool/BUILD.bazel
@@ -1,20 +1,20 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "remotetool_lib",
     srcs = ["main.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/cmd/remotetool",
     visibility = ["//visibility:private"],
     deps = [
-        "//go/pkg/flags:go_default_library",
-        "//go/pkg/outerr:go_default_library",
-        "//go/pkg/tool:go_default_library",
+        "//go/pkg/flags",
+        "//go/pkg/outerr",
+        "//go/pkg/tool",
         "@com_github_golang_glog//:go_default_library",
     ],
 )
 
 go_binary(
     name = "remotetool",
-    embed = [":go_default_library"],
+    embed = [":remotetool_lib"],
     visibility = ["//visibility:public"],
 )

--- a/go/cmd/rexec/BUILD.bazel
+++ b/go/cmd/rexec/BUILD.bazel
@@ -1,23 +1,23 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "rexec_lib",
     srcs = ["main.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/cmd/rexec",
     visibility = ["//visibility:private"],
     deps = [
-        "//go/pkg/command:go_default_library",
-        "//go/pkg/filemetadata:go_default_library",
-        "//go/pkg/flags:go_default_library",
-        "//go/pkg/moreflag:go_default_library",
-        "//go/pkg/outerr:go_default_library",
-        "//go/pkg/rexec:go_default_library",
+        "//go/pkg/command",
+        "//go/pkg/filemetadata",
+        "//go/pkg/flags",
+        "//go/pkg/moreflag",
+        "//go/pkg/outerr",
+        "//go/pkg/rexec",
         "@com_github_golang_glog//:go_default_library",
     ],
 )
 
 go_binary(
     name = "rexec",
-    embed = [":go_default_library"],
+    embed = [":rexec_lib"],
     visibility = ["//visibility:public"],
 )

--- a/go/pkg/actas/BUILD.bazel
+++ b/go/pkg/actas/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "actas",
     srcs = ["actas.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/actas",
     visibility = ["//visibility:public"],
@@ -13,9 +13,9 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "actas_test",
     srcs = ["actas_test.go"],
-    embed = [":go_default_library"],
+    embed = [":actas"],
     deps = [
         "@com_github_golang_glog//:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",

--- a/go/pkg/balancer/BUILD.bazel
+++ b/go/pkg/balancer/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "balancer",
     srcs = [
         "gcp_balancer.go",
         "gcp_interceptor.go",
@@ -10,7 +10,7 @@ go_library(
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/balancer",
     visibility = ["//visibility:public"],
     deps = [
-        "//go/pkg/balancer/proto:go_default_library",
+        "//go/pkg/balancer/proto",
         "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//balancer:go_default_library",
@@ -21,9 +21,9 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "balancer_test",
     srcs = ["gcp_balancer_test.go"],
-    embed = [":go_default_library"],
+    embed = [":balancer"],
     deps = [
         "@com_github_pborman_uuid//:go_default_library",
         "@org_golang_google_grpc//balancer:go_default_library",

--- a/go/pkg/balancer/proto/BUILD.bazel
+++ b/go/pkg/balancer/proto/BUILD.bazel
@@ -1,8 +1,9 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 go_library(
-    name = "go_default_library",
+    name = "proto",
     embed = [":grpcbalancer_go_proto"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/balancer/proto",
     visibility = ["//visibility:public"],

--- a/go/pkg/cache/BUILD.bazel
+++ b/go/pkg/cache/BUILD.bazel
@@ -1,14 +1,14 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "cache",
     srcs = ["singleflightcache.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/cache",
     visibility = ["//visibility:public"],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "cache_test",
     srcs = ["singleflightcache_test.go"],
-    embed = [":go_default_library"],
+    embed = [":cache"],
 )

--- a/go/pkg/cas/BUILD.bazel
+++ b/go/pkg/cas/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "cas",
     srcs = [
         "client.go",
         "ioutil.go",
@@ -10,9 +10,9 @@ go_library(
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/cas",
     visibility = ["//visibility:public"],
     deps = [
-        "//go/pkg/cache:go_default_library",
-        "//go/pkg/digest:go_default_library",
-        "//go/pkg/retry:go_default_library",
+        "//go/pkg/cache",
+        "//go/pkg/digest",
+        "//go/pkg/retry",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
@@ -26,10 +26,10 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "cas_test",
     srcs = ["upload_test.go"],
     data = glob(["testdata/**"]),
-    embed = [":go_default_library"],
+    embed = [":cas"],
     deps = [
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",

--- a/go/pkg/chunker/BUILD.bazel
+++ b/go/pkg/chunker/BUILD.bazel
@@ -1,24 +1,24 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "chunker",
     srcs = ["chunker.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/chunker",
     visibility = ["//visibility:public"],
     deps = [
-        "//go/pkg/reader:go_default_library",
-        "//go/pkg/uploadinfo:go_default_library",
+        "//go/pkg/reader",
+        "//go/pkg/uploadinfo",
         "@com_github_klauspost_compress//zstd:go_default_library",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "chunker_test",
     srcs = ["chunker_test.go"],
-    embed = [":go_default_library"],
+    embed = [":chunker"],
     deps = [
-        "//go/pkg/digest:go_default_library",
-        "//go/pkg/uploadinfo:go_default_library",
+        "//go/pkg/digest",
+        "//go/pkg/uploadinfo",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
     ],

--- a/go/pkg/client/BUILD.bazel
+++ b/go/pkg/client/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "client",
     srcs = [
         "bytestream.go",
         "capabilities.go",
@@ -15,15 +15,15 @@ go_library(
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/client",
     visibility = ["//visibility:public"],
     deps = [
-        "//go/pkg/actas:go_default_library",
-        "//go/pkg/balancer:go_default_library",
-        "//go/pkg/balancer/proto:go_default_library",
-        "//go/pkg/chunker:go_default_library",
-        "//go/pkg/command:go_default_library",
-        "//go/pkg/digest:go_default_library",
-        "//go/pkg/filemetadata:go_default_library",
-        "//go/pkg/retry:go_default_library",
-        "//go/pkg/uploadinfo:go_default_library",
+        "//go/pkg/actas",
+        "//go/pkg/balancer",
+        "//go/pkg/balancer/proto",
+        "//go/pkg/chunker",
+        "//go/pkg/command",
+        "//go/pkg/digest",
+        "//go/pkg/filemetadata",
+        "//go/pkg/retry",
+        "//go/pkg/uploadinfo",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
@@ -49,7 +49,7 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "client_test",
     srcs = [
         "batch_retries_test.go",
         "cas_internal_test.go",
@@ -60,16 +60,16 @@ go_test(
         "tree_test.go",
         "tree_whitebox_test.go",
     ],
-    embed = [":go_default_library"],
+    embed = [":client"],
     deps = [
-        "//go/pkg/chunker:go_default_library",
-        "//go/pkg/command:go_default_library",
-        "//go/pkg/digest:go_default_library",
-        "//go/pkg/fakes:go_default_library",
-        "//go/pkg/filemetadata:go_default_library",
-        "//go/pkg/portpicker:go_default_library",
-        "//go/pkg/retry:go_default_library",
-        "//go/pkg/uploadinfo:go_default_library",
+        "//go/pkg/chunker",
+        "//go/pkg/command",
+        "//go/pkg/digest",
+        "//go/pkg/fakes",
+        "//go/pkg/filemetadata",
+        "//go/pkg/portpicker",
+        "//go/pkg/retry",
+        "//go/pkg/uploadinfo",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/semver:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",

--- a/go/pkg/command/BUILD.bazel
+++ b/go/pkg/command/BUILD.bazel
@@ -1,13 +1,13 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "command",
     srcs = ["command.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/command",
     visibility = ["//visibility:public"],
     deps = [
-        "//go/api/command:go_default_library",
-        "//go/pkg/digest:go_default_library",
+        "//go/api/command",
+        "//go/pkg/digest",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
@@ -17,9 +17,9 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "command_test",
     srcs = ["command_test.go"],
-    embed = [":go_default_library"],
+    embed = [":command"],
     deps = [
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",

--- a/go/pkg/digest/BUILD.bazel
+++ b/go/pkg/digest/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "digest",
     srcs = ["digest.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/digest",
     visibility = ["//visibility:public"],
@@ -12,8 +12,8 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "digest_test",
     srcs = ["digest_test.go"],
-    embed = [":go_default_library"],
+    embed = [":digest"],
     deps = ["@com_github_golang_protobuf//proto:go_default_library"],
 )

--- a/go/pkg/fakes/BUILD.bazel
+++ b/go/pkg/fakes/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "fakes",
     srcs = [
         "ac.go",
         "cas.go",
@@ -11,13 +11,13 @@ go_library(
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/fakes",
     visibility = ["//visibility:public"],
     deps = [
-        "//go/pkg/chunker:go_default_library",
-        "//go/pkg/client:go_default_library",
-        "//go/pkg/command:go_default_library",
-        "//go/pkg/digest:go_default_library",
-        "//go/pkg/filemetadata:go_default_library",
-        "//go/pkg/rexec:go_default_library",
-        "//go/pkg/uploadinfo:go_default_library",
+        "//go/pkg/chunker",
+        "//go/pkg/client",
+        "//go/pkg/command",
+        "//go/pkg/digest",
+        "//go/pkg/filemetadata",
+        "//go/pkg/rexec",
+        "//go/pkg/uploadinfo",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",

--- a/go/pkg/filemetadata/BUILD.bazel
+++ b/go/pkg/filemetadata/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "filemetadata",
     srcs = [
         "cache.go",
         "filemetadata.go",
@@ -9,22 +9,22 @@ go_library(
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/filemetadata",
     visibility = ["//visibility:public"],
     deps = [
-        "//go/pkg/cache:go_default_library",
-        "//go/pkg/digest:go_default_library",
+        "//go/pkg/cache",
+        "//go/pkg/digest",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "filemetadata_test",
     srcs = [
         "cache_posix_test.go",
         "cache_test.go",
         "filemetadata_test.go",
     ],
-    embed = [":go_default_library"],
+    embed = [":filemetadata"],
     deps = [
-        "//go/pkg/digest:go_default_library",
-        "//go/pkg/testutil:go_default_library",
+        "//go/pkg/digest",
+        "//go/pkg/testutil",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
     ],

--- a/go/pkg/flags/BUILD.bazel
+++ b/go/pkg/flags/BUILD.bazel
@@ -1,13 +1,13 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "flags",
     srcs = ["flags.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/flags",
     visibility = ["//visibility:public"],
     deps = [
-        "//go/pkg/balancer:go_default_library",
-        "//go/pkg/client:go_default_library",
-        "//go/pkg/moreflag:go_default_library",
+        "//go/pkg/balancer",
+        "//go/pkg/client",
+        "//go/pkg/moreflag",
     ],
 )

--- a/go/pkg/moreflag/BUILD.bazel
+++ b/go/pkg/moreflag/BUILD.bazel
@@ -1,15 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "moreflag",
     srcs = ["moreflag.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/moreflag",
     visibility = ["//visibility:public"],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "moreflag_test",
     srcs = ["moreflag_test.go"],
-    embed = [":go_default_library"],
+    embed = [":moreflag"],
     deps = ["@com_github_google_go_cmp//cmp:go_default_library"],
 )

--- a/go/pkg/outerr/BUILD.bazel
+++ b/go/pkg/outerr/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "outerr",
     srcs = ["outerr.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/outerr",
     visibility = ["//visibility:public"],
@@ -9,7 +9,7 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "outerr_test",
     srcs = ["outerr_test.go"],
-    embed = [":go_default_library"],
+    embed = [":outerr"],
 )

--- a/go/pkg/portpicker/BUILD.bazel
+++ b/go/pkg/portpicker/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "portpicker",
     srcs = ["portpicker.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/portpicker",
     visibility = ["//visibility:public"],

--- a/go/pkg/reader/BUILD.bazel
+++ b/go/pkg/reader/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "reader",
     srcs = ["reader.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/reader",
     visibility = ["//visibility:public"],
@@ -12,11 +12,11 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "reader_test",
     srcs = ["reader_test.go"],
-    embed = [":go_default_library"],
+    embed = [":reader"],
     deps = [
-        "//go/pkg/testutil:go_default_library",
+        "//go/pkg/testutil",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_klauspost_compress//zstd:go_default_library",
     ],

--- a/go/pkg/retry/BUILD.bazel
+++ b/go/pkg/retry/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "retry",
     srcs = ["retry.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/retry",
     visibility = ["//visibility:public"],
@@ -14,9 +14,9 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "retry_test",
     srcs = ["retry_test.go"],
-    embed = [":go_default_library"],
+    embed = [":retry"],
     deps = [
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",

--- a/go/pkg/rexec/BUILD.bazel
+++ b/go/pkg/rexec/BUILD.bazel
@@ -1,17 +1,17 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "rexec",
     srcs = ["rexec.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/rexec",
     visibility = ["//visibility:public"],
     deps = [
-        "//go/pkg/client:go_default_library",
-        "//go/pkg/command:go_default_library",
-        "//go/pkg/digest:go_default_library",
-        "//go/pkg/filemetadata:go_default_library",
-        "//go/pkg/outerr:go_default_library",
-        "//go/pkg/uploadinfo:go_default_library",
+        "//go/pkg/client",
+        "//go/pkg/command",
+        "//go/pkg/digest",
+        "//go/pkg/filemetadata",
+        "//go/pkg/outerr",
+        "//go/pkg/uploadinfo",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
@@ -23,14 +23,13 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "rexec_test",
     srcs = ["rexec_test.go"],
-    embed = [":go_default_library"],
     deps = [
-        "//go/pkg/command:go_default_library",
-        "//go/pkg/digest:go_default_library",
-        "//go/pkg/fakes:go_default_library",
-        "//go/pkg/outerr:go_default_library",
+        "//go/pkg/command",
+        "//go/pkg/digest",
+        "//go/pkg/fakes",
+        "//go/pkg/outerr",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",

--- a/go/pkg/testutil/BUILD.bazel
+++ b/go/pkg/testutil/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "testutil",
     srcs = ["testutil.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/testutil",
     visibility = ["//visibility:public"],

--- a/go/pkg/tool/BUILD.bazel
+++ b/go/pkg/tool/BUILD.bazel
@@ -1,18 +1,18 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "tool",
     srcs = ["tool.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/tool",
     visibility = ["//visibility:public"],
     deps = [
-        "//go/pkg/client:go_default_library",
-        "//go/pkg/command:go_default_library",
-        "//go/pkg/digest:go_default_library",
-        "//go/pkg/filemetadata:go_default_library",
-        "//go/pkg/outerr:go_default_library",
-        "//go/pkg/rexec:go_default_library",
-        "//go/pkg/uploadinfo:go_default_library",
+        "//go/pkg/client",
+        "//go/pkg/command",
+        "//go/pkg/digest",
+        "//go/pkg/filemetadata",
+        "//go/pkg/outerr",
+        "//go/pkg/rexec",
+        "//go/pkg/uploadinfo",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
@@ -20,14 +20,14 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "tool_test",
     srcs = ["tool_test.go"],
-    embed = [":go_default_library"],
+    embed = [":tool"],
     deps = [
-        "//go/pkg/command:go_default_library",
-        "//go/pkg/digest:go_default_library",
-        "//go/pkg/fakes:go_default_library",
-        "//go/pkg/outerr:go_default_library",
+        "//go/pkg/command",
+        "//go/pkg/digest",
+        "//go/pkg/fakes",
+        "//go/pkg/outerr",
         "@com_github_google_go_cmp//cmp:go_default_library",
     ],
 )

--- a/go/pkg/uploadinfo/BUILD.bazel
+++ b/go/pkg/uploadinfo/BUILD.bazel
@@ -1,12 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "uploadinfo",
     srcs = ["entry.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/uploadinfo",
     visibility = ["//visibility:public"],
     deps = [
-        "//go/pkg/digest:go_default_library",
+        "//go/pkg/digest",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )


### PR DESCRIPTION
This uses the newer (nicer) gazelle naming scheme.