### PR TITLE
Fix all lint errors and enable golint

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -11,6 +11,7 @@ tasks:
       - "curl https://mirror.bazel.build/golang.org/dl/go1.16.7.linux-amd64.tar.gz | tar xvz --strip-components=1 -C $GO_HOME"
       - "echo +++ Check go format"
       - "./check-gofmt.sh `find go -name '*.go'`"
+      - "./check-golint.sh"
       - "echo +++ Check go vet"
       - "go vet ./..."
     build_targets:

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,6 +7,7 @@
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
 
 ./check-gofmt.sh $gofiles
+./check-golint.sh
 
 ########################################################################
 # Precommit hook to rebuild generated go code. Fails if building or

--- a/check-golint.sh
+++ b/check-golint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+linterrs=$(golint -min_confidence 1.0 ./...)
+[ -z "$linterrs" ] && exit 0
+
+# Some files are not golint'd. Print message and fail.
+
+echo >&2 "Please fix the following lint errors:"
+echo >&2 "$linterrs"
+
+exit 1

--- a/go/pkg/client/client_context.go
+++ b/go/pkg/client/client_context.go
@@ -33,7 +33,7 @@ type ContextMetadata struct {
 	ToolVersion string
 }
 
-// LogContextInfof(ctx, x, ...) is equivalent to log.V(x).Infof(...) except it
+// LogContextInfof is equivalent to log.V(x).Infof(...) except it
 // also logs context metadata, if available.
 func LogContextInfof(ctx context.Context, v log.Level, format string, args ...interface{}) {
 	if log.V(v) {

--- a/go/pkg/digest/digest.go
+++ b/go/pkg/digest/digest.go
@@ -21,7 +21,7 @@ var (
 	// hexStringRegex doesn't contain the size because that's checked separately.
 	hexStringRegex = regexp.MustCompile("^[a-f0-9]+$")
 
-	// The digest function used.
+	// HashFn is the digest function used.
 	HashFn = crypto.SHA256
 
 	// Empty is the digest of the empty blob.

--- a/go/pkg/fakes/exec.go
+++ b/go/pkg/fakes/exec.go
@@ -110,7 +110,7 @@ func (s *Exec) fakeExecution(dg digest.Digest, skipCacheLookup bool) (*oppb.Oper
 }
 
 // GetCapabilities returns the fake capabilities.
-func (c *Exec) GetCapabilities(ctx context.Context, req *repb.GetCapabilitiesRequest) (res *repb.ServerCapabilities, err error) {
+func (s *Exec) GetCapabilities(ctx context.Context, req *repb.GetCapabilitiesRequest) (res *repb.ServerCapabilities, err error) {
 	dgFn := digest.GetDigestFunction()
 	res = &repb.ServerCapabilities{
 		ExecutionCapabilities: &repb.ExecutionCapabilities{

--- a/go/pkg/reader/reader.go
+++ b/go/pkg/reader/reader.go
@@ -13,11 +13,13 @@ import (
 	"github.com/mostynb/zstdpool-syncpool"
 )
 
+// Initializable is an interface containing methods to initialize a ReadSeeker.
 type Initializable interface {
 	IsInitialized() bool
 	Initialize() error
 }
 
+// ReadSeeker is an interface used to capture a file reader with seek functionality.
 type ReadSeeker interface {
 	io.Reader
 	io.Closer
@@ -102,7 +104,7 @@ func (fio *fileSeeker) Initialize() error {
 		return err
 	}
 	if off != fio.seekOffset {
-		return errors.New(fmt.Sprintf("File seeking ended at %d. Expected %d,", off, fio.seekOffset))
+		return fmt.Errorf("File seeking ended at %d. Expected %d,", off, fio.seekOffset)
 	}
 
 	if fio.reader == nil {

--- a/go/pkg/testutil/testutil.go
+++ b/go/pkg/testutil/testutil.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+// CreateFile is used to create a temp file with the given contents and executable permissions.
+// It returns the name of the created file or error if file creation has failed.
 func CreateFile(t *testing.T, executable bool, contents string) (string, error) {
 	t.Helper()
 	perm := os.FileMode(0666)


### PR DESCRIPTION
This is so that we catch lint issues here before we import the SDK to
google3. Also added the lint check to presubmit hooks just like how we
do for gofmt.