### PR TITLE
[cas] Read files once

### DIFF
--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -274,7 +274,9 @@ func (u *uploader) visitPath(ctx context.Context, absPath string, info os.FileIn
 	cacheKey := cacheKeyType{
 		AbsPath: absPath,
 	}
-	if pathExclude != nil {
+	// Incorporate the pathExclude only if the path is a directory.
+	// If it is a regular file or a symlink, then read it only once.
+	if info.IsDir() && pathExclude != nil {
 		cacheKey.ExcludeRegexp = pathExclude.String()
 	}
 

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -274,9 +274,9 @@ func (u *uploader) visitPath(ctx context.Context, absPath string, info os.FileIn
 	cacheKey := cacheKeyType{
 		AbsPath: absPath,
 	}
-	// Incorporate the pathExclude only if the path is a directory.
-	// If it is a regular file or a symlink, then read it only once.
-	if info.IsDir() && pathExclude != nil {
+	// Incorporate the pathExclude, unless it is a regular file.
+	// If it is a regular file, then pathExclude is not used, see below.
+	if pathExclude != nil && !info.Mode().IsRegular() {
 		cacheKey.ExcludeRegexp = pathExclude.String()
 	}
 
@@ -287,6 +287,7 @@ func (u *uploader) visitPath(ctx context.Context, absPath string, info os.FileIn
 		case info.Mode().IsDir():
 			return u.visitDir(ctx, absPath, pathExclude)
 		case info.Mode().IsRegular():
+			// Code above assumes that pathExclude is not used here.
 			return u.visitRegularFile(ctx, absPath, info)
 		default:
 			return nil, fmt.Errorf("unexpected file mode %s", info.Mode())

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -275,7 +275,7 @@ func (u *uploader) visitPath(ctx context.Context, absPath string, info os.FileIn
 		AbsPath: absPath,
 	}
 	// Incorporate the pathExclude, unless it is a regular file.
-	// If it is a regular file, then pathExclude is not used, see below.
+	// If it is a regular file, then pathExclude is not used below.
 	if pathExclude != nil && !info.Mode().IsRegular() {
 		cacheKey.ExcludeRegexp = pathExclude.String()
 	}

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -275,7 +275,8 @@ func (u *uploader) visitPath(ctx context.Context, absPath string, info os.FileIn
 		AbsPath: absPath,
 	}
 	// Incorporate the pathExclude, unless it is a regular file.
-	// If it is a regular file, then pathExclude is not used below.
+	// If it is a regular file, then there's no need to include pathExclude in the cache key, as we already know the
+	// regex does not match the file and the exclusion isn't propagated.
 	if pathExclude != nil && !info.Mode().IsRegular() {
 		cacheKey.ExcludeRegexp = pathExclude.String()
 	}

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -275,8 +275,9 @@ func (u *uploader) visitPath(ctx context.Context, absPath string, info os.FileIn
 		AbsPath: absPath,
 	}
 	// Incorporate the pathExclude, unless it is a regular file.
-	// If it is a regular file, then there's no need to include pathExclude in the cache key, as we already know the
-	// regex does not match the file and the exclusion isn't propagated.
+	// If it is a regular file, then there's no need to include pathExclude in the
+	// cache key, as we already know the regex does not match the file and the
+	// exclusion isn't propagated.
 	if pathExclude != nil && !info.Mode().IsRegular() {
 		cacheKey.ExcludeRegexp = pathExclude.String()
 	}

--- a/go/pkg/cas/upload_test.go
+++ b/go/pkg/cas/upload_test.go
@@ -151,6 +151,23 @@ func TestFS(t *testing.T) {
 			},
 		},
 		{
+			desc: "same-regular-file-is-not-uploaded-twice",
+			// The two regexps below do not exclude anything.
+			// This test ensures that same files aren't checked twice.
+			inputs: []*UploadInput{
+				{
+					Path:        filepath.Join(tmpDir, "root"),
+					PathExclude: regexp.MustCompile(`1$`),
+				},
+				{
+					Path:        filepath.Join(tmpDir, "root"),
+					PathExclude: regexp.MustCompile(`2$`),
+				},
+			},
+			// Directories are checked twice, but files are checked only once.
+			wantScheduledChecks: []*uploadItem{rootItem, rootItem, aItem, bItem, subdirItem, subdirItem, cItem},
+		},
+		{
 			desc:   "root-without-subdir",
 			inputs: []*UploadInput{{Path: filepath.Join(tmpDir, "root")}},
 			opt: UploadOptions{

--- a/go/pkg/cas/upload_test.go
+++ b/go/pkg/cas/upload_test.go
@@ -151,7 +151,7 @@ func TestFS(t *testing.T) {
 			},
 		},
 		{
-			desc: "same-regular-file-is-not-uploaded-twice",
+			desc: "same-regular-file-is-read-only-once",
 			// The two regexps below do not exclude anything.
 			// This test ensures that same files aren't checked twice.
 			inputs: []*UploadInput{


### PR DESCRIPTION
Currently PathExclude regexp is incorporated into the cache key
unconditionally. However, pathExclude isn't used if the path is a regular file.
Thus do not incorporate PathExclude into the cache key in this case.