### PR TITLE
Update writeChunked method in bytestream.go to allow resumable upload with ByteStream Write API.

### DIFF
--- a/go/pkg/client/BUILD.bazel
+++ b/go/pkg/client/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
     name = "client_test",
     srcs = [
         "batch_retries_test.go",
+        "bytestream_test.go",
         "cas_internal_test.go",
         "cas_test.go",
         "client_test.go",

--- a/go/pkg/client/bytestream.go
+++ b/go/pkg/client/bytestream.go
@@ -179,6 +179,7 @@ func (c *Client) readStreamed(ctx context.Context, name string, offset, limit in
 	if err != nil {
 		return 0, err
 	}
+
 	var n int64
 	for {
 		var resp *bspb.ReadResponse

--- a/go/pkg/client/bytestream.go
+++ b/go/pkg/client/bytestream.go
@@ -20,12 +20,12 @@ type ByteStreamWriteOption interface {
 	Apply(*ByteStreamWriteOpts)
 }
 
-// ByteSteramOptFinishWrite is a boolean flag to set FinishWrite
+// ByteStreamOptFinishWrite is a boolean flag to set FinishWrite
 // in ByteStream.WriteRequest.
-type ByteSteramOptFinishWrite bool
+type ByteStreamOptFinishWrite bool
 
-// Apply sets ByteSteramOptFinishWrite in ByteStreamWriteOpts.
-func (o ByteSteramOptFinishWrite) Apply(opts *ByteStreamWriteOpts) {
+// Apply sets ByteStreamOptFinishWrite in ByteStreamWriteOpts.
+func (o ByteStreamOptFinishWrite) Apply(opts *ByteStreamWriteOpts) {
 	opts.FinishWrite = bool(o)
 }
 

--- a/go/pkg/client/bytestream_test.go
+++ b/go/pkg/client/bytestream_test.go
@@ -1,0 +1,220 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"google.golang.org/grpc"
+
+	bsgrpc "google.golang.org/genproto/googleapis/bytestream"
+	bspb "google.golang.org/genproto/googleapis/bytestream"
+)
+
+
+var (
+	logStreams map[string]*logStream
+)
+
+type logStream struct {
+	logStreamID   string
+	logicalOffset int64
+	finalized     bool
+}
+
+func TestWriteChunkedWithOffset_LogStream(t *testing.T) {
+	tests := []struct {
+		description string
+		ls          *logStream
+		data        []byte
+		numIterate  int
+		offset      int64
+		notFound    bool
+		wantBytes   int64
+		wantErr     bool
+	}{
+		{
+			description: "valid data with offset 0",
+			ls:          &logStream{logStreamID: "logstream1", logicalOffset: 0},
+			data:        []byte("Hello World! This is large data to send."),
+			numIterate:  3,
+			offset:      0,
+			wantErr:     false,
+		},
+		{
+			description: "valid data with non-zero offset",
+			ls:          &logStream{logStreamID: "logstream2", logicalOffset: 4},
+			data:        []byte("Hello World! This is large data to send."),
+			numIterate:  3,
+			offset:      4,
+			wantErr:     false,
+		},
+		{
+			description: "one big chunk",
+			ls:          &logStream{logStreamID: "logstream3", logicalOffset: 0},
+			data:        []byte("Hello World! This is large data to send."),
+			numIterate:  1,
+			offset:      0,
+			wantErr:     false,
+		},
+		{
+			description: "empty data",
+			ls:          &logStream{logStreamID: "logstream4", logicalOffset: 0},
+			data:        []byte{},
+
+			numIterate: 1,
+			offset:     0,
+			wantBytes:  0,
+			wantErr:    false,
+		},
+		{
+			description: "invalid write to finalized logstream",
+			ls:          &logStream{logStreamID: "logstream5", logicalOffset: 5, finalized: true},
+			data:        []byte("Hello World! This is large data to send."),
+			numIterate:  1,
+			offset:      5,
+			wantBytes:   0,
+			wantErr:     true,
+		},
+		{
+			description: "not found",
+			ls:          &logStream{logStreamID: "notFound", logicalOffset: 0},
+			data:        []byte("Hello World! This is large data to send."),
+			numIterate:  1,
+			offset:      0,
+			notFound:    true,
+			wantBytes:   0,
+			wantErr:     true,
+		},
+		{
+			description: "invlid offset",
+			ls:          &logStream{logStreamID: "logstream6", logicalOffset: 8},
+			data:        []byte("Hello World! This is large data to send."),
+			numIterate:  1,
+			offset:      5,
+			notFound:    false,
+			wantBytes:   0,
+			wantErr:     true,
+		},
+	}
+
+	b := setup(t)
+	defer b.shutDown()
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			size := len(test.data)/test.numIterate + 1
+			start := int(test.offset)
+			end := size
+			test.wantBytes = int64(len(test.data))
+			lsID := test.ls.logStreamID
+			opts := &ByteStreamWriteOpts{LastLogicalOffset: test.offset}
+			if !test.notFound {
+				logStreams[lsID] = test.ls
+			}
+			ChunkMaxSize(size).Apply(b.client)
+
+			for i := 0; i < test.numIterate; i++ {
+				if end > len(test.data) {
+					end = len(test.data)
+				}
+				if i == test.numIterate-1 {
+					opts.FinishWrite = true
+				}
+				writtenBytes, err := b.client.WriteBytesWithOffset(b.ctx, lsID, test.data[start:end], opts)
+
+				if test.wantErr && err == nil {
+					t.Fatal("WriteBytesWithOffset() got nil error, want non-nil error")
+				}
+				if !test.wantErr && err != nil {
+					t.Fatal("WriteBytesWithOffset() failed unexpectedly: %v", err)
+				}
+				opts.LastLogicalOffset += writtenBytes
+				start = end
+				end += size
+			}
+
+			if !test.wantErr && logStreams[lsID].logicalOffset != test.wantBytes {
+				t.Errorf("WriteBytesWithOffset() = %d, want %d", logStreams[lsID].logicalOffset, test.wantBytes)
+			}
+			if !test.wantErr && logStreams[lsID].finalized == false {
+				t.Errorf("WriteBytesWithOffset() didn't correctly finalize logstream")
+			}
+		})
+	}
+}
+
+type Bytestream struct {
+}
+
+type Server struct {
+	client   *Client
+	listener net.Listener
+	server   *grpc.Server
+	fake     *Bytestream
+	ctx      context.Context
+}
+
+func setup(t *testing.T) *Server {
+	s := &Server{ctx: context.Background()}
+	var err error
+	s.listener, err = net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Cannot listen: %v", err)
+	}
+	s.server = grpc.NewServer()
+	s.fake = &Bytestream{}
+	bsgrpc.RegisterByteStreamServer(s.server, s.fake)
+
+	go s.server.Serve(s.listener)
+	s.client, err = NewClient(s.ctx, instance, DialParams{
+		Service:    s.listener.Addr().String(),
+		NoSecurity: true,
+	}, StartupCapabilities(false), ChunkMaxSize(2))
+	if err != nil {
+		t.Fatalf("Error connecting to server: %v", err)
+	}
+	logStreams = make(map[string]*logStream, 10)
+	return s
+}
+
+func (s *Server) shutDown() {
+	s.client.Close()
+	s.listener.Close()
+	s.server.Stop()
+}
+
+func (b *Bytestream) QueryWriteStatus(context.Context, *bspb.QueryWriteStatusRequest) (*bspb.QueryWriteStatusResponse, error) {
+	return &bspb.QueryWriteStatusResponse{}, nil
+}
+
+func (b *Bytestream) Read(req *bspb.ReadRequest, stream bsgrpc.ByteStream_ReadServer) error {
+	return nil
+}
+
+// Write implements the write operation for LogStream Write API.
+func (b *Bytestream) Write(stream bsgrpc.ByteStream_WriteServer) error {
+	defer stream.SendAndClose(&bspb.WriteResponse{})
+	req, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+
+	size := int64(len(req.GetData()))
+	ls, ok := logStreams[req.GetResourceName()]
+	if !ok {
+		return fmt.Errorf("unable to find LogStream")
+	}
+	if ls.finalized {
+		return fmt.Errorf("unable to extend finalized LogStream")
+	}
+	if ls.logicalOffset != req.GetWriteOffset() {
+		return fmt.Errorf("incorrect LogStream offset")
+	}
+	ls.finalized = req.GetFinishWrite()
+	ls.logicalOffset += size
+
+	return nil
+}
+

