### PR TITLE
[cas] Rename UploadOptions.Callback to Prelude

### DIFF
--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -96,20 +96,20 @@ type UploadOptions struct {
 	// This field is ignored if PreserveSymlinks is false, which is the default.
 	AllowDanglingSymlinks bool
 
-	// Callback is called for each file/dir to be uploaded.
+	// Preflight is called for each file/dir to be read and uploaded.
 	// If it returns an error which is ErrSkip according to errors.Is, then the
 	// file/dir is not processed.
 	// If it returns another error, then the upload is halted with that error.
 	//
-	// Callback might be called multiple times for the same file if different
+	// Preflight might be called multiple times for the same file if different
 	// UploadInputs directly/indirectly refer to the same file, but with different
 	// PathExclude.
 	//
-	// Callback is called from different goroutines.
-	Callback func(absPath string, mode os.FileMode) error
+	// Preflight is called from different goroutines.
+	Preflight func(absPath string, mode os.FileMode) error
 }
 
-// ErrSkip, when returned by UploadOptions.Callback, means the file/dir must be
+// ErrSkip, when returned by UploadOptions.Preflight, means the file/dir must be
 // not be uploaded.
 //
 // Note that if UploadOptions.PreserveSymlinks is true and the ErrSkip is
@@ -256,9 +256,9 @@ func (u *uploader) visitPath(ctx context.Context, absPath string, info os.FileIn
 	if pathExclude != nil && pathExclude.MatchString(absPath) {
 		return nil, nil
 	}
-	// Call the callback only after checking the pathExclude.
-	if u.Callback != nil {
-		switch err := u.Callback(absPath, info.Mode()); {
+	// Call the Preflight only after checking the pathExclude.
+	if u.Preflight != nil {
+		switch err := u.Preflight(absPath, info.Mode()); {
 		case errors.Is(err, ErrSkip):
 			return nil, nil
 		case err != nil:
@@ -530,7 +530,7 @@ func (u *uploader) visitSymlink(ctx context.Context, absPath string, pathExclude
 	case !u.PreserveSymlinks:
 		return targetNode, nil
 	case targetNode == nil && !u.AllowDanglingSymlinks:
-		// The target got skipped via Callback or PathExclude,
+		// The target got skipped via Preflight or PathExclude,
 		// resulting in a dangling symlink, which is not allowed.
 		return nil, errors.Wrapf(ErrFilteredSymlinkTarget, "path: %q, target: %q", absPath, target)
 	default:

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -96,20 +96,20 @@ type UploadOptions struct {
 	// This field is ignored if PreserveSymlinks is false, which is the default.
 	AllowDanglingSymlinks bool
 
-	// Preflight is called for each file/dir to be read and uploaded.
+	// Prelude is called for each file/dir to be read and uploaded.
 	// If it returns an error which is ErrSkip according to errors.Is, then the
 	// file/dir is not processed.
 	// If it returns another error, then the upload is halted with that error.
 	//
-	// Preflight might be called multiple times for the same file if different
+	// Prelude might be called multiple times for the same file if different
 	// UploadInputs directly/indirectly refer to the same file, but with different
 	// PathExclude.
 	//
-	// Preflight is called from different goroutines.
-	Preflight func(absPath string, mode os.FileMode) error
+	// Prelude is called from different goroutines.
+	Prelude func(absPath string, mode os.FileMode) error
 }
 
-// ErrSkip, when returned by UploadOptions.Preflight, means the file/dir must be
+// ErrSkip, when returned by UploadOptions.Prelude, means the file/dir must be
 // not be uploaded.
 //
 // Note that if UploadOptions.PreserveSymlinks is true and the ErrSkip is
@@ -256,9 +256,9 @@ func (u *uploader) visitPath(ctx context.Context, absPath string, info os.FileIn
 	if pathExclude != nil && pathExclude.MatchString(absPath) {
 		return nil, nil
 	}
-	// Call the Preflight only after checking the pathExclude.
-	if u.Preflight != nil {
-		switch err := u.Preflight(absPath, info.Mode()); {
+	// Call the Prelude only after checking the pathExclude.
+	if u.Prelude != nil {
+		switch err := u.Prelude(absPath, info.Mode()); {
 		case errors.Is(err, ErrSkip):
 			return nil, nil
 		case err != nil:
@@ -530,7 +530,7 @@ func (u *uploader) visitSymlink(ctx context.Context, absPath string, pathExclude
 	case !u.PreserveSymlinks:
 		return targetNode, nil
 	case targetNode == nil && !u.AllowDanglingSymlinks:
-		// The target got skipped via Preflight or PathExclude,
+		// The target got skipped via Prelude or PathExclude,
 		// resulting in a dangling symlink, which is not allowed.
 		return nil, errors.Wrapf(ErrFilteredSymlinkTarget, "path: %q, target: %q", absPath, target)
 	default:

--- a/go/pkg/cas/upload_test.go
+++ b/go/pkg/cas/upload_test.go
@@ -109,7 +109,7 @@ func TestFS(t *testing.T) {
 			desc:   "root-without-a-using-callback",
 			inputs: []*UploadInput{{Path: filepath.Join(tmpDir, "root")}},
 			opt: UploadOptions{
-				Callback: func(absPath string, mode os.FileMode) error {
+				Prelude: func(absPath string, mode os.FileMode) error {
 					if filepath.Base(absPath) == "a" {
 						return ErrSkip
 					}
@@ -154,7 +154,7 @@ func TestFS(t *testing.T) {
 			desc:   "root-without-subdir",
 			inputs: []*UploadInput{{Path: filepath.Join(tmpDir, "root")}},
 			opt: UploadOptions{
-				Callback: func(absPath string, mode os.FileMode) error {
+				Prelude: func(absPath string, mode os.FileMode) error {
 					if strings.Contains(absPath, "subdir") {
 						return ErrSkip
 					}


### PR DESCRIPTION
"Callback" may mean many things. The name does not entail *when* it is
called. The next CL will introduce another callback which is called
*after* a blob is uploaded. Rename "Callback" to "Prelude" to avoid
ambiguity.