### PR TITLE
Revert "Add useful error message for uploading files. (#339)"

### DIFF
--- a/go/pkg/client/cas_test.go
+++ b/go/pkg/client/cas_test.go
@@ -686,7 +686,7 @@ func TestUploadConcurrentCancel(t *testing.T) {
 			for i := 0; i < 50; i++ {
 				eg.Go(func() error {
 					// Verify that we got a context cancellation error. Sometimes, the request can succeed, if the original thread takes a while to run.
-					if _, _, err := c.UploadIfMissing(cCtx, input...); err != nil && !errors.Is(err, context.Canceled) {
+					if _, _, err := c.UploadIfMissing(cCtx, input...); err != nil && err != context.Canceled {
 						return fmt.Errorf("c.UploadIfMissing(ctx, input) gave error %v, expected context canceled", err)
 					}
 					return nil


### PR DESCRIPTION
This reverts commit e155d015bcc4c9eb9978572422e3404f26220700.

gRPC errors are... hard. And the gRPC team isn't willing to support
wrapping, which leads to complicated handling. See
https://github.com/grpc/grpc-go/issues/3616.

I'll send a different PR to add stack traces to these grpc errors.