### PR TITLE
[cas] Add UploadResult.Digest

### DIFF
--- a/go/pkg/cache/singleflightcache.go
+++ b/go/pkg/cache/singleflightcache.go
@@ -34,6 +34,20 @@ func (s *SingleFlight) LoadOrStore(key interface{}, valFn func() (interface{}, e
 	return e.val, e.err
 }
 
+// Load is similar to a sync.Map.Load.
+func (s *SingleFlight) Load(key interface{}) (val interface{}, err error, loaded bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var eUntyped interface{}
+	eUntyped, loaded = s.store.Load(key)
+	if loaded {
+		e := eUntyped.(*entry)
+		val = e.val
+		err = e.err
+	}
+	return
+}
+
 // Store forcefully updates the given cache key with val. Note that unlike LoadOrStore,
 // Store accepts a value instead of a valFn since it is intended to be only used in
 // cases where updates are lightweight and do not involve computing the cache value.

--- a/go/pkg/cache/singleflightcache_test.go
+++ b/go/pkg/cache/singleflightcache_test.go
@@ -25,6 +25,16 @@ func TestSimpleValueStore(t *testing.T) {
 	if val != val1 {
 		t.Errorf("LoadOrStore(%v) loaded wrong value: got %v, want %v", key1, val, val1)
 	}
+	val, err, loaded := s.Load(key1)
+	if !loaded {
+		t.Errorf("expected to load value")
+	}
+	if err != nil {
+		t.Errorf("Load(%v) failed: %v", key1, err)
+	}
+	if val != val1 {
+		t.Errorf("Load(%v) loaded wrong value: got %v, want %v", key1, val, val1)
+	}
 
 	val, err = s.LoadOrStore(key2, func() (interface{}, error) { return val2, nil })
 	if err != nil {
@@ -32,6 +42,16 @@ func TestSimpleValueStore(t *testing.T) {
 	}
 	if val != val2 {
 		t.Errorf("LoadOrStore(%v) loaded wrong value: got %v, want %v", key2, val, val2)
+	}
+	val, err, loaded = s.Load(key2)
+	if !loaded {
+		t.Errorf("expected to load value")
+	}
+	if err != nil {
+		t.Errorf("Load(%v) failed: %v", key2, err)
+	}
+	if val != val2 {
+		t.Errorf("Load(%v) loaded wrong value: got %v, want %v", key2, val, val1)
 	}
 }
 

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -100,6 +100,12 @@ type UploadOptions struct {
 	Prelude func(absPath string, mode os.FileMode) error
 }
 
+// digested is a result of preprocessing a file/dir.
+type digested struct {
+	dirEntry proto.Message // FileNode, DirectoryNode or SymlinkNode
+	digest   *repb.Digest  // may be nil, e.g. for dangling symlinks
+}
+
 // ErrSkip when returned by UploadOptions.Prelude, means the file/dir must be
 // not be uploaded.
 //
@@ -108,6 +114,46 @@ type UploadOptions struct {
 // result in a dangling symlink.
 var ErrSkip = errors.New("skip file")
 
+// UploadResult is the result of a Client.Upload call.
+// It provides file/dir digests and statistics.
+type UploadResult struct {
+	Stats TransferStats
+	u     *uploader
+}
+
+// Digest returns the digest computed for a file/dir at ps.Path.
+//
+// To retrieve a digest of a regular file, only ps.Path is checked - other
+// fields are ignored.
+//
+// To retrieve a digest of a directory or a symlink, ps.Exclude must match one
+// of the PathSpecs passed to Client.Upload earlier.
+//
+// If the digest is unknown, returns (nil, nil).
+// If the file is a danging symlink, then its digest is unknown.
+func (r *UploadResult) Digest(ps *PathSpec) (*digest.Digest, error) {
+	if !filepath.IsAbs(ps.Path) {
+		return nil, errors.Errorf("%q is not absolute", ps.Path)
+	}
+
+	// TODO(nodir): cache this syscall too.
+	info, err := os.Lstat(ps.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	key := makeFSCacheKey(ps.Path, info.Mode(), ps.Exclude)
+	switch val, err, loaded := r.u.fsCache.Load(key); {
+	case !loaded:
+		return nil, nil
+	case err != nil:
+		return nil, err
+	default:
+		dig := digest.NewFromProtoUnvalidated(val.(*digested).digest)
+		return &dig, nil
+	}
+}
+
 // Upload uploads all files/directories specified by pathC.
 //
 // Close pathC to indicate that there are no more files/dirs to upload.
@@ -115,7 +161,7 @@ var ErrSkip = errors.New("skip file")
 // exits successfully.
 //
 // If ctx is canceled, the Upload returns with an error.
-func (c *Client) Upload(ctx context.Context, opt UploadOptions, pathC <-chan *PathSpec) (stats *TransferStats, err error) {
+func (c *Client) Upload(ctx context.Context, opt UploadOptions, pathC <-chan *PathSpec) (*UploadResult, error) {
 	eg, ctx := errgroup.WithContext(ctx)
 	// Do not exit until all sub-goroutines exit, to prevent goroutine leaks.
 	defer eg.Wait()
@@ -179,7 +225,7 @@ func (c *Client) Upload(ctx context.Context, opt UploadOptions, pathC <-chan *Pa
 			}
 		}
 	})
-	return &u.stats, eg.Wait()
+	return &UploadResult{Stats: u.stats, u: u}, eg.Wait()
 }
 
 // uploader implements a concurrent multi-stage pipeline to read blobs from the
@@ -204,6 +250,8 @@ type uploader struct {
 	wgFS sync.WaitGroup
 
 	// fsCache contains already-processed files.
+	// A key can be produced by makeFSCacheKey.
+	// The values are of type *digested.
 	fsCache cache.SingleFlight
 
 	// checkBundler bundles digests that need to be checked for presence on the
@@ -240,11 +288,39 @@ func (u *uploader) startProcessing(ctx context.Context, ps *PathSpec) error {
 	return nil
 }
 
+// makeFSCacheKey returns a key for u.fsCache.
+func makeFSCacheKey(absPath string, mode os.FileMode, pathExclude *regexp.Regexp) interface{} {
+	// The structure of the cache key is incapsulated by this function.
+	type cacheKey struct {
+		AbsPath       string
+		ExcludeRegexp string
+	}
+
+	key := cacheKey{
+		AbsPath: absPath,
+	}
+
+	if mode.IsRegular() {
+		// This is a regular file.
+		// Its digest depends only on the file path (assuming content didn't change),
+		// so the cache key is complete. Just return it.
+		return key
+	}
+	// This is a directory and/or a symlink, so the digest also depends on fs-walk
+	// settings. Incroporate those too.
+
+	if pathExclude != nil {
+		key.ExcludeRegexp = pathExclude.String()
+	}
+	return key
+}
+
 // visitPath visits the file/dir depending on its type (regular, dir, symlink).
 // Visits each file only once.
 //
 // If the file should be skipped, then returns (nil, nil).
-func (u *uploader) visitPath(ctx context.Context, absPath string, info os.FileInfo, pathExclude *regexp.Regexp) (dirEntry proto.Message, err error) {
+// The returned digested.digest may also be nil if the symlink is dangling.
+func (u *uploader) visitPath(ctx context.Context, absPath string, info os.FileInfo, pathExclude *regexp.Regexp) (*digested, error) {
 	// First, check if the file passes all filters.
 	if pathExclude != nil && pathExclude.MatchString(filepath.ToSlash(absPath)) {
 		return nil, nil
@@ -259,31 +335,21 @@ func (u *uploader) visitPath(ctx context.Context, absPath string, info os.FileIn
 		}
 	}
 
-	// Make a cache key.
-	type cacheKeyType struct {
-		AbsPath       string
-		ExcludeRegexp string
-	}
-	cacheKey := cacheKeyType{
-		AbsPath: absPath,
-	}
-	// Incorporate the pathExclude, unless it is a regular file.
-	// If it is a regular file, then there's no need to include pathExclude in the
-	// cache key, as we already know the regex does not match the file and the
-	// exclusion isn't propagated.
-	if pathExclude != nil && !info.Mode().IsRegular() {
-		cacheKey.ExcludeRegexp = pathExclude.String()
-	}
-
-	node, err := u.fsCache.LoadOrStore(cacheKey, func() (interface{}, error) {
+	cacheKey := makeFSCacheKey(absPath, info.Mode(), pathExclude)
+	cached, err := u.fsCache.LoadOrStore(cacheKey, func() (interface{}, error) {
 		switch {
 		case info.Mode()&os.ModeSymlink == os.ModeSymlink:
 			return u.visitSymlink(ctx, absPath, pathExclude)
+
 		case info.Mode().IsDir():
-			return u.visitDir(ctx, absPath, pathExclude)
+			node, err := u.visitDir(ctx, absPath, pathExclude)
+			return &digested{dirEntry: node, digest: node.GetDigest()}, err
+
 		case info.Mode().IsRegular():
-			// Code above assumes that pathExclude is not used here.
-			return u.visitRegularFile(ctx, absPath, info)
+			// Note: makeFSCacheKey assumes that pathExclude is not used here.
+			node, err := u.visitRegularFile(ctx, absPath, info)
+			return &digested{dirEntry: node, digest: node.GetDigest()}, err
+
 		default:
 			return nil, fmt.Errorf("unexpected file mode %s", info.Mode())
 		}
@@ -291,7 +357,7 @@ func (u *uploader) visitPath(ctx context.Context, absPath string, info os.FileIn
 	if err != nil {
 		return nil, err
 	}
-	return node.(proto.Message), nil
+	return cached.(*digested), nil
 }
 
 // visitRegularFile computes the hash of a regular file and schedules a presence
@@ -434,23 +500,26 @@ func (u *uploader) visitDir(ctx context.Context, absPath string, pathExclude *re
 				u.eg.Go(func() error {
 					defer wgChildren.Done()
 					defer u.wgFS.Done()
-					node, err := u.visitPath(ctx, absChild, info, pathExclude)
+					digested, err := u.visitPath(ctx, absChild, info, pathExclude)
 					mu.Lock()
 					defer mu.Unlock()
-					if err != nil {
+
+					switch {
+					case err != nil:
 						subErr = err
 						return err
+					case digested == nil:
+						// This file should be ignored.
+						return nil
 					}
 
-					switch node := node.(type) {
+					switch node := digested.dirEntry.(type) {
 					case *repb.FileNode:
 						dir.Files = append(dir.Files, node)
 					case *repb.DirectoryNode:
 						dir.Directories = append(dir.Directories, node)
 					case *repb.SymlinkNode:
 						dir.Symlinks = append(dir.Symlinks, node)
-					case nil:
-						// This file should be ignored.
 					default:
 						// This condition is impossible because all functions in this file
 						// return one of the three types above.
@@ -485,7 +554,9 @@ func (u *uploader) visitDir(ctx context.Context, absPath string, pathExclude *re
 // of the target file.
 // If u.PreserveSymlinks is true, then returns a SymlinkNode, otherwise
 // returns the directory node of the target file.
-func (u *uploader) visitSymlink(ctx context.Context, absPath string, pathExclude *regexp.Regexp) (proto.Message, error) {
+//
+// The returned digested.digest is nil if the symlink is dangling.
+func (u *uploader) visitSymlink(ctx context.Context, absPath string, pathExclude *regexp.Regexp) (*digested, error) {
 	target, err := os.Readlink(absPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "os.ReadLink")
@@ -516,23 +587,26 @@ func (u *uploader) visitSymlink(ctx context.Context, absPath string, pathExclude
 	switch {
 	case os.IsNotExist(err) && u.PreserveSymlinks && u.AllowDanglingSymlinks:
 		// Special case for preserved dangling links.
-		return symlinkNode, nil
+		return &digested{dirEntry: symlinkNode}, nil
 	case err != nil:
 		return nil, errors.WithStack(err)
 	}
 
-	switch targetNode, err := u.visitPath(ctx, absTarget, targetInfo, pathExclude); {
+	switch digestedTarget, err := u.visitPath(ctx, absTarget, targetInfo, pathExclude); {
 	case err != nil:
 		return nil, err
 	case !u.PreserveSymlinks:
-		return targetNode, nil
-	case targetNode == nil && !u.AllowDanglingSymlinks:
+		return digestedTarget, nil
+	case digestedTarget == nil && !u.AllowDanglingSymlinks:
 		// The target got skipped via Prelude or PathSpec.Exclude,
 		// resulting in a dangling symlink, which is not allowed.
 		return nil, errors.Wrapf(ErrFilteredSymlinkTarget, "path: %q, target: %q", absPath, target)
 	default:
-		// Note: even though we throw away targetNode, it was still important to visit the target.
-		return symlinkNode, nil
+		ret := &digested{dirEntry: symlinkNode}
+		if digestedTarget != nil {
+			ret.digest = digestedTarget.digest
+		}
+		return ret, nil
 	}
 }
 


### PR DESCRIPTION
The callers of `Client.Upload` need the digest back in order to
pass it to another system which would fetch the uploaded files.
Add `cas.UploadInput.OnDigest` callback, called when a digest is computed.

Note that by the time `OnDigest` is called, the item is not fully uploaded yet.
It is generally hard to detect when a tree is fully uploaded because
file uploads happen in arbitrary order. In particular, a blob for a
parent directory may be uploaded before its children.
Still, this is enough for the purpose.

Returning digests from `Upload()` function was also considered, but it
is getting complicated quickly because the callsite needs to know
uploadItem->digest association.

Another considered alternative is to add something like
`UploadInput.Digest digest.Digest` which is populated by `Upload()`.
This is a bit awkward because Digest is output, while the struct is called
`UploadInput`.