### PR TITLE
Fix ComputeMerkleTree to handle empty root

### DIFF
--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -204,7 +204,9 @@ func loadFiles(execRoot string, excl []*command.InputExclusion, filesToProcess [
 			}
 
 			if len(files) == 0 {
-				fs[normPath] = &fileSysNode{emptyDirectoryMarker: true}
+				if normPath != "." {
+					fs[normPath] = &fileSysNode{emptyDirectoryMarker: true}
+				}
 				continue
 			}
 			for _, f := range files {
@@ -243,7 +245,9 @@ func (c *Client) ComputeMerkleTree(execRoot string, is *command.InputSpec, cache
 			return digest.Empty, nil, nil, err
 		}
 		if i.IsEmptyDirectory {
-			fs[normPath] = &fileSysNode{emptyDirectoryMarker: true}
+			if normPath != "." {
+				fs[normPath] = &fileSysNode{emptyDirectoryMarker: true}
+			}
 			continue
 		}
 		fs[normPath] = &fileSysNode{

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -369,8 +369,8 @@ func TestComputeMerkleTreeEmptyRoot(t *testing.T) {
 	if len(inputs) != 1 {
 		t.Errorf("ComputeMerkleTree(...) should only include one input:\n%v", inputs)
 	}
-	wantInput := uploadinfo.EntryFromBlob(nil)
-	if diff := cmp.Diff(wantInput, inputs[0], cmpopts.IgnoreFields(uploadinfo.Entry{}, "ueType")); diff != "" {
+	wantInput := uploadinfo.EntryFromBlob([]byte{})
+	if diff := cmp.Diff(wantInput, inputs[0], cmp.AllowUnexported(uploadinfo.Entry{})); diff != "" {
 		t.Errorf("ComputeMerkleTree(...) gave diff on input (-want +got) on blobs:\n%s", diff)
 	}
 	wantStats := &client.TreeStats{InputDirectories: 1}

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -350,11 +350,7 @@ func TestComputeMerkleTreeEmptyStructureVirtualInputs(t *testing.T) {
 }
 
 func TestComputeMerkleTreeEmptyRoot(t *testing.T) {
-	root, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatalf("failed to make temp dir: %v", err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 	inputSpec := &command.InputSpec{
 		Inputs: []string{"."},
 	}

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -373,7 +373,7 @@ func TestComputeMerkleTreeEmptyRoot(t *testing.T) {
 	if len(inputs) != 1 {
 		t.Errorf("ComputeMerkleTree(...) should only include one input:\n%v", inputs)
 	}
-	wantInput := uploadinfo.EntryFromBlob([]byte{})
+	wantInput := uploadinfo.EntryFromBlob(nil)
 	if diff := cmp.Diff(wantInput, inputs[0], cmpopts.IgnoreFields(uploadinfo.Entry{}, "ueType")); diff != "" {
 		t.Errorf("ComputeMerkleTree(...) gave diff on input (-want +got) on blobs:\n%s", diff)
 	}


### PR DESCRIPTION
The added test returns rood digest "24b2420bc49d8b8fdc1d011a163708927532b37dc9f91d7d8d6877e3a86559ca/73", which includes an empty dir "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/0" at path ".".

This change ignores empty dir if it's root dir.