### PR TITLE
Refactor Entry struct to ensure immutability

### DIFF
--- a/go/pkg/client/cas_test.go
+++ b/go/pkg/client/cas_test.go
@@ -614,7 +614,7 @@ func TestUploadCancel(t *testing.T) {
 				t.Error(err)
 			}
 			// Verify that nothing was written.
-			if fake.BlobWrites(ue.Digest) != 0 {
+			if fake.BlobWrites(ue.Digest()) != 0 {
 				t.Errorf("Blob was written, expected cancellation.")
 			}
 			close(wait)
@@ -828,7 +828,7 @@ func TestUpload(t *testing.T) {
 			}
 
 			for i, ue := range input {
-				dg := ue.Digest
+				dg := ue.Digest()
 				blob := tc.input[i]
 				if present[dg] {
 					if fake.BlobWrites(dg) > 0 {

--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -379,7 +379,7 @@ func packageTree(t *treeNode, stats *TreeStats) (root digest.Digest, blobs map[d
 	sort.Slice(dir.Directories, func(i, j int) bool { return dir.Directories[i].Name < dir.Directories[j].Name })
 
 	for name, fn := range t.files {
-		dg := fn.ue.Digest
+		dg := fn.ue.Digest()
 		dir.Files = append(dir.Files, &repb.FileNode{Name: name, Digest: dg.ToProto(), IsExecutable: fn.isExecutable})
 		blobs[dg] = fn.ue
 		stats.InputFiles++
@@ -397,7 +397,7 @@ func packageTree(t *treeNode, stats *TreeStats) (root digest.Digest, blobs map[d
 	if err != nil {
 		return digest.Empty, nil, err
 	}
-	dg := ue.Digest
+	dg := ue.Digest()
 	blobs[dg] = ue
 	stats.TotalInputBytes += dg.Size
 	stats.InputDirectories++
@@ -513,7 +513,7 @@ func packageDirectories(t *treeNode) (root *repb.Directory, files map[digest.Dig
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		dg := ue.Digest
+		dg := ue.Digest()
 		root.Directories = append(root.Directories, &repb.DirectoryNode{Name: name, Digest: dg.ToProto()})
 		for d, b := range childFiles {
 			files[d] = b
@@ -524,7 +524,7 @@ func packageDirectories(t *treeNode) (root *repb.Directory, files map[digest.Dig
 	sort.Slice(root.Directories, func(i, j int) bool { return root.Directories[i].Name < root.Directories[j].Name })
 
 	for name, fn := range t.files {
-		dg := fn.ue.Digest
+		dg := fn.ue.Digest()
 		root.Files = append(root.Files, &repb.FileNode{Name: name, Digest: dg.ToProto(), IsExecutable: fn.isExecutable})
 		files[dg] = fn.ue
 	}
@@ -579,23 +579,23 @@ func (c *Client) ComputeOutputsToUpload(execRoot, workingDir string, paths []str
 		if err != nil {
 			return nil, nil, err
 		}
-		outs[ue.Digest] = ue
+		outs[ue.Digest()] = ue
 		treePb.Root = rootDir
 		ue, err = uploadinfo.EntryFromProto(treePb)
 		if err != nil {
 			return nil, nil, err
 		}
-		outs[ue.Digest] = ue
+		outs[ue.Digest()] = ue
 		for _, ue := range files {
-			outs[ue.Digest] = ue
+			outs[ue.Digest()] = ue
 		}
-		resPb.OutputDirectories = append(resPb.OutputDirectories, &repb.OutputDirectory{Path: normPath, TreeDigest: ue.Digest.ToProto()})
+		resPb.OutputDirectories = append(resPb.OutputDirectories, &repb.OutputDirectory{Path: normPath, TreeDigest: ue.Digest().ToProto()})
 		// Upload the child directories individually as well
 		ueRoot, _ := uploadinfo.EntryFromProto(treePb.Root)
-		outs[ueRoot.Digest] = ueRoot
+		outs[ueRoot.Digest()] = ueRoot
 		for _, child := range treePb.Children {
 			ueChild, _ := uploadinfo.EntryFromProto(child)
-			outs[ueChild.Digest] = ueChild
+			outs[ueChild.Digest()] = ueChild
 		}
 	}
 	return outs, resPb, nil

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -277,7 +277,7 @@ func TestComputeMerkleTreeEmptySubdirs(t *testing.T) {
 		if err != nil {
 			t.Errorf("chunker %v FullData() returned error %v", ch, err)
 		}
-		gotBlobs[ue.Digest] = blob
+		gotBlobs[ue.Digest()] = blob
 	}
 	if diff := cmp.Diff(aDirDg, gotRootDg); diff != "" {
 		t.Errorf("ComputeMerkleTree(...) gave diff (-want +got) on root:\n%s", diff)
@@ -375,7 +375,7 @@ func TestComputeMerkleTreeEmptyStructureVirtualInputs(t *testing.T) {
 		if err != nil {
 			t.Errorf("chunker %v FullData() returned error %v", ch, err)
 		}
-		gotBlobs[ue.Digest] = blob
+		gotBlobs[ue.Digest()] = blob
 	}
 	if diff := cmp.Diff(aDirDg, gotRootDg); diff != "" {
 		t.Errorf("ComputeMerkleTree(...) gave diff (-want +got) on root:\n%s", diff)
@@ -1355,7 +1355,7 @@ func TestComputeMerkleTree(t *testing.T) {
 				if err != nil {
 					t.Errorf("chunker %v FullData() returned error %v", ch, err)
 				}
-				gotBlobs[ue.Digest] = blob
+				gotBlobs[ue.Digest()] = blob
 			}
 			if diff := cmp.Diff(rootDg, gotRootDg); diff != "" {
 				t.Errorf("ComputeMerkleTree(...) gave diff (-want +got) on root:\n%s", diff)
@@ -1686,7 +1686,7 @@ func TestComputeOutputsToUploadFiles(t *testing.T) {
 				if err != nil {
 					t.Errorf("chunker %v FullData() returned error %v", ch, err)
 				}
-				gotBlobs[ue.Digest] = blob
+				gotBlobs[ue.Digest()] = blob
 			}
 			if diff := cmp.Diff(wantBlobs, gotBlobs); diff != "" {
 				t.Errorf("ComputeOutputsToUpload(...) gave diff (-want +got) on blobs:\n%s", diff)
@@ -1860,7 +1860,7 @@ func TestComputeOutputsToUploadDirectories(t *testing.T) {
 				if err != nil {
 					t.Errorf("chunker %v FullData() returned error %v", ch, err)
 				}
-				gotBlobs[ue.Digest] = blob
+				gotBlobs[ue.Digest()] = blob
 			}
 			if diff := cmp.Diff(tc.wantCacheCalls, cache.calls, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("ComputeOutputsToUpload(...) gave diff on file metadata cache access (-want +got) on blobs:\n%s", diff)

--- a/go/pkg/rexec/rexec.go
+++ b/go/pkg/rexec/rexec.go
@@ -161,7 +161,7 @@ func (ec *Context) computeInputs() error {
 	if ec.cmdUe, err = uploadinfo.EntryFromProto(cmdPb); err != nil {
 		return err
 	}
-	cmdDg := ec.cmdUe.Digest
+	cmdDg := ec.cmdUe.Digest()
 	ec.Metadata.CommandDigest = cmdDg
 	log.V(1).Infof("%s %s> Command digest: %s", cmdID, executionID, cmdDg)
 	log.V(1).Infof("%s %s> Computing input Merkle tree...", cmdID, executionID)
@@ -190,7 +190,7 @@ func (ec *Context) computeInputs() error {
 	if ec.acUe, err = uploadinfo.EntryFromProto(acPb); err != nil {
 		return err
 	}
-	acDg := ec.acUe.Digest
+	acDg := ec.acUe.Digest()
 	log.V(1).Infof("%s %s> Action digest: %s", cmdID, executionID, acDg)
 	ec.inputBlobs = append(ec.inputBlobs, ec.cmdUe)
 	ec.inputBlobs = append(ec.inputBlobs, ec.acUe)


### PR DESCRIPTION
The changes preserve semantics and provide strong immutability guarantees. This is stop-gap change for extending the Entry struct to support the implementation from pkg/cas.