### PR TITLE
Add output symlinks to the action metadata.

### DIFF
--- a/go/pkg/command/command.go
+++ b/go/pkg/command/command.go
@@ -509,6 +509,8 @@ type Metadata struct {
 	OutputFileDigests map[string]digest.Digest
 	// Output Directory digests.
 	OutputDirectoryDigests map[string]digest.Digest
+	// Output Symlinks.
+	OutputSymlinks map[string]string
 	// Missing digests that are uploaded to CAS.
 	MissingDigests []digest.Digest
 	// LogicalBytesUploaded is the sum of sizes in bytes of the blobs that were uploaded. It should be

--- a/go/pkg/fakes/server.go
+++ b/go/pkg/fakes/server.go
@@ -297,6 +297,18 @@ func (d *OutputDir) Apply(ac *repb.ActionResult, s *Server, execRoot string) err
 	return nil
 }
 
+// OutputSymlink is to be added as an output of the fake action.
+type OutputSymlink struct {
+	Path   string
+	Target string
+}
+
+// Apply puts the file in the fake CAS and the given ActionResult.
+func (l *OutputSymlink) Apply(ac *repb.ActionResult, s *Server, execRoot string) error {
+	ac.OutputFileSymlinks = append(ac.OutputFileSymlinks, &repb.OutputSymlink{Path: l.Path, Target: l.Target})
+	return nil
+}
+
 // BuildDir builds the directory tree by recursively iterating through the directory.
 // This is similar to tree.go ComputeMerkleTree.
 func BuildDir(path string, s *Server, execRoot string) (root *repb.Directory, childDir []*repb.Directory, err error) {

--- a/go/pkg/rexec/rexec.go
+++ b/go/pkg/rexec/rexec.go
@@ -100,6 +100,7 @@ func (ec *Context) setOutputMetadata() {
 	ec.Metadata.OutputDirectories = len(ec.resPb.OutputDirectories) + len(ec.resPb.OutputDirectorySymlinks)
 	ec.Metadata.OutputFileDigests = make(map[string]digest.Digest)
 	ec.Metadata.OutputDirectoryDigests = make(map[string]digest.Digest)
+	ec.Metadata.OutputSymlinks = make(map[string]string)
 	ec.Metadata.TotalOutputBytes = 0
 	for _, file := range ec.resPb.OutputFiles {
 		dg := digest.NewFromProtoUnvalidated(file.Digest)
@@ -110,6 +111,9 @@ func (ec *Context) setOutputMetadata() {
 		dg := digest.NewFromProtoUnvalidated(dir.TreeDigest)
 		ec.Metadata.OutputDirectoryDigests[dir.Path] = dg
 		ec.Metadata.TotalOutputBytes += dg.Size
+	}
+	for _, sl := range ec.resPb.OutputFileSymlinks {
+		ec.Metadata.OutputSymlinks[sl.Path] = sl.Target
 	}
 	if ec.resPb.StdoutRaw != nil {
 		ec.Metadata.TotalOutputBytes += int64(len(ec.resPb.StdoutRaw))

--- a/go/pkg/rexec/rexec_test.go
+++ b/go/pkg/rexec/rexec_test.go
@@ -87,6 +87,7 @@ func TestExecCacheHit(t *testing.T) {
 					RealBytesDownloaded:    12,
 					OutputFileDigests:      map[string]digest.Digest{"a/b/out": digest.NewFromBlob([]byte("output"))},
 					OutputDirectoryDigests: map[string]digest.Digest{},
+					OutputSymlinks:         map[string]string{},
 				}
 				if diff := cmp.Diff(wantRes, res); diff != "" {
 					t.Errorf("Run() gave result diff (-want +got):\n%s", diff)
@@ -378,6 +379,66 @@ func TestDoNotDownloadOutputs(t *testing.T) {
 				t.Errorf("expected output file %s to not be downloaded, but it was", path)
 			}
 		})
+	}
+}
+
+func TestOutputSymlinks(t *testing.T) {
+	e, cleanup := fakes.NewTestEnv(t)
+	defer cleanup()
+	e.Client.GrpcClient.Retrier = nil // Disable retries
+	cmd := &command.Command{
+		Args:        []string{"tool"},
+		OutputFiles: []string{"a/b/out"},
+		ExecRoot:    e.ExecRoot,
+	}
+	opt := &command.ExecutionOptions{AcceptCached: true, DownloadOutputs: true, DownloadOutErr: false}
+	wantRes := &command.Result{Status: command.CacheHitResultStatus}
+	cmdDg, acDg := e.Set(cmd, opt, wantRes, fakes.StdOut("stdout"), fakes.StdErr("stderr"), &fakes.OutputFile{Path: "a/b/out", Contents: "output"}, &fakes.OutputSymlink{Path: "a/b/sl", Target: "out"}, fakes.ExecutionCacheHit(true))
+	oe := outerr.NewRecordingOutErr()
+
+	res, meta := e.Client.Run(context.Background(), cmd, opt, oe)
+
+	if diff := cmp.Diff(wantRes, res, cmp.Comparer(proto.Equal), cmp.Comparer(equalError)); diff != "" {
+		t.Errorf("Run() gave result diff (-want +got):\n%s", diff)
+	}
+	if len(oe.Stdout()) != 0 {
+		t.Errorf("Run() gave unexpected stdout: %v", string(oe.Stdout()))
+	}
+	if len(oe.Stderr()) != 0 {
+		t.Errorf("Run() gave unexpected stderr: %v", string(oe.Stderr()))
+	}
+	path := filepath.Join(e.ExecRoot, "a/b/out")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected output file %s to not be downloaded, but it was", path)
+	}
+	path = filepath.Join(e.ExecRoot, "a/b/sl")
+	file, err := os.Stat(path)
+	if err != nil {
+		t.Errorf("expected output file %s to be downloaded, but it was not", path)
+	}
+	if file.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("expected output file %s to be a symlink, but it was not", path)
+	}
+	wantMeta := &command.Metadata{
+		CommandDigest:    cmdDg,
+		ActionDigest:     acDg,
+		InputDirectories: 1,
+		TotalInputBytes:  cmdDg.Size + acDg.Size,
+		OutputFiles:      2,
+		TotalOutputBytes: 18, // "output" + "stdout" + "stderr"
+		// "output" + "stdout" for both. StdErr is inlined in ActionResult in this test, and ActionResult
+		// isn't done through bytestream so not checked here.
+		LogicalBytesDownloaded: 6,
+		RealBytesDownloaded:    6,
+		OutputFileDigests:      map[string]digest.Digest{"a/b/out": digest.NewFromBlob([]byte("output"))},
+		OutputDirectoryDigests: map[string]digest.Digest{},
+		OutputSymlinks:         map[string]string{"a/b/sl": "out"},
+	}
+	if diff := cmp.Diff(wantRes, res); diff != "" {
+		t.Errorf("Run() gave result diff (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(wantMeta, meta, cmpopts.IgnoreFields(command.Metadata{}, "EventTimes")); diff != "" {
+		t.Errorf("Run() gave result diff (-want +got):\n%s", diff)
 	}
 }
 

--- a/go/pkg/rexec/rexec_test.go
+++ b/go/pkg/rexec/rexec_test.go
@@ -412,12 +412,15 @@ func TestOutputSymlinks(t *testing.T) {
 		t.Errorf("expected output file %s to not be downloaded, but it was", path)
 	}
 	path = filepath.Join(e.ExecRoot, "a/b/sl")
-	file, err := os.Stat(path)
+	file, err := os.Lstat(path)
 	if err != nil {
 		t.Errorf("expected output file %s to be downloaded, but it was not", path)
 	}
-	if file.Mode()&os.ModeSymlink != 0 {
+	if file.Mode()&os.ModeSymlink == 0 {
 		t.Errorf("expected output file %s to be a symlink, but it was not", path)
+	}
+	if dest, err := os.Readlink(path); err != nil || dest != "out" {
+		t.Errorf("expected output file %s to link to a/b/out, got %v, %v", path, dest, err)
 	}
 	wantMeta := &command.Metadata{
 		CommandDigest:    cmdDg,


### PR DESCRIPTION
Add output symlinks to the Metadata struct. Also add tests to ensure symlink behavior is correct.