--- a/go/pkg/client/bytestream_test.go
+++ b/go/pkg/client/bytestream_test.go
@@ -88,7 +88,7 @@ func TestWriteBytesWithOffsetSuccess_LogStream(t *testing.T) {
 
 				writtenBytes, err := b.client.WriteBytesWithOptions(b.ctx, lsID, test.data[start:end], test.opts...)
 				if err != nil {
-					t.Fatalf("WriteBytesWithOffset() failed unexpectedly: %v", err)
+					t.Errorf("WriteBytesWithOffset() failed unexpectedly: %v", err)
 				}
 				test.opts[0] = test.opts[0].(ByteStreamOptOffset) + ByteStreamOptOffset(writtenBytes)
 				start = end
@@ -162,7 +162,7 @@ func TestWriteBytesWithOffsetErrors_LogStream(t *testing.T) {
 			ChunkMaxSize(len(data)).Apply(b.client)
 			writtenBytes, err := b.client.WriteBytesWithOptions(b.ctx, lsID, data, test.opts...)
 			if err == nil {
-				t.Errorf("WriteBytesWithOffset() got nil error, want non-nil error")
+				t.Error("WriteBytesWithOffset() got nil error, want non-nil error")
 			}
 			if writtenBytes != 0 {
 				t.Errorf("WriteBytesWithOffset() got %d byte(s), want 0 byte", writtenBytes)
@@ -183,14 +183,14 @@ func TestWirteBytesWithOptions_FinishWrite(t *testing.T) {
 
 			_, err := b.client.WriteBytesWithOptions(b.ctx, lsID, logStreamData, flag)
 			if err != nil {
-				t.Fatalf("WriteBytesWithOffset() failed unexpectedly: %v", err)
+				t.Errorf("WriteBytesWithOffset() failed unexpectedly: %v", err)
 			}
 
 			if logStreams[lsID].logicalOffset != int64(dataSize) {
 				t.Errorf("WriteBytesWithOffset() = %d, want %d", logStreams[lsID].logicalOffset, int64(dataSize))
 			}
 			if logStreams[lsID].finalized != bool(flag.(ByteSteramOptFinishWrite)) {
-				t.Errorf("WriteBytesWithOffset() didn't correctly finalize logstream")
+				t.Errorf("WriteBytesWithOffset() got %t, want %t state", logStreams[lsID].finalized, bool(flag.(ByteSteramOptFinishWrite)))
 			}
 		})
 
@@ -209,13 +209,13 @@ func TestWirteBytesWithOptions_Offset(t *testing.T) {
 
 			_, err := b.client.WriteBytesWithOptions(b.ctx, lsID, logStreamData[int(offset.(ByteStreamOptOffset)):], offset)
 			if err != nil {
-				t.Fatalf("WriteBytesWithOffset() failed unexpectedly: %v", err)
+				t.Errorf("WriteBytesWithOffset() failed unexpectedly: %v", err)
 			}
 			if logStreams[lsID].logicalOffset != int64(dataSize) {
 				t.Errorf("WriteBytesWithOffset() = %d, want %d", logStreams[lsID].logicalOffset, int64(dataSize))
 			}
 			if logStreams[lsID].finalized != true {
-				t.Errorf("WriteBytesWithOffset() didn't correctly finalize logstream")
+				t.Error("WriteBytesWithOffset() didn't correctly finalize logstream")
 			}
 		})
 	}

