### PR TITLE
Fix what path gets updated in cache

### DIFF
--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -1306,7 +1306,11 @@ func (c *Client) downloadOutputs(ctx context.Context, outs map[string]*TreeOutpu
 			Digest:       output.Digest,
 			IsExecutable: output.IsExecutable,
 		}
-		if err := cache.Update(path, md); err != nil {
+		absPath := path
+		if !filepath.IsAbs(absPath) {
+			absPath = filepath.Join(outDir, absPath)
+		}
+		if err := cache.Update(absPath, md); err != nil {
 			return fullStats, err
 		}
 	}


### PR DESCRIPTION
We always lookup the absolute path, so when we update the cache, we
should also update it to be the absolute path.

Test: Ran the repro in bug b/228312861