### PR TITLE
Added com_google_cloud_go_compute_metadata dependency

### DIFF
--- a/remote-apis-sdks-deps.bzl
+++ b/remote-apis-sdks-deps.bzl
@@ -91,6 +91,13 @@ def remote_apis_sdks_go_deps():
     )
     _maybe(
         go_repository,
+        name = "com_google_cloud_go_compute_metadata",
+        importpath = "cloud.google.com/go/compute/metadata",
+        sum = "h1:efOwf5ymceDhK6PKMnnrTHP4pppY5L22mle96M1yP48=",
+        version = "v0.2.1",
+    )
+    _maybe(
+        go_repository,
         name = "com_google_cloud_go_compute",
         version = "v0.1.0",
         sum = "h1:rSUBvAyVwNJ5uQCKNJFMwPtTvJkfN38b6Pvb9zZoqJ8=",


### PR DESCRIPTION
Similar to #396, the `cloud.google.com/go/compute/metadata` submodule was carved out and has caused some build failures.

Unfortunately, there seems to be a leak in the "hermetic" build for Bazel + Go projects (`rules_go` + `gazelle` stack), because these changes should not be necessary given that the previously defined dependency, `cloud.google.com/go/compute@v0.1.0` and the dep before _that_ was added, `cloud.google.com/go/compute@v0.65.0`, should have all of the necessary code for dependencies to be resolved. Builds with native the `go` tool work fine without any changes to the `go.mod` to account for this.

The "fix" is to explicitly state the dependency, which I've done here. `bazel build //...` passes. I actually did some more testing and I could remove the other `com_google_cloud_go` targets and it still builds, but I went with the simple thing here.

cc: @codyoss who I work with on `cloud.google.com/go`