--- a/go/pkg/client/bytestream_test.go
+++ b/go/pkg/client/bytestream_test.go
@@ -23,7 +23,7 @@ type logStream struct {
 	finalized     bool
 }
 
-func TestWriteChunkedWithOffset_LogStream(t *testing.T) {
+func TestWriteBytesWithOffset_LogStream(t *testing.T) {
 	tests := []struct {
 		description string
 		ls          *logStream

--- a/go/pkg/client/bytestream_test.go
+++ b/go/pkg/client/bytestream_test.go
@@ -12,7 +12,6 @@ import (
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
-
 var (
 	logStreams map[string]*logStream
 )
@@ -128,7 +127,7 @@ func TestWriteChunkedWithOffset_LogStream(t *testing.T) {
 					t.Fatal("WriteBytesWithOffset() got nil error, want non-nil error")
 				}
 				if !test.wantErr && err != nil {
-					t.Fatal("WriteBytesWithOffset() failed unexpectedly: %v", err)
+					t.Fatalf("WriteBytesWithOffset() failed unexpectedly: %v", err)
 				}
 				opts.LastLogicalOffset += writtenBytes
 				start = end
@@ -139,7 +138,7 @@ func TestWriteChunkedWithOffset_LogStream(t *testing.T) {
 				t.Errorf("WriteBytesWithOffset() = %d, want %d", logStreams[lsID].logicalOffset, test.wantBytes)
 			}
 			if !test.wantErr && logStreams[lsID].finalized == false {
-				t.Errorf("WriteBytesWithOffset() didn't correctly finalize logstream")
+				t.Error("WriteBytesWithOffset() didn't correctly finalize logstream")
 			}
 		})
 	}
@@ -217,4 +216,3 @@ func (b *Bytestream) Write(stream bsgrpc.ByteStream_WriteServer) error {
 
 	return nil
 }
-

--- a/go/pkg/client/bytestream_test.go
+++ b/go/pkg/client/bytestream_test.go
@@ -71,7 +71,7 @@ func TestWriteBytesWithOffsetSuccess_LogStream(t *testing.T) {
 			start := int(test.opts[0].(ByteStreamOptOffset))
 			end := size
 			lsID := test.description
-			test.ls.logStreamID = test.description
+			test.ls.logStreamID = lsID
 			b.fake.logStreams[lsID] = test.ls
 			ChunkMaxSize(size).Apply(b.client)
 
@@ -88,12 +88,11 @@ func TestWriteBytesWithOffsetSuccess_LogStream(t *testing.T) {
 					t.Errorf("WriteBytesWithOffset() failed unexpectedly: %v", err)
 				}
 				if b.fake.logStreams[lsID].logicalOffset != int64(end) {
-					t.Errorf("WriteBytesWithOffset() = %d, want %d", b.fake.logStreams[lsID].logicalOffset, end+1)
+					t.Errorf("WriteBytesWithOffset() = %d, want %d", b.fake.logStreams[lsID].logicalOffset, end)
 				}
-
 				// LogStream shouldn't be finalized when we set ByteSteramOptFinishWrite false.
 				if i != test.dataPartsLen-1 && b.fake.logStreams[lsID].finalized == true {
-					t.Error("WriteBytesWithOffset() didn't correctly finalize logstream")
+					t.Error("WriteBytesWithOffset() incorrectly finalized LogStream")
 				}
 
 				test.opts[0] = test.opts[0].(ByteStreamOptOffset) + ByteStreamOptOffset(writtenBytes)
@@ -105,7 +104,7 @@ func TestWriteBytesWithOffsetSuccess_LogStream(t *testing.T) {
 				t.Errorf("WriteBytesWithOffset() = %d, want %d", b.fake.logStreams[lsID].logicalOffset, test.wantBytesLen)
 			}
 			if b.fake.logStreams[lsID].finalized == false {
-				t.Error("WriteBytesWithOffset() didn't correctly finalize logstream")
+				t.Error("WriteBytesWithOffset() didn't correctly finalize LogStream")
 			}
 		})
 	}
