### PR TITLE
Download Golang during CI job

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,7 +2,13 @@
 validate_config: 1
 tasks:
   ubuntu1804:
+    environment:
+      GO_HOME: "$HOME/go-1.16.7"
+      PATH: "$PATH:$GO_HOME/bin"
     shell_commands:
+      - "echo --- Downloading and extracting Go 1.16.7 to $GO_HOME"
+      - "mkdir $GO_HOME"
+      - "curl https://mirror.bazel.build/golang.org/dl/go1.16.7.linux-amd64.tar.gz | tar xvz --strip-components=1 -C $GO_HOME"
       - "echo +++ Check go format"
       - "./check-gofmt.sh `find go -name '*.go'`"
       - "echo +++ Check go vet"
@@ -15,7 +21,13 @@ tasks:
   ubuntu1804_gobuild:
     platform: ubuntu1804
     name: "go build / test"
+    environment:
+      GO_HOME: "$HOME/go-1.16.7"
+      PATH: "$PATH:$GO_HOME/bin"
     shell_commands:
+      - "echo --- Downloading and extracting Go 1.16.7 to $GO_HOME"
+      - "mkdir $GO_HOME"
+      - "curl https://mirror.bazel.build/golang.org/dl/go1.16.7.linux-amd64.tar.gz | tar xvz --strip-components=1 -C $GO_HOME"
       - "echo +++ Running go build"
       - "go build ./..."
       - "echo +++ Running go test"


### PR DESCRIPTION
This fixes the Bazel CI pipeline, which turned red when we removed the pre-installed Go version in the base image.