### PR TITLE
Optionally process symlinks pointing outside exec root

### DIFF
--- a/go/pkg/client/BUILD.bazel
+++ b/go/pkg/client/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//testing/protocmp",
         "@org_golang_google_protobuf//types/known/anypb:go_default_library",
         "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",


### PR DESCRIPTION
Previously if `TreeSymlinkOpts.Preserved` was set to `true`, symlinks pointing outside of the exec root would always be rejected. However, it can be useful to preserve symlinks by default while replacing them with the targeted file if the targeted file is outside of the exec root.

So add a new `TreeSymlinkOpts.MaterializeOutsideExecRoot` option that enables this behavior if set to true.

See https://crbug.com/1216363 for context on why this is useful.