### PR TITLE
Refactor public methods to delegate to impls

### DIFF
--- a/go/pkg/client/BUILD.bazel
+++ b/go/pkg/client/BUILD.bazel
@@ -86,7 +86,7 @@ go_test(
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
-        "@org_golang_google_protobuf//testing/protocmp",
+        "@org_golang_google_protobuf//testing/protocmp:go_default_library",
         "@org_golang_google_protobuf//types/known/anypb:go_default_library",
         "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",

--- a/go/pkg/client/cas.go
+++ b/go/pkg/client/cas.go
@@ -106,6 +106,24 @@ func (c *Client) makeBatches(ctx context.Context, dgs []digest.Digest, optimizeS
 	return batches
 }
 
+func (c *Client) makeQueryBatches(ctx context.Context, digests []digest.Digest) [][]digest.Digest {
+	var batches [][]digest.Digest
+	for len(digests) > 0 {
+		batchSize := int(c.MaxQueryBatchDigests)
+		if len(digests) < int(c.MaxQueryBatchDigests) {
+			batchSize = len(digests)
+		}
+		batch := make([]digest.Digest, 0, batchSize)
+		for i := 0; i < batchSize; i++ {
+			batch = append(batch, digests[i])
+		}
+		digests = digests[batchSize:]
+		LogContextInfof(ctx, log.Level(3), "Created query batch of %d blobs", len(batch))
+		batches = append(batches, batch)
+	}
+	return batches
+}
+
 func getUnifiedLabel(labels map[string]bool) string {
 	var keys []string
 	for k := range labels {

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -132,8 +132,10 @@ type Client struct {
 	// compressed. Use 0 for all writes being compressed, and a negative number for all operations being
 	// uncompressed.
 	CompressedBytestreamThreshold CompressedBytestreamThreshold
-	// MaxBatchDigests is maximum amount of digests to batch in batched operations.
+	// MaxBatchDigests is maximum amount of digests to batch in upload and download operations.
 	MaxBatchDigests MaxBatchDigests
+	// MaxQueryBatchDigests is maximum amount of digests to batch in CAS query operations.
+	MaxQueryBatchDigests MaxQueryBatchDigests
 	// MaxBatchSize is maximum size in bytes of a batch request for batch operations.
 	MaxBatchSize MaxBatchSize
 	// DirMode is mode used to create directories.
@@ -178,6 +180,9 @@ const (
 	// DefaultMaxBatchDigests is a suggested approximate limit based on current RBE implementation.
 	// Above that BatchUpdateBlobs calls start to exceed a typical minute timeout.
 	DefaultMaxBatchDigests = 4000
+
+	// DefaultMaxQueryBatchDigests is a suggested limit for the number of items for in batch for a missing blobs query.
+	DefaultMaxQueryBatchDigests = 10_000
 
 	// DefaultDirMode is mode used to create directories.
 	DefaultDirMode = 0777
@@ -349,12 +354,20 @@ func (o *TreeSymlinkOpts) Apply(c *Client) {
 	c.TreeSymlinkOpts = o
 }
 
-// MaxBatchDigests is maximum amount of digests to batch in batched operations.
+// MaxBatchDigests is maximum amount of digests to batch in upload and download operations.
 type MaxBatchDigests int
 
 // Apply sets the client's maximal batch digests to s.
 func (s MaxBatchDigests) Apply(c *Client) {
 	c.MaxBatchDigests = s
+}
+
+// MaxQueryBatchDigests is maximum amount of digests to batch in query operations.
+type MaxQueryBatchDigests int
+
+// Apply sets the client's maximal batch digests to s.
+func (s MaxQueryBatchDigests) Apply(c *Client) {
+	c.MaxQueryBatchDigests = s
 }
 
 // MaxBatchSize is maximum size in bytes of a batch request for batch operations.
@@ -735,6 +748,7 @@ func NewClientFromConnection(ctx context.Context, instanceName string, conn, cas
 		CompressedBytestreamThreshold: DefaultCompressedBytestreamThreshold,
 		ChunkMaxSize:                  chunker.DefaultChunkSize,
 		MaxBatchDigests:               DefaultMaxBatchDigests,
+		MaxQueryBatchDigests:          DefaultMaxQueryBatchDigests,
 		MaxBatchSize:                  DefaultMaxBatchSize,
 		DirMode:                       DefaultDirMode,
 		ExecutableMode:                DefaultExecutableMode,


### PR DESCRIPTION
Moved internal implementations to separate methods to allow public methods to select implementations based on feature flags.

No functional changes made.

This is a stop-gap change to merge cas/upload.go into client pkg.