### PR TITLE
[cas] Clean PathSpec.Path

### DIFF
--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -173,7 +173,7 @@ func (c *Client) Upload(ctx context.Context, opt UploadOptions, pathC <-chan *Pa
 				if !ok {
 					return nil
 				}
-				if err := u.startProcessing(ctx, *ps); err != nil {
+				if err := u.startProcessing(ctx, ps); err != nil {
 					return err
 				}
 			}
@@ -216,10 +216,12 @@ type uploader struct {
 }
 
 // startProcessing adds the item to the appropriate stage depending on its type.
-func (u *uploader) startProcessing(ctx context.Context, ps PathSpec) error {
+func (u *uploader) startProcessing(ctx context.Context, ps *PathSpec) error {
 	if !filepath.IsAbs(ps.Path) {
 		return errors.Errorf("%q is not absolute", ps.Path)
 	}
+	cpy := *ps
+	ps = &cpy
 	ps.Path = filepath.Clean(ps.Path)
 
 	// Schedule a file system walk.

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -173,7 +173,7 @@ func (c *Client) Upload(ctx context.Context, opt UploadOptions, pathC <-chan *Pa
 				if !ok {
 					return nil
 				}
-				if err := u.startProcessing(ctx, ps); err != nil {
+				if err := u.startProcessing(ctx, *ps); err != nil {
 					return err
 				}
 			}
@@ -216,10 +216,11 @@ type uploader struct {
 }
 
 // startProcessing adds the item to the appropriate stage depending on its type.
-func (u *uploader) startProcessing(ctx context.Context, ps *PathSpec) error {
+func (u *uploader) startProcessing(ctx context.Context, ps PathSpec) error {
 	if !filepath.IsAbs(ps.Path) {
 		return errors.Errorf("%q is not absolute", ps.Path)
 	}
+	ps.Path = filepath.Clean(ps.Path)
 
 	// Schedule a file system walk.
 	u.wgFS.Add(1)


### PR DESCRIPTION
https://github.com/bazelbuild/remote-apis-sdks/pull/345
removed filepath.Abs call, but it has a side effect that we no longer
clean the path. Clean it explicitly.