### PR TITLE
Ignore empty directory virtual inputs if inputs exist under them.

### DIFF
--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -322,7 +322,9 @@ func buildTree(files map[string]*fileSysNode) (*treeNode, error) {
 				node.dirs = make(map[string]*treeNode)
 			}
 			if node.dirs[base] != nil {
-				return nil, fmt.Errorf("path %v was tagged as an empty dir but isn't empty", name)
+				// Ignore empty directory if there exists a physical file or
+				// directory in this location.
+				continue
 			}
 			node.dirs[base] = &treeNode{}
 			continue

--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -321,12 +321,9 @@ func buildTree(files map[string]*fileSysNode) (*treeNode, error) {
 			if node.dirs == nil {
 				node.dirs = make(map[string]*treeNode)
 			}
-			if node.dirs[base] != nil {
-				// Ignore empty directory if there exists a physical file or
-				// directory in this location.
-				continue
+			if node.dirs[base] == nil {
+				node.dirs[base] = &treeNode{}
 			}
-			node.dirs[base] = &treeNode{}
 			continue
 		}
 		if fn.file != nil {

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -28,14 +28,15 @@ var (
 
 	fooDir    = &repb.Directory{Files: []*repb.FileNode{{Name: "foo", Digest: fooDgPb, IsExecutable: true}}}
 	barDir    = &repb.Directory{Files: []*repb.FileNode{{Name: "bar", Digest: barDgPb}}}
+	vBarDir   = &repb.Directory{Directories: []*repb.DirectoryNode{{Name: "baz", Digest: digest.Empty.ToProto()}}}
 	foobarDir = &repb.Directory{Files: []*repb.FileNode{
 		{Name: "bar", Digest: barDgPb},
 		{Name: "foo", Digest: fooDgPb, IsExecutable: true},
 	}}
 
-	fooDirBlob, barDirBlob, foobarDirBlob = mustMarshal(fooDir), mustMarshal(barDir), mustMarshal(foobarDir)
-	fooDirDg, barDirDg, foobarDirDg       = digest.NewFromBlob(fooDirBlob), digest.NewFromBlob(barDirBlob), digest.NewFromBlob(foobarDirBlob)
-	fooDirDgPb, barDirDgPb, foobarDirDgPb = fooDirDg.ToProto(), barDirDg.ToProto(), foobarDirDg.ToProto()
+	fooDirBlob, barDirBlob, foobarDirBlob, vBarDirBlob = mustMarshal(fooDir), mustMarshal(barDir), mustMarshal(foobarDir), mustMarshal(vBarDir)
+	fooDirDg, barDirDg, foobarDirDg, vBarDirDg         = digest.NewFromBlob(fooDirBlob), digest.NewFromBlob(barDirBlob), digest.NewFromBlob(foobarDirBlob), digest.NewFromBlob(vBarDirBlob)
+	fooDirDgPb, barDirDgPb, foobarDirDgPb, vBarDirDgPb = fooDirDg.ToProto(), barDirDg.ToProto(), foobarDirDg.ToProto(), vBarDirDg.ToProto()
 )
 
 func mustMarshal(p proto.Message) []byte {
@@ -1106,6 +1107,66 @@ func TestComputeMerkleTree(t *testing.T) {
 				InputDirectories: 3,
 				InputFiles:       2,
 				TotalInputBytes:  fooDg.Size + fooDirDg.Size + barDg.Size + barDirDg.Size,
+			},
+		},
+		{
+			desc: "Virtual inputs as ancestors of physical inputs",
+			input: []*inputPath{
+				{path: "fooDir/foo", fileContents: fooBlob, isExecutable: true},
+				{path: "barDir/bar", fileContents: barBlob},
+			},
+			spec: &command.InputSpec{
+				Inputs: []string{"fooDir", "barDir"},
+				VirtualInputs: []*command.VirtualInput{
+					&command.VirtualInput{Path: "barDir", IsEmptyDirectory: true},
+				},
+			},
+			rootDir: &repb.Directory{Directories: []*repb.DirectoryNode{
+				{Name: "barDir", Digest: barDirDgPb},
+				{Name: "fooDir", Digest: fooDirDgPb},
+			}},
+			additionalBlobs: [][]byte{fooBlob, barBlob, fooDirBlob, barDirBlob},
+			wantCacheCalls: map[string]int{
+				"fooDir":     1,
+				"fooDir/foo": 1,
+				"barDir":     1,
+				"barDir/bar": 1,
+			},
+			wantStats: &client.TreeStats{
+				InputDirectories: 3,
+				InputFiles:       2,
+				TotalInputBytes:  fooDg.Size + fooDirDg.Size + barDg.Size + barDirDg.Size,
+			},
+		},
+		{
+			desc: "Virtual inputs as children of physical inputs",
+			input: []*inputPath{
+				{path: "fooDir/foo", fileContents: fooBlob, isExecutable: true},
+				{path: "bar", fileContents: barBlob},
+			},
+			spec: &command.InputSpec{
+				Inputs: []string{"fooDir", "bar"},
+				VirtualInputs: []*command.VirtualInput{
+					&command.VirtualInput{Path: "bar/baz", IsEmptyDirectory: true},
+				},
+			},
+			rootDir: &repb.Directory{
+				Directories: []*repb.DirectoryNode{
+					{Name: "bar", Digest: vBarDirDgPb},
+					{Name: "fooDir", Digest: fooDirDgPb},
+				},
+				Files: []*repb.FileNode{{Name: "bar", Digest: barDgPb}},
+			},
+			additionalBlobs: [][]byte{fooBlob, barBlob, fooDirBlob, vBarDirBlob, []byte{}},
+			wantCacheCalls: map[string]int{
+				"fooDir":     1,
+				"fooDir/foo": 1,
+				"bar":        1,
+			},
+			wantStats: &client.TreeStats{
+				InputDirectories: 4,
+				InputFiles:       2,
+				TotalInputBytes:  fooDg.Size + fooDirDg.Size + barDg.Size + vBarDirDg.Size,
 			},
 		},
 		{


### PR DESCRIPTION
Currently if a treeNode has children and is also marked as an empty directory (virtual input), ComputeMerkleTree returns an error. This behavior is actually inconsistent, since it relies on the order of inputs checked in a loop over a map. This PR makes the behavior consistent and ignores empty directory virtual inputs if physical inputs exist under them. Note that physical input precedence is already enforced in ComputeMerkleTree where a virtual input has the same name as a physical input. This PR extends this behavior to virtual inputs that are ancestors to physical inputs.