@@ -156,7 +155,7 @@ func TestWriteBytesWithOffsetErrors_LogStream(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			lsID := test.description
 			if test.ls != nil {
-				test.ls.logStreamID = test.description
+				test.ls.logStreamID = lsID
 				b.fake.logStreams[lsID] = test.ls
 			}
 			data := []byte("Hello World!")
@@ -216,7 +215,7 @@ func TestWirteBytesWithOptions_LogStream_Offset(t *testing.T) {
 				t.Errorf("WriteBytesWithOffset() = %d, want %d", b.fake.logStreams[lsID].logicalOffset, int64(dataSize))
 			}
 			if !b.fake.logStreams[lsID].finalized {
-				t.Error("WriteBytesWithOffset() didn't correctly finalize logstream")
+				t.Error("WriteBytesWithOffset() didn't correctly finalize LogStream")
 			}
 		})
 	}

--- a/go/pkg/client/bytestream_test.go
+++ b/go/pkg/client/bytestream_test.go
@@ -33,7 +33,7 @@ func TestWriteBytesWithOffsetSuccess_LogStream(t *testing.T) {
 			description:  "valid data with offset 0",
 			ls:           &logStream{logicalOffset: 0},
 			data:         logStreamData,
-			opts:         []ByteStreamWriteOption{ByteStreamOptOffset(0), ByteSteramOptFinishWrite(false)},
+			opts:         []ByteStreamWriteOption{ByteStreamOptOffset(0), ByteStreamOptFinishWrite(false)},
 			dataPartsLen: 3,
 			wantBytesLen: int64(len(logStreamData)),
 		},
