### PR TITLE
allow to use streamBufSize larger than 32KiB

### DIFF
--- a/go/pkg/cas/client.go
+++ b/go/pkg/cas/client.go
@@ -276,7 +276,7 @@ func (c *Client) init() {
 	}
 
 	streamBufSize := 32 * 1024 // by default, send 32KiB chunks.
-	if streamBufSize > c.Config.ByteStreamWrite.MaxSizeBytes {
+	if streamBufSize < c.Config.ByteStreamWrite.MaxSizeBytes {
 		streamBufSize = int(c.Config.ByteStreamWrite.MaxSizeBytes)
 	}
 	c.streamBufs.New = func() interface{} {


### PR DESCRIPTION
I think we want to specify larger value for streamBufSize (e.g. 4MiB)