### PR TITLE
Add testing functionality for WaitExecution

### DIFF
--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -112,6 +112,10 @@ type Client struct {
 	casDownloadRequests chan *downloadRequest
 	rpcTimeouts         RPCTimeouts
 	creds               credentials.PerRPCCredentials
+	// ForceEarlyWaitCalls specifies whether ExecuteAndWait should call WaitExecution immedately
+	// after receiving an Operation from Execute. It is primarily useful for testing
+	// WaitExecution.
+	ForceEarlyWaitCalls bool
 }
 
 const (

--- a/go/pkg/client/exec.go
+++ b/go/pkg/client/exec.go
@@ -247,6 +247,7 @@ func (c *Client) ExecuteAndWaitProgress(ctx context.Context, req *repb.ExecuteRe
 			if e != nil {
 				return e
 			}
+			returnEarly := !wait && c.ForceEarlyWaitCalls && !op.Done
 			wait = !op.Done
 			lastOp = op
 			if progress != nil {
@@ -254,6 +255,9 @@ func (c *Client) ExecuteAndWaitProgress(ctx context.Context, req *repb.ExecuteRe
 				if err := ptypes.UnmarshalAny(op.Metadata, metadata); err == nil {
 					progress(metadata)
 				}
+			}
+			if returnEarly {
+				return status.Error(codes.Internal, "fake error to for wait call")
 			}
 		}
 		return nil

--- a/go/pkg/client/exec.go
+++ b/go/pkg/client/exec.go
@@ -218,12 +218,6 @@ func buildCommand(ac *Action) *repb.Command {
 //   1) If an error occurs before the first operation is returned, or after the final operation is
 //      returned (i.e. the one with op.Done==true), retry by calling Execute again.
 //   2) Otherwise, retry by calling WaitExecution with the last operation name.
-// In addition, we want the retrier to trigger based on certain operation statuses as well as on
-// explicit errors. (The shouldRetry function knows which statuses.) We do this by mapping statuses,
-// if present, to errors inside the closure and then throwing away such "fake" errors outside the
-// closure (if we ran out of retries or if there was never a retrier enabled). The exception is
-// deadline-exceeded statuses, which we never give to the retrier (and hence will always propagate
-// directly to the caller).
 func (c *Client) ExecuteAndWait(ctx context.Context, req *repb.ExecuteRequest) (op *oppb.Operation, err error) {
 	return c.ExecuteAndWaitProgress(ctx, req, nil)
 }
@@ -234,7 +228,6 @@ func (c *Client) ExecuteAndWait(ctx context.Context, req *repb.ExecuteRequest) (
 // the remote action.
 func (c *Client) ExecuteAndWaitProgress(ctx context.Context, req *repb.ExecuteRequest, progress func(metadata *repb.ExecuteOperationMetadata)) (op *oppb.Operation, err error) {
 	wait := false    // Should we retry by calling WaitExecution instead of Execute?
-	opError := false // Are we propagating an Operation status as an error for the retrier's benefit?
 	lastOp := &oppb.Operation{}
 	closure := func(ctx context.Context) (e error) {
 		var res regrpc.Execution_ExecuteClient
@@ -263,18 +256,10 @@ func (c *Client) ExecuteAndWaitProgress(ctx context.Context, req *repb.ExecuteRe
 				}
 			}
 		}
-		st := OperationStatus(lastOp)
-		if st != nil {
-			opError = true
-			if st.Code() == codes.DeadlineExceeded {
-				return nil
-			}
-			return st.Err()
-		}
 		return nil
 	}
 	err = c.Retrier.Do(ctx, func() error { return c.CallWithTimeout(ctx, "Execute", closure) })
-	if err != nil && !opError {
+	if err != nil {
 		if st, ok := status.FromError(err); ok {
 			err = StatusDetailedError(st)
 		}

--- a/go/pkg/client/exec.go
+++ b/go/pkg/client/exec.go
@@ -227,7 +227,7 @@ func (c *Client) ExecuteAndWait(ctx context.Context, req *repb.ExecuteRequest) (
 // The supplied callback function is called for each message received to update the state of
 // the remote action.
 func (c *Client) ExecuteAndWaitProgress(ctx context.Context, req *repb.ExecuteRequest, progress func(metadata *repb.ExecuteOperationMetadata)) (op *oppb.Operation, err error) {
-	wait := false    // Should we retry by calling WaitExecution instead of Execute?
+	wait := false // Should we retry by calling WaitExecution instead of Execute?
 	lastOp := &oppb.Operation{}
 	closure := func(ctx context.Context) (e error) {
 		var res regrpc.Execution_ExecuteClient


### PR DESCRIPTION
The existing ExecuteAndWait function will rarely actually call
WaitExecution when used against a live server. This change adds the
ability to terminate the Execute call early and switch to WaitExecution
immediately so that it's possible for service implementors to test
WaitExecution.