@@ -41,7 +41,7 @@ func TestWriteBytesWithOffsetSuccess_LogStream(t *testing.T) {
 			description:  "valid data with non-zero offset",
 			ls:           &logStream{logicalOffset: 4},
 			data:         logStreamData,
-			opts:         []ByteStreamWriteOption{ByteStreamOptOffset(4), ByteSteramOptFinishWrite(false)},
+			opts:         []ByteStreamWriteOption{ByteStreamOptOffset(4), ByteStreamOptFinishWrite(false)},
 			dataPartsLen: 3,
 			wantBytesLen: int64(len(logStreamData)),
 		},
@@ -49,7 +49,7 @@ func TestWriteBytesWithOffsetSuccess_LogStream(t *testing.T) {
 			description:  "one big chunk",
 			ls:           &logStream{logicalOffset: 0},
 			data:         logStreamData,
-			opts:         []ByteStreamWriteOption{ByteStreamOptOffset(0), ByteSteramOptFinishWrite(true)},
+			opts:         []ByteStreamWriteOption{ByteStreamOptOffset(0), ByteStreamOptFinishWrite(true)},
 			dataPartsLen: 1,
 			wantBytesLen: int64(len(logStreamData)),
 		},
@@ -57,7 +57,7 @@ func TestWriteBytesWithOffsetSuccess_LogStream(t *testing.T) {
 			description:  "empty data",
 			ls:           &logStream{logicalOffset: 0},
 			data:         []byte{},
-			opts:         []ByteStreamWriteOption{ByteStreamOptOffset(0), ByteSteramOptFinishWrite(false)},
+			opts:         []ByteStreamWriteOption{ByteStreamOptOffset(0), ByteStreamOptFinishWrite(false)},
 			dataPartsLen: 1,
 			wantBytesLen: 0,
 		},
@@ -80,7 +80,7 @@ func TestWriteBytesWithOffsetSuccess_LogStream(t *testing.T) {
 					end = len(test.data)
 				}
 				if i == test.dataPartsLen-1 {
-					test.opts[1] = ByteSteramOptFinishWrite(true)
+					test.opts[1] = ByteStreamOptFinishWrite(true)
 				}
 
 				writtenBytes, err := b.client.WriteBytesWithOptions(b.ctx, lsID, test.data[start:end], test.opts...)
@@ -90,7 +90,7 @@ func TestWriteBytesWithOffsetSuccess_LogStream(t *testing.T) {
 				if b.fake.logStreams[lsID].logicalOffset != int64(end) {
 					t.Errorf("WriteBytesWithOffset() = %d, want %d", b.fake.logStreams[lsID].logicalOffset, end)
 				}
-				// LogStream shouldn't be finalized when we set ByteSteramOptFinishWrite false.
+				// LogStream shouldn't be finalized when we set ByteStreamOptFinishWrite false.
 				if i != test.dataPartsLen-1 && b.fake.logStreams[lsID].finalized == true {
 					t.Error("WriteBytesWithOffset() incorrectly finalized LogStream")
 				}
@@ -121,31 +121,31 @@ func TestWriteBytesWithOffsetErrors_LogStream(t *testing.T) {
 			description: "invalid write to finalized logstream",
 			ls:          &logStream{logicalOffset: 0, finalized: true},
 			data:        logStreamData,
-			opts:        []ByteStreamWriteOption{ByteStreamOptOffset(0), ByteSteramOptFinishWrite(false)},
+			opts:        []ByteStreamWriteOption{ByteStreamOptOffset(0), ByteStreamOptFinishWrite(false)},
 		},
 		{
 			description: "not found",
 			ls:          nil,
 			data:        logStreamData,
-			opts:        []ByteStreamWriteOption{ByteStreamOptOffset(0), ByteSteramOptFinishWrite(false)},
+			opts:        []ByteStreamWriteOption{ByteStreamOptOffset(0), ByteStreamOptFinishWrite(false)},
 		},
 		{
 			description: "invlid smaller offset",
 			ls:          &logStream{logicalOffset: 4},
 			data:        logStreamData,
-			opts:        []ByteStreamWriteOption{ByteStreamOptOffset(1), ByteSteramOptFinishWrite(false)},
+			opts:        []ByteStreamWriteOption{ByteStreamOptOffset(1), ByteStreamOptFinishWrite(false)},
 		},
 		{
 			description: "invlid larger offset",
 			ls:          &logStream{logicalOffset: 2},
 			data:        logStreamData,
-			opts:        []ByteStreamWriteOption{ByteStreamOptOffset(4), ByteSteramOptFinishWrite(false)},
+			opts:        []ByteStreamWriteOption{ByteStreamOptOffset(4), ByteStreamOptFinishWrite(false)},
 		},
 		{
 			description: "invlid negative offset",
 			ls:          &logStream{logicalOffset: 0},
 			data:        logStreamData,
-			opts:        []ByteStreamWriteOption{ByteStreamOptOffset(-1), ByteSteramOptFinishWrite(false)},
+			opts:        []ByteStreamWriteOption{ByteStreamOptOffset(-1), ByteStreamOptFinishWrite(false)},
 		},
 	}
 
