### PR TITLE
Expose errors in closing the Writer.

### DIFF
--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -1002,12 +1002,12 @@ func (c *Client) readBlobStreamed(ctx context.Context, d digest.Digest, offset, 
 
 			if err == nil && errC != nil {
 				err = errC
-			} else {
+			} else if errC != nil {
 				log.Errorf("Failed to close writer: %v", errC)
 			}
 			if err == nil && errD != nil {
 				err = errD
-			} else {
+			} else if errD != nil {
 				log.Errorf("Failed to finalize writing blob: %v", errD)
 			}
 		}()

--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -1003,8 +1003,8 @@ func (c *Client) readBlobStreamed(ctx context.Context, d digest.Digest, offset, 
 			if err != nil && errC != nil {
 				err = errC
 			}
-			if err != nil && errD != nil {
-				err = fmt.Errorf("Failed to finalize writing downloaded data downstream: %v", err)
+			if errD != nil {
+				err = fmt.Errorf("Failed to finalize writing downloaded data downstream: %v", errD)
 			}
 		}()
 
@@ -1020,7 +1020,7 @@ func (c *Client) readBlobStreamed(ctx context.Context, d digest.Digest, offset, 
 		return stats, err
 	}
 	if wt.n != sz {
-		return stats, fmt.Errorf("partial read of digest %s returned %d bytes", d, sz)
+		return stats, fmt.Errorf("partial read of digest %s returned %d bytes, expected %d bytes", d, wt.n, sz)
 	}
 
 	// Incomplete reads only, since we can't reliably calculate hash without the full blob

--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -1000,11 +1000,15 @@ func (c *Client) readBlobStreamed(ctx context.Context, d digest.Digest, offset, 
 			errD := <-done
 			close(done)
 
-			if err != nil && errC != nil {
+			if err == nil && errC != nil {
 				err = errC
+			} else {
+				log.Errorf("Failed to close writer: %v", errC)
 			}
-			if errD != nil {
-				err = fmt.Errorf("Failed to finalize writing downloaded data downstream: %v", errD)
+			if err == nil && errD != nil {
+				err = errD
+			} else {
+				log.Errorf("Failed to finalize writing blob: %v", errD)
 			}
 		}()
 


### PR DESCRIPTION
In case the machine runs out of disk space, the write error will be
captured in the done channel, but is suppressed if no other errors
were encountered. This PR exposes the error in the done channel.