### PR TITLE
Download Specified Outputs

### DIFF
--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -1242,7 +1242,7 @@ func (c *Client) DownloadDirectory(ctx context.Context, d digest.Digest, outDir 
 		return nil, stats, err
 	}
 
-	outStats, err := c.downloadOutputs(ctx, outputs, outDir, cache)
+	outStats, err := c.DownloadOutputs(ctx, outputs, outDir, cache)
 	stats.addFrom(outStats)
 	return outputs, stats, err
 }
@@ -1261,10 +1261,13 @@ func (c *Client) DownloadActionOutputs(ctx context.Context, resPb *repb.ActionRe
 			return nil, err
 		}
 	}
-	return c.downloadOutputs(ctx, outs, outDir, cache)
+	return c.DownloadOutputs(ctx, outs, outDir, cache)
 }
 
-func (c *Client) downloadOutputs(ctx context.Context, outs map[string]*TreeOutput, outDir string, cache filemetadata.Cache) (*MovedBytesMetadata, error) {
+// DownloadOutputs downloads the specified outputs. It returns the amount of downloaded bytes.
+// It returns the number of logical and real bytes downloaded, which may be different from sum
+// of sizes of the files due to dedupping and compression.
+func (c *Client) DownloadOutputs(ctx context.Context, outs map[string]*TreeOutput, outDir string, cache filemetadata.Cache) (*MovedBytesMetadata, error) {
 	var symlinks, copies []*TreeOutput
 	downloads := make(map[digest.Digest]*TreeOutput)
 	fullStats := &MovedBytesMetadata{}

--- a/go/pkg/command/command.go
+++ b/go/pkg/command/command.go
@@ -306,6 +306,9 @@ type ExecutionOptions struct {
 	// Download command outputs after execution. Defaults to true.
 	DownloadOutputs bool
 
+	// Preserve mtimes for unchanged outputs when downloading. Defaults to false.
+	PreserveUnchangedOutputMtime bool
+
 	// Download command stdout and stderr. Defaults to true.
 	DownloadOutErr bool
 }
@@ -313,10 +316,11 @@ type ExecutionOptions struct {
 // DefaultExecutionOptions returns the recommended ExecutionOptions.
 func DefaultExecutionOptions() *ExecutionOptions {
 	return &ExecutionOptions{
-		AcceptCached:    true,
-		DoNotCache:      false,
-		DownloadOutputs: true,
-		DownloadOutErr:  true,
+		AcceptCached:                 true,
+		DoNotCache:                   false,
+		DownloadOutputs:              true,
+		PreserveUnchangedOutputMtime: false,
+		DownloadOutErr:               true,
 	}
 }
 


### PR DESCRIPTION
Adds functions to retrieve outputs and download specified outputs instead of the ones in working dir. Also adds a new command option for preserving mtimes of unchanged outputs.