### PR TITLE
Make numExecCalls increment atomic

### DIFF
--- a/go/pkg/fakes/exec.go
+++ b/go/pkg/fakes/exec.go
@@ -3,6 +3,7 @@ package fakes
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/client"
@@ -36,7 +37,7 @@ type Exec struct {
 	// Any blobs that will be put in the CAS after the fake execution completes.
 	OutputBlobs [][]byte
 	// Number of Execute calls.
-	numExecCalls int
+	numExecCalls int32
 	// Used for errors.
 	t testing.TB
 	// The digest of the fake action.
@@ -61,7 +62,7 @@ func (s *Exec) Clear() {
 
 // ExecuteCalls returns the total number of Execute calls.
 func (s *Exec) ExecuteCalls() int {
-	return s.numExecCalls
+	return int(s.numExecCalls)
 }
 
 func (s *Exec) fakeExecution(dg digest.Digest, skipCacheLookup bool) (*oppb.Operation, error) {
@@ -144,7 +145,7 @@ func (s *Exec) Execute(req *repb.ExecuteRequest, stream regrpc.Execution_Execute
 	} else if err = stream.Send(op); err != nil {
 		return err
 	}
-	s.numExecCalls++
+	atomic.AddInt32(&s.numExecCalls, 1)
 	return nil
 }
 


### PR DESCRIPTION
When execute() is called from multiple threads,
the standard increment of numExecCalls can result
in a race condition leading to incorrect counts.
Using atomic eliminates the issue.