### PR TITLE
[cas] Fix joinFilePathsFast

### DIFF
--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -945,6 +946,10 @@ const pathSep = string(filepath.Separator)
 // joinFilePathsFast is a faster version of filepath.Join because it does not
 // call filepath.Clean.
 func joinFilePathsFast(a, b string) string {
+	if strings.HasSuffix(a, pathSep) {
+		// May happen if a is the root.
+		return a + b
+	}
 	return a + pathSep + b
 }
 


### PR DESCRIPTION
Fix joinFilePathsFast where the first path is the root.
We don't expect it in production, but it happens in tests.