### PR TITLE
Add DownloadAction and ExecuteAction operations to remotetool.

### DIFF
--- a/go/cmd/remotetool/main.go
+++ b/go/cmd/remotetool/main.go
@@ -38,9 +38,10 @@ type OpType string
 const (
 	downloadActionResult OpType = "download_action_result"
 	showAction           OpType = "show_action"
+	downloadAction       OpType = "download_action"
 	downloadBlob         OpType = "download_blob"
 	downloadDir          OpType = "download_dir"
-	reexecuteAction      OpType = "reexecute_action"
+	executeAction        OpType = "execute_action"
 	checkDeterminism     OpType = "check_determinism"
 	uploadBlob           OpType = "upload_blob"
 	uploadBlobV2         OpType = "upload_blob_v2"
@@ -49,9 +50,10 @@ const (
 var supportedOps = []OpType{
 	downloadActionResult,
 	showAction,
+	downloadAction,
 	downloadBlob,
 	downloadDir,
-	reexecuteAction,
+	executeAction,
 	checkDeterminism,
 	uploadBlob,
 }
@@ -60,8 +62,9 @@ var (
 	operation    = flag.String("operation", "", fmt.Sprintf("Specifies the operation to perform. Supported values: %v", supportedOps))
 	digest       = flag.String("digest", "", "Digest in <digest/size_bytes> format.")
 	pathPrefix   = flag.String("path", "", "Path to which outputs should be downloaded to.")
-	inputRoot    = flag.String("input_root", "", "For reexecute_action: if specified, override the action inputs with the specified input root.")
+	actionRoot   = flag.String("action_root", "", "For execute_action: the root of the action spec, containing ac.textproto (Action proto), cmd.textproto (Command proto), and input/ (root of the input tree).")
 	execAttempts = flag.Int("exec_attempts", 10, "For check_determinism: the number of times to remotely execute the action and check for mismatches.")
+	_            = flag.String("input_root", "", "Deprecated. Use action root instead.")
 )
 
 func main() {
@@ -110,14 +113,21 @@ func main() {
 		}
 		os.Stdout.Write([]byte(res))
 
-	case reexecuteAction:
-		if err := c.ReexecuteAction(ctx, getDigestFlag(), *inputRoot, outerr.SystemOutErr); err != nil {
-			log.Exitf("error reexecuting action %v: %v", getDigestFlag(), err)
+	case downloadAction:
+		err := c.DownloadAction(ctx, getDigestFlag(), getPathFlag())
+		if err != nil {
+			log.Exitf("error fetching action %v: %v", getDigestFlag(), err)
+		}
+		fmt.Printf("Action downloaded to %v\n", getPathFlag())
+
+	case executeAction:
+		if _, err := c.ExecuteAction(ctx, *digest, *actionRoot, getPathFlag(), outerr.SystemOutErr); err != nil {
+			log.Exitf("error executing action: %v", err)
 		}
 
 	case checkDeterminism:
-		if err := c.CheckDeterminism(ctx, getDigestFlag(), *inputRoot, *execAttempts); err != nil {
-			log.Exitf("error checking the determinism of %v: %v", getDigestFlag(), err)
+		if err := c.CheckDeterminism(ctx, *digest, *actionRoot, *execAttempts); err != nil {
+			log.Exitf("error checking determinism: %v", err)
 		}
 
 	case uploadBlob:

--- a/go/pkg/tool/BUILD.bazel
+++ b/go/pkg/tool/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//go/pkg/uploadinfo",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_golang_glog//:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_pkg_errors//:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",


### PR DESCRIPTION
DownloadAction downloads the action proto, the command proto and the
inputs into a directory. This allows inspection of the full action data
as well as modification and execution via the ExecuteAction operation.

The action is downloaded to a directory with the following structure:
- ac.textproto (the action proto in text format)
- cmd.textproto (the command proto in text format)
- input/ (the root of the input tree)

The above can be modified locally and then executed on the remote server
using the ExecuteAction command. For instance, you can add args to the
command, change environment variables, or change the input tree.