### PR TITLE
[cas] Rename UploadInput to PathSpec

### DIFF
--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -44,8 +44,6 @@ var zstdEncoders = sync.Pool{
 // PathSpec specifies a subset of the file system.
 type PathSpec struct {
 	// Path to the file or a directory to upload.
-	// If empty, the Content is uploaded instead.
-	//
 	// Must be absolute or relative to CWD.
 	Path string
 
@@ -54,8 +52,6 @@ type PathSpec struct {
 	// If the Path is a directory, then the filter is evaluated against each file
 	// in the subtree.
 	// See ErrSkip comments for more details on semantics regarding excluding symlinks .
-	//
-	// This field has no effect if Path is empty.
 	Exclude *regexp.Regexp
 }
 

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -106,8 +106,11 @@ type UploadOptions struct {
 // result in a dangling symlink.
 var ErrSkip = errors.New("skip file")
 
-// Upload uploads all path specs.
-// It exits when pathC is closed or ctx is canceled.
+// Upload uploads all files/directories specified by pathC.
+//
+// Close pathC to indicate that there are no more files/dirs to upload.
+// When pathC is closed, Upload finishes uploading the remaining files/dirs and
+// exits successfully.
 func (c *Client) Upload(ctx context.Context, opt UploadOptions, pathC <-chan *PathSpec) (stats *TransferStats, err error) {
 	eg, ctx := errgroup.WithContext(ctx)
 	// Do not exit until all sub-goroutines exit, to prevent goroutine leaks.

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -28,7 +28,7 @@ import (
 )
 
 // ErrFilteredSymlinkTarget is returned when a symlink's target was filtered out
-// via PathSpec.PathExclude or ErrSkip, while the symlink itself wasn't.
+// via PathSpec.Exclude or ErrSkip, while the symlink itself wasn't.
 var ErrFilteredSymlinkTarget = errors.New("symlink's target was filtered out")
 
 // zstdEncoders is a pool of ZStd encoders.
@@ -523,7 +523,7 @@ func (u *uploader) visitSymlink(ctx context.Context, absPath string, pathExclude
 	case !u.PreserveSymlinks:
 		return targetNode, nil
 	case targetNode == nil && !u.AllowDanglingSymlinks:
-		// The target got skipped via Prelude or PathExclude,
+		// The target got skipped via Prelude or PathSpec.Exclude,
 		// resulting in a dangling symlink, which is not allowed.
 		return nil, errors.Wrapf(ErrFilteredSymlinkTarget, "path: %q, target: %q", absPath, target)
 	default:

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -111,6 +111,8 @@ var ErrSkip = errors.New("skip file")
 // Close pathC to indicate that there are no more files/dirs to upload.
 // When pathC is closed, Upload finishes uploading the remaining files/dirs and
 // exits successfully.
+//
+// If ctx is canceled, the Upload returns with an error.
 func (c *Client) Upload(ctx context.Context, opt UploadOptions, pathC <-chan *PathSpec) (stats *TransferStats, err error) {
 	eg, ctx := errgroup.WithContext(ctx)
 	// Do not exit until all sub-goroutines exit, to prevent goroutine leaks.

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -110,7 +110,8 @@ type UploadOptions struct {
 // result in a dangling symlink.
 var ErrSkip = errors.New("skip file")
 
-// Upload uploads all inputs. It exits when inputC is closed or ctx is canceled.
+// Upload uploads all path specs.
+// It exits when pathC is closed or ctx is canceled.
 func (c *Client) Upload(ctx context.Context, opt UploadOptions, pathC <-chan *PathSpec) (stats *TransferStats, err error) {
 	eg, ctx := errgroup.WithContext(ctx)
 	// Do not exit until all sub-goroutines exit, to prevent goroutine leaks.
@@ -149,7 +150,7 @@ func (c *Client) Upload(ctx context.Context, opt UploadOptions, pathC <-chan *Pa
 	u.batchBundler.BundleByteLimit = c.Config.BatchUpdateBlobs.MaxSizeBytes - int(marshalledFieldSize(int64(len(c.InstanceName)))) - 1000
 	u.batchBundler.BundleCountThreshold = c.Config.BatchUpdateBlobs.MaxItems
 
-	// Start processing input.
+	// Start processing path specs.
 	eg.Go(func() error {
 		// Before exiting this main goroutine, ensure all the work has been completed.
 		// Just waiting for u.eg isn't enough because some work may be temporarily

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -49,14 +49,14 @@ type PathSpec struct {
 	// Must be absolute or relative to CWD.
 	Path string
 
-	// PathExclude is a file/dir filter. If PathExclude is not nil and the
+	// Exclude is a file/dir filter. If Exclude is not nil and the
 	// absolute path of a file/dir match this regexp, then the file/dir is skipped.
 	// If the Path is a directory, then the filter is evaluated against each file
 	// in the subtree.
 	// See ErrSkip comments for more details on semantics regarding excluding symlinks .
 	//
 	// This field has no effect if Path is empty.
-	PathExclude *regexp.Regexp
+	Exclude *regexp.Regexp
 }
 
 // TransferStats is upload/download statistics.
@@ -96,7 +96,7 @@ type UploadOptions struct {
 	//
 	// Prelude might be called multiple times for the same file if different
 	// PathSpecs directly/indirectly refer to the same file, but with different
-	// PathExclude.
+	// PathSpec.Exclude.
 	//
 	// Prelude is called from different goroutines.
 	Prelude func(absPath string, mode os.FileMode) error
@@ -230,7 +230,7 @@ func (u *uploader) startProcessing(ctx context.Context, ps *PathSpec) error {
 			return errors.WithStack(err)
 		}
 
-		_, err = u.visitPath(ctx, absPath, info, ps.PathExclude)
+		_, err = u.visitPath(ctx, absPath, info, ps.Exclude)
 		return errors.Wrapf(err, "%q", absPath)
 	})
 	return nil

--- a/go/pkg/cas/upload_test.go
+++ b/go/pkg/cas/upload_test.go
@@ -133,8 +133,8 @@ func TestFS(t *testing.T) {
 		{
 			desc: "root-without-b-using-exclude",
 			paths: []*PathSpec{{
-				Path:        filepath.Join(tmpDir, "root"),
-				PathExclude: regexp.MustCompile(`[/\\]b$`),
+				Path:    filepath.Join(tmpDir, "root"),
+				Exclude: regexp.MustCompile(`[/\\]b$`),
 			}},
 			wantScheduledChecks: []*uploadItem{
 				uploadItemFromDirMsg(filepath.Join(tmpDir, "root"), &repb.Directory{
@@ -156,12 +156,12 @@ func TestFS(t *testing.T) {
 			// This test ensures that same files aren't checked twice.
 			paths: []*PathSpec{
 				{
-					Path:        filepath.Join(tmpDir, "root"),
-					PathExclude: regexp.MustCompile(`1$`),
+					Path:    filepath.Join(tmpDir, "root"),
+					Exclude: regexp.MustCompile(`1$`),
 				},
 				{
-					Path:        filepath.Join(tmpDir, "root"),
-					PathExclude: regexp.MustCompile(`2$`),
+					Path:    filepath.Join(tmpDir, "root"),
+					Exclude: regexp.MustCompile(`2$`),
 				},
 			},
 			// Directories are checked twice, but files are checked only once.
@@ -220,8 +220,8 @@ func TestFS(t *testing.T) {
 			desc: "dangling-symlink-via-filtering",
 			opt:  UploadOptions{PreserveSymlinks: true},
 			paths: []*PathSpec{{
-				Path:        filepath.Join(tmpDir, "with-symlinks"),
-				PathExclude: regexp.MustCompile("root"),
+				Path:    filepath.Join(tmpDir, "with-symlinks"),
+				Exclude: regexp.MustCompile("root"),
 			}},
 			wantErr: ErrFilteredSymlinkTarget,
 		},
@@ -229,8 +229,8 @@ func TestFS(t *testing.T) {
 			desc: "dangling-symlink-via-filtering-allow",
 			opt:  UploadOptions{PreserveSymlinks: true, AllowDanglingSymlinks: true},
 			paths: []*PathSpec{{
-				Path:        filepath.Join(tmpDir, "with-symlinks"),
-				PathExclude: regexp.MustCompile("root"),
+				Path:    filepath.Join(tmpDir, "with-symlinks"),
+				Exclude: regexp.MustCompile("root"),
 			}},
 			wantScheduledChecks: []*uploadItem{withSymlinksItemPreserved},
 		},


### PR DESCRIPTION
Rename UploadInput to PathSpec, which specifies a subset
of the file system. Also remove UploadInput.Content as it is not
critical for most use cases and complicates more important things.