### PR TITLE
"Wrap" gRPC error codes.

### DIFF
--- a/go/pkg/client/cas_test.go
+++ b/go/pkg/client/cas_test.go
@@ -686,8 +686,8 @@ func TestUploadConcurrentCancel(t *testing.T) {
 			for i := 0; i < 50; i++ {
 				eg.Go(func() error {
 					// Verify that we got a context cancellation error. Sometimes, the request can succeed, if the original thread takes a while to run.
-					if _, _, err := c.UploadIfMissing(cCtx, input...); err != nil && err != context.Canceled {
-						return fmt.Errorf("c.UploadIfMissing(ctx, input) gave error %v, expected context canceled", err)
+					if _, _, err := c.UploadIfMissing(cCtx, input...); err != nil && !errors.Is(err, context.Canceled) {
+						return fmt.Errorf("c.UploadIfMissing(ctx, input) gave error %+v!, expected context canceled", err)
 					}
 					return nil
 				})


### PR DESCRIPTION
While gRPC error codes aren't wrapper-friendly (see
https://github.com/grpc/grpc-go/issues/3616), we still
want to be able to get more context from errors.

Adding stack traces on their messages was the easiest way
I thought of that'd maintain backwards compatibility.