### PR TITLE
Always set file modified time after writing to a file

### DIFF
--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -1340,7 +1340,7 @@ func copyFile(srcOutDir, dstOutDir, from, to string, mode os.FileMode) error {
 	defer s.Close()
 
 	dst := filepath.Join(dstOutDir, to)
-	t, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE, mode)
+	t, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Two problems:
1. We are incorrectly writing to a file if the destination file has more
   content than the source file during copying.
2. We aren't updating the timestamp of the file when the destiination
   file has zero bytes.

Both these would be fixed by just setting the file open mode to
os.O_TRUNC which would truncate the file if it already exists.

Test:
1. Unit tests
2. Tested in Android build with:
```
rm -f out/reproxy* && touch frameworks/opt/net/voip/src/java/com/android/server/sip/SipWakeupTimer.java && RBE_v=3 RBE_instance="projects/foundry-x-experiments/instances/default-instance" RBE_use_unified_cas_ops=false RBE_use_batches=false RBE_METALAVA=true m out/soong/.intermediates/frameworks/base/api-stubs-docs-non-updatable/android_common/metalava/check_last_released_api.timestamp
```

and confirmed that `restat` warnings were no longer popping up during
rebuilds.