### PR TITLE
use semaphore for large file upload

### DIFF
--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -591,7 +591,7 @@ func (u *uploader) visitRegularFile(ctx context.Context, absPath string, info os
 	if isLarge {
 		// Read only a few large files at a time.
 		if err := u.semLargeFile.Acquire(ctx, 1); err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		defer u.semLargeFile.Release(1)
 	}


### PR DESCRIPTION
Only one file upload concurrency seems too strict.

With this, uploading 16 1GiB files with compression took 91s on HDD Linux GCE.
https://chromium-swarm.appspot.com/task?id=54c6ff9164a1e010

Without this, uploading 16 1GiB files with compression took 208s on HDD Linux GCE.
https://chromium-swarm.appspot.com/task?id=54c6f96c61139510