### PR TITLE
Returned a customized error when initializing a new client

### DIFF
--- a/go/pkg/fakes/server.go
+++ b/go/pkg/fakes/server.go
@@ -77,7 +77,8 @@ func (s *Server) NewTestClient(ctx context.Context) (*rc.Client, error) {
 // NewClientConn returns a gRPC client connction to the server.
 func (s *Server) NewClientConn(ctx context.Context) (*grpc.ClientConn, error) {
 	p := s.dialParams()
-	return client.Dial(ctx, p.Service, p)
+	conn, _, err := client.Dial(ctx, p.Service, p)
+	return conn, err
 }
 
 func (s *Server) dialParams() rc.DialParams {

--- a/go/pkg/filemetadata/filemetadata_test.go
+++ b/go/pkg/filemetadata/filemetadata_test.go
@@ -41,6 +41,7 @@ func TestComputeFilesNoXattr(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			before := time.Now().Truncate(time.Second)
+			time.Sleep(5 * time.Second)
 			filename, err := testutil.CreateFile(t, tc.executable, tc.contents)
 			if err != nil {
 				t.Fatalf("Failed to create tmp file for testing digests: %v", err)


### PR DESCRIPTION
This is to also indicate the type of authenticated used by the SDK to
connect to the RBE so that clients of the SDK can report better error
messages to indicate how the authentication failure can be fixed.

Test: Applied this change in re-client and confirmed that the returned
object has the proper auth type set.