@@ -175,8 +175,8 @@ func TestWirteBytesWithOptions_LogStream_FinishWrite(t *testing.T) {
 	b := newServer(t)
 	defer b.shutDown()
 	dataSize := len(logStreamData)
-	for i, flag := range []ByteStreamWriteOption{ByteSteramOptFinishWrite(true), ByteSteramOptFinishWrite(false)} {
-		t.Run(fmt.Sprintf("ByteSteramOptFinishWrite=%t", flag), func(t *testing.T) {
+	for i, flag := range []ByteStreamWriteOption{ByteStreamOptFinishWrite(true), ByteStreamOptFinishWrite(false)} {
+		t.Run(fmt.Sprintf("ByteStreamOptFinishWrite=%t", flag), func(t *testing.T) {
 			lsID := fmt.Sprintf("logstream%d", i+1)
 			b.fake.logStreams[lsID] = &logStream{logStreamID: lsID, logicalOffset: 0}
 			ChunkMaxSize(dataSize).Apply(b.client)
@@ -189,8 +189,8 @@ func TestWirteBytesWithOptions_LogStream_FinishWrite(t *testing.T) {
 			if b.fake.logStreams[lsID].logicalOffset != int64(dataSize) {
 				t.Errorf("WriteBytesWithOffset() = %d, want %d", b.fake.logStreams[lsID].logicalOffset, int64(dataSize))
 			}
-			if b.fake.logStreams[lsID].finalized != bool(flag.(ByteSteramOptFinishWrite)) {
-				t.Errorf("WriteBytesWithOffset() got %t, want %t state", b.fake.logStreams[lsID].finalized, bool(flag.(ByteSteramOptFinishWrite)))
+			if b.fake.logStreams[lsID].finalized != bool(flag.(ByteStreamOptFinishWrite)) {
+				t.Errorf("WriteBytesWithOffset() got %t, want %t state", b.fake.logStreams[lsID].finalized, bool(flag.(ByteStreamOptFinishWrite)))
 			}
 		})
 

--- a/go/pkg/client/bytestream_test.go
+++ b/go/pkg/client/bytestream_test.go
@@ -91,7 +91,7 @@ func TestWriteBytesWithOffsetSuccess_LogStream(t *testing.T) {
 					t.Errorf("WriteBytesWithOffset() = %d, want %d", b.fake.logStreams[lsID].logicalOffset, end)
 				}
 				// LogStream shouldn't be finalized when we set ByteStreamOptFinishWrite false.
-				if i != test.dataPartsLen-1 && b.fake.logStreams[lsID].finalized == true {
+				if i != test.dataPartsLen-1 && b.fake.logStreams[lsID].finalized {
 					t.Error("WriteBytesWithOffset() incorrectly finalized LogStream")
 				}
 
@@ -103,7 +103,7 @@ func TestWriteBytesWithOffsetSuccess_LogStream(t *testing.T) {
 			if b.fake.logStreams[lsID].logicalOffset != test.wantBytesLen {
 				t.Errorf("WriteBytesWithOffset() = %d, want %d", b.fake.logStreams[lsID].logicalOffset, test.wantBytesLen)
 			}
-			if b.fake.logStreams[lsID].finalized == false {
+			if !b.fake.logStreams[lsID].finalized {
 				t.Error("WriteBytesWithOffset() didn't correctly finalize LogStream")
 			}
 		})

--- a/go/pkg/client/cas_upload.go
+++ b/go/pkg/client/cas_upload.go
@@ -172,7 +172,7 @@ func (c *Client) WriteBlob(ctx context.Context, blob []byte) (digest.Digest, err
 	if err != nil {
 		return dg, err
 	}
-	_, err = c.writeChunked(ctx, c.writeRscName(dg), ch)
+	_, err = c.writeChunked(ctx, c.writeRscName(dg), ch, false, 0)
 	return dg, err
 }
 
@@ -474,7 +474,7 @@ func (c *Client) upload(reqs []*uploadRequest) {
 				if err != nil {
 					updateAndNotify(st, 0, err, true)
 				}
-				totalBytes, err := c.writeChunked(cCtx, c.writeRscName(dg), ch)
+				totalBytes, err := c.writeChunked(cCtx, c.writeRscName(dg), ch, false, 0)
 				updateAndNotify(st, totalBytes, err, true)
 			}
 		}()
@@ -575,7 +575,7 @@ func (c *Client) uploadNonUnified(ctx context.Context, data ...*uploadinfo.Entry
 				if err != nil {
 					return err
 				}
-				written, err := c.writeChunked(eCtx, c.writeRscName(dg), ch)
+				written, err := c.writeChunked(eCtx, c.writeRscName(dg), ch, false, 0)
 				if err != nil {
 					return fmt.Errorf("failed to upload %s: %w", ue.Path, err)
 				}

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -168,7 +168,6 @@ type Client struct {
 	casDownloadRequests chan *downloadRequest
 	rpcTimeouts         RPCTimeouts
 	creds               credentials.PerRPCCredentials
-	ResumableWriteOpts  *ResumableWriteOpts
 }
 
 const (
@@ -475,15 +474,10 @@ func getRPCCreds(ctx context.Context, credFile string, useApplicationDefault boo
 	return rpcCreds, CredsFileAuth, nil
 }
 
-// ResumableWriteOpts sets options required for resumable ByteStream write operations.
-type ResumableWriteOpts struct {
+// ByteStreamWriteOpts sets options required for resumable ByteStream write operations.
+type ByteStreamWriteOpts struct {
 	FinishWrite       bool
 	LastLogicalOffset int64
-}
-
-// Apply sets the ResumableWriteOpts in a client.
-func (r *ResumableWriteOpts) Apply(c *Client) {
-	c.ResumableWriteOpts = r
 }
 
 // DialParams contains all the parameters that Dial needs.

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -168,6 +168,7 @@ type Client struct {
 	casDownloadRequests chan *downloadRequest
 	rpcTimeouts         RPCTimeouts
 	creds               credentials.PerRPCCredentials
+	ResumableWriteOpts	*ResumableWriteOpts
 }
 
 const (
@@ -472,6 +473,17 @@ func getRPCCreds(ctx context.Context, credFile string, useApplicationDefault boo
 		return nil, CredsFileAuth, fmt.Errorf("couldn't create RPC creds from %s: %v", credFile, err)
 	}
 	return rpcCreds, CredsFileAuth, nil
+}
+
+// ResumableWriteOpts sets options required for resumable ByteStream write operations. 
+type ResumableWriteOpts struct {
+	FinishWrite       bool
+	LastLogicalOffset int64
+}
+
+// Apply sets the ResumableWriteOpts in a client.
+func (r *ResumableWriteOpts) Apply(c *Client) {
+	c.ResumableWriteOpts = r
 }
 
 // DialParams contains all the parameters that Dial needs.

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -168,7 +168,7 @@ type Client struct {
 	casDownloadRequests chan *downloadRequest
 	rpcTimeouts         RPCTimeouts
 	creds               credentials.PerRPCCredentials
-	ResumableWriteOpts	*ResumableWriteOpts
+	ResumableWriteOpts  *ResumableWriteOpts
 }
 
 const (
@@ -475,7 +475,7 @@ func getRPCCreds(ctx context.Context, credFile string, useApplicationDefault boo
 	return rpcCreds, CredsFileAuth, nil
 }
 
-// ResumableWriteOpts sets options required for resumable ByteStream write operations. 
+// ResumableWriteOpts sets options required for resumable ByteStream write operations.
 type ResumableWriteOpts struct {
 	FinishWrite       bool
 	LastLogicalOffset int64

--- a/go/pkg/client/retries_test.go
+++ b/go/pkg/client/retries_test.go
@@ -285,6 +285,36 @@ func TestWriteRetries(t *testing.T) {
 	}
 }
 
+func TestWriteRetriesWithOptions(t *testing.T) {
+	opts := [][]client.ByteStreamWriteOption{
+		{client.ByteSteramOptFinishWrite(true), client.ByteStreamOptOffset(0)},
+		{client.ByteSteramOptFinishWrite(false), client.ByteStreamOptOffset(0)},
+		{client.ByteSteramOptFinishWrite(true)},
+		{client.ByteSteramOptFinishWrite(false)},
+		{client.ByteStreamOptOffset(0)},
+		{},
+	}
+
+	for _, opt := range opts {
+		opt := opt
+		t.Run(fmt.Sprintf("write options=%v", opt), func(t *testing.T) {
+			t.Parallel()
+			f := setup(t)
+			defer f.shutDown()
+
+			name := "fake"
+			data := []byte("byte")
+			writtenBytes, err := f.client.WriteBytesWithOptions(f.ctx, name, data, opt...)
+			if err != nil {
+				t.Errorf("client.WriteBytesWithOptions(ctx, name, bytes, %v) gave error %s, wanted nil", opt, err)
+			}
+			if len(data) != int(writtenBytes) {
+				t.Errorf("client.WriteBytesWithOptions(ctx, name, bytes, %v) got %d bytes, want %d", opt, writtenBytes, len(data))
+			}
+		})
+	}
+}
+
 func TestReadRetries(t *testing.T) {
 	t.Parallel()
 	for _, sleep := range []bool{false, true} {

--- a/go/pkg/client/retries_test.go
+++ b/go/pkg/client/retries_test.go
@@ -312,22 +312,22 @@ func TestWriteRetriesWithOptions(t *testing.T) {
 	}{
 		{
 			description:   "true and offset 0",
-			opts:          []client.ByteStreamWriteOption{client.ByteSteramOptFinishWrite(true), client.ByteStreamOptOffset(0)},
+			opts:          []client.ByteStreamWriteOption{client.ByteStreamOptFinishWrite(true), client.ByteStreamOptOffset(0)},
 			initialOffset: 0,
 		},
 		{
 			description:   "false and offset 0",
-			opts:          []client.ByteStreamWriteOption{client.ByteSteramOptFinishWrite(false), client.ByteStreamOptOffset(0)},
+			opts:          []client.ByteStreamWriteOption{client.ByteStreamOptFinishWrite(false), client.ByteStreamOptOffset(0)},
 			initialOffset: 0,
 		},
 		{
 			description:   "true",
-			opts:          []client.ByteStreamWriteOption{client.ByteSteramOptFinishWrite(true)},
+			opts:          []client.ByteStreamWriteOption{client.ByteStreamOptFinishWrite(true)},
 			initialOffset: 0,
 		},
 		{
 			description:   "false",
-			opts:          []client.ByteStreamWriteOption{client.ByteSteramOptFinishWrite(false)},
+			opts:          []client.ByteStreamWriteOption{client.ByteStreamOptFinishWrite(false)},
 			initialOffset: 0,
 		},
 		{

--- a/go/pkg/client/retries_test.go
+++ b/go/pkg/client/retries_test.go
@@ -347,17 +347,17 @@ func TestWriteRetriesWithOptions(t *testing.T) {
 			f := setup(t)
 			defer f.shutDown()
 			name := test.description
-			data := []byte("byte")
+			data := []byte("Hello World!")
 			if test.initialOffset > 0 {
 				f.fake.setInitialOffset(name, test.initialOffset)
 			}
 
-			writtenBytes, err := f.client.WriteBytesWithOptions(f.ctx, name, data, test.opts...)
+			writtenBytes, err := f.client.WriteBytesWithOptions(f.ctx, name, data[test.initialOffset:], test.opts...)
 			if err != nil {
 				t.Errorf("client.WriteBytesWithOptions(ctx, name, %s, %v) gave error %s, want nil", string(data), test.opts, err)
 			}
-			if len(data) != int(writtenBytes) {
-				t.Errorf("client.WriteBytesWithOptions(ctx, name, %s, %v) gave %d byte(s), want %d", string(data), test.opts, writtenBytes, len(data))
+			if int64(len(data))-test.initialOffset != writtenBytes {
+				t.Errorf("client.WriteBytesWithOptions(ctx, name, %s, %v) gave %d byte(s), want %d", string(data), test.opts, writtenBytes, int64(len(data))-test.initialOffset)
 			}
 		})
 	}


### PR DESCRIPTION
Update writeChunked method in bytestream.go to allow resumable upload with ByteStream Write API.

I also added a new struct ResumableWriteOpts and it’s added to Client to keep track of write offset so that we can start writing data at an arbitrary offset.