### PR TITLE
introduce immutable path package

### DIFF
--- a/go/pkg/errors/BUILD.bazel
+++ b/go/pkg/errors/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "errors",
+    srcs = ["errors.go"],
+    importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/errors",
+    visibility = ["//visibility:public"],
+)

--- a/go/pkg/errors/errors.go
+++ b/go/pkg/errors/errors.go
@@ -1,0 +1,81 @@
+// Package errors provides the ability to wrap multiple errors while maintaining API compatibility with the standard package.
+// This functionality is a drop-in replacement from go1.20. Remove this package once the SDK is updated to g1.20.
+package errors
+
+import "errors"
+
+type joinError struct {
+	errs []error
+}
+
+// Error joins the texts of the wrapped errors using newline as the delimiter.
+func (e *joinError) Error() string {
+	var b []byte
+	for i, err := range e.errs {
+		if i > 0 {
+			b = append(b, '\n')
+		}
+		b = append(b, err.Error()...)
+	}
+	return string(b)
+}
+
+// Join wraps the specified errors into one error that prints the entire list using newline as the delimiter.
+func Join(errs ...error) error {
+	n := 0
+	for _, err := range errs {
+		if err != nil {
+			n++
+		}
+	}
+
+	if n == 0 {
+		return nil
+	}
+
+	// Unlike go1.20, this allows for efficient and convenient wrapping of errors without additional guards.
+	// E.g. the following code returns err as is without any allocations if errClose is nil:
+	// errClose := f.Close(); err = errors.Join(errClose, err)
+	if n == 1 {
+		for _, err := range errs {
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	e := &joinError{
+		errs: make([]error, 0, n),
+	}
+	for _, err := range errs {
+		if err != nil {
+			e.errs = append(e.errs, err)
+		}
+	}
+	return e
+}
+
+// Is implements the corresponding interface allowing the joinError type to be compatible with
+// errors.Is(error) bool of the standard package without having to override it.
+func (e *joinError) Is(target error) bool {
+	if target == nil || e == nil {
+		return e == target
+	}
+
+	for _, e := range e.errs {
+		if errors.Is(e, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// Is delegates to the standard package.
+func Is(err, target error) bool {
+	return errors.Is(err, target)
+}
+
+// New delegates to the standard package.
+func New(text string) error {
+	return errors.New(text)
+}

--- a/go/pkg/io/impath/BUILD.bazel
+++ b/go/pkg/io/impath/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "impath",
+    srcs = ["impath.go"],
+    importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/io/impath",
+    visibility = ["//visibility:public"],
+    deps = ["//go/pkg/errors"],
+)
+
+go_test(
+    name = "impath_test",
+    srcs = ["impath_test.go"],
+    deps = [":impath"],
+)

--- a/go/pkg/io/impath/impath.go
+++ b/go/pkg/io/impath/impath.go
@@ -1,0 +1,155 @@
+// Package impath (immutable path) provides immutable and distinguishable types for absolute and relative paths.
+// This allows for strong guarantees at compile time, improves legibility and reduces maintenance burden.
+package impath
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/errors"
+)
+
+var (
+	ErrNotAbsolute   = errors.New("path is not absolute")
+	ErrNotRelative   = errors.New("path is not relative")
+	ErrNotDescendant = errors.New("target is not a descendant of base")
+	Root             = os.Getenv("SYSTEMDRIVE") + string(os.PathSeparator)
+)
+
+// Absolute represents an immutable absolute path.
+// The zero value is system root, which is `/` on Unix and `C:\` on Windows.
+type Absolute struct {
+	path string
+}
+
+// Relative represents an immutable relative path.
+// The zero value is the empty path, which is an alias to the current directory `.`.
+type Relative struct {
+	path string
+}
+
+// Dir is a convenient method that returns all path elements except the last.
+func (p Absolute) Dir() Absolute {
+	return Absolute{path: filepath.Dir(p.path)}
+}
+
+// Dir is a convenient method that returns all path elements except the last.
+func (p Relative) Dir() Relative {
+	return Relative{path: filepath.Dir(p.path)}
+}
+
+// Base is a convenient method that returns the last path element.
+func (p Absolute) Base() Absolute {
+	return Absolute{path: filepath.Base(p.path)}
+}
+
+// Base is a convenient method that returns the last path element.
+func (p Relative) Base() Relative {
+	return Relative{path: filepath.Base(p.path)}
+}
+
+// String implements the Stringer interface and returns the path as a string.
+func (p Absolute) String() string {
+	pstr := string(p.path)
+	if pstr == "" {
+		return Root
+	}
+	return pstr
+}
+
+// String implements the Stringer interface and returns the path as a string.
+func (p Relative) String() string {
+	return string(p.path)
+}
+
+func join(base string, elements []Relative) []string {
+	paths := make([]string, len(elements)+1)
+	paths[0] = base
+	for i, p := range elements {
+		paths[i+1] = p.String()
+	}
+	return paths
+}
+
+// Append is a convenient method to join additional elements to this path.
+func (p Absolute) Append(elements ...Relative) Absolute {
+	paths := join(p.String(), elements)
+	return Absolute{path: filepath.Join(paths...)}
+}
+
+// Append is a convenient method to join additional elements to this path.
+func (p Relative) Append(elements ...Relative) Relative {
+	paths := join(p.String(), elements)
+	return Relative{path: filepath.Join(paths...)}
+}
+
+var (
+	zeroAbs = Absolute{}
+	zeroRel = Relative{}
+)
+
+// Abs creates a new absolute and clean path from the specified elements.
+//
+// If the specified elements do not join to a valid absolute path, ErrNotAbsolute is returned.
+func Abs(elements ...string) (Absolute, error) {
+	p := filepath.Join(elements...)
+	if filepath.IsAbs(p) {
+		return Absolute{path: p}, nil
+	}
+	return zeroAbs, errors.Join(ErrNotAbsolute, fmt.Errorf("path %q", p))
+}
+
+// MustAbs is a convenient wrapper of ToAbs that is useful for constant paths.
+//
+// If the specified elements do not join to a valid absolute path, this function panics.
+func MustAbs(elements ...string) Absolute {
+	p, err := Abs(elements...)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+// Rel creates a new relative and clean path from the specified elements.
+//
+// If the specified elements do not join to a valid relative path, ErrNotRelative is returned.
+func Rel(elements ...string) (Relative, error) {
+	p := filepath.Join(elements...)
+	if filepath.IsAbs(p) {
+		return zeroRel, errors.Join(ErrNotRelative, fmt.Errorf("path %q", p))
+	}
+	return Relative{path: p}, nil
+}
+
+// MustRel is a convenient wrapper of ToRel that is useful for constant paths.
+//
+// If the specified elements do not join to a valid relative path, this function panics.
+func MustRel(elements ...string) Relative {
+	p, err := Rel(elements...)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+// Descendant returns a relative path to the specified base path such that
+// when joined together with the base using filepath.Join(base, path), the result
+// is lexically equivalent to the specified target path.
+//
+// The returned error is nil, ErrNotRelative, or ErrNotDescendant.
+// ErrNotRelative indicates that the target cannot be made relative to base.
+// ErrNotDescendant indicates the target is not a descendant of base, even though it is relative.
+func Descendant(base Absolute, target Absolute) (Relative, error) {
+	p, err := filepath.Rel(base.String(), target.String())
+	if err != nil {
+		// On unix, this should never happen since all absolute paths share the same root.
+		// On Windows, it's possible for two absolute paths to have different roots (different drive letters).
+		return zeroRel, errors.Join(ErrNotRelative, err)
+	}
+	if strings.HasPrefix(p, "..") {
+		return zeroRel, errors.Join(ErrNotDescendant, fmt.Errorf("target %q is not a descendant of base %q", target, base))
+	}
+	return Relative{path: p}, nil
+}

--- a/go/pkg/io/impath/impath_test.go
+++ b/go/pkg/io/impath/impath_test.go
@@ -1,0 +1,219 @@
+package impath_test
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/io/impath"
+)
+
+func Test_Abs(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []string
+		want  string
+		err   error
+	}{
+		{
+			name:  "valid",
+			parts: []string{impath.Root, "foo", "bar", "baz"},
+			want:  filepath.Join(impath.Root, "foo", "bar", "baz"),
+			err:   nil,
+		},
+		{
+			name:  "not_absolute",
+			parts: []string{"foo", "bar", "baz"},
+			want:  impath.Root,
+			err:   impath.ErrNotAbsolute,
+		},
+		{
+			name:  "not_clean",
+			parts: []string{impath.Root, "foo", "bar", "..", "baz"},
+			want:  filepath.Join(impath.Root, "foo", "baz"),
+			err:   nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			got, err := impath.Abs(test.parts...)
+			if !errors.Is(err, test.err) {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got.String() != test.want {
+				t.Errorf("path mismatch: want %q, got %q", test.want, got)
+			}
+		})
+	}
+}
+
+func Test_Rel(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []string
+		want  string
+		err   error
+	}{
+		{
+			name:  "valid",
+			parts: []string{"foo", "bar", "baz"},
+			want:  filepath.Join("foo", "bar", "baz"),
+			err:   nil,
+		},
+		{
+			name:  "not_relative",
+			parts: []string{impath.Root, "foo", "bar", "baz"},
+			want:  "",
+			err:   impath.ErrNotRelative,
+		},
+		{
+			name:  "not_clean",
+			parts: []string{"foo", "bar", "..", "baz"},
+			want:  filepath.Join("foo", "baz"),
+			err:   nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			got, err := impath.Rel(test.parts...)
+			if !errors.Is(err, test.err) {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got.String() != test.want {
+				t.Errorf("path mismatch: want %q, got %q", test.want, got)
+			}
+		})
+	}
+}
+
+func Test_AbsAppend(t *testing.T) {
+	tests := []struct {
+		name   string
+		parent impath.Absolute
+		parts  []impath.Relative
+		want   string
+		err    error
+	}{
+		{
+			name:   "valid",
+			parent: impath.MustAbs(impath.Root, "foo"),
+			parts:  []impath.Relative{impath.MustRel("bar"), impath.MustRel("baz")},
+			want:   filepath.Join(impath.Root, "foo", "bar", "baz"),
+			err:    nil,
+		},
+		{
+			name:   "not_clean",
+			parent: impath.MustAbs(impath.Root, "foo"),
+			parts:  []impath.Relative{impath.MustRel("bar"), impath.MustRel(".."), impath.MustRel("baz")},
+			want:   filepath.Join(impath.Root, "foo", "baz"),
+			err:    nil,
+		},
+		{
+			name:   "zero",
+			parent: impath.Absolute{},
+			parts:  []impath.Relative{impath.MustRel("bar"), impath.MustRel("baz")},
+			want:   filepath.Join(impath.Root, "bar", "baz"),
+			err:    impath.ErrNotAbsolute,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			got := test.parent.Append(test.parts...)
+			if got.String() != test.want {
+				t.Errorf("path mismatch: want %q, got %q", test.want, got)
+			}
+		})
+	}
+}
+
+func Test_RelAppend(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []impath.Relative
+		want  string
+	}{
+		{
+			name:  "valid",
+			parts: []impath.Relative{impath.MustRel("bar"), impath.MustRel("baz")},
+			want:  filepath.Join("bar", "baz"),
+		},
+		{
+			name:  "not_clean",
+			parts: []impath.Relative{impath.MustRel("bar"), impath.MustRel(".."), impath.MustRel("baz")},
+			want:  "baz",
+		},
+		{
+			name:  "empty_elements",
+			parts: []impath.Relative{{}, impath.MustRel("bar"), {}, impath.MustRel("baz"), {}},
+			want:  filepath.Join("bar", "baz"),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			got := test.parts[0].Append(test.parts[1:]...)
+			if got.String() != test.want {
+				t.Errorf("path mismatch: want %q, got %q", test.want, got)
+			}
+		})
+	}
+}
+
+func Test_Descendant(t *testing.T) {
+	tests := []struct {
+		name   string
+		base   impath.Absolute
+		target impath.Absolute
+		want   string
+		err    error
+	}{
+		{
+			name:   "valid",
+			base:   impath.MustAbs(impath.Root, "a", "b"),
+			target: impath.MustAbs(impath.Root, "a", "b", "c", "d"),
+			want:   filepath.Join("c/d"),
+			err:    nil,
+		},
+		{
+			name:   "not_descendent",
+			base:   impath.MustAbs(impath.Root, "a", "b"),
+			target: impath.MustAbs(impath.Root, "c", "d"),
+			want:   "",
+			err:    impath.ErrNotDescendant,
+		},
+		{
+			name:   "zero_base",
+			base:   impath.Absolute{},
+			target: impath.MustAbs(impath.Root, "c", "d"),
+			want:   filepath.Join("c", "d"),
+			err:    nil,
+		},
+		{
+			name:   "zero_target",
+			base:   impath.MustAbs(impath.Root, "a", "b"),
+			target: impath.Absolute{},
+			want:   "",
+			err:    impath.ErrNotDescendant,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			got, err := impath.Descendant(test.base, test.target)
+			if !errors.Is(err, test.err) {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got.String() != test.want {
+				t.Errorf("path mismatch: want %q, got %q", test.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This implementation helps eliminate all ambiguity stemming from using strings as path, namely differentiating between absolute and relative paths.