### PR TITLE
Avoid delays in unified uploads due to batching of FindMissingBlobs.

### DIFF
--- a/go/pkg/client/cas_test.go
+++ b/go/pkg/client/cas_test.go
@@ -795,6 +795,7 @@ func TestUpload(t *testing.T) {
 			for _, o := range tc.opts {
 				o.Apply(c)
 			}
+			c.RunBackgroundTasks()
 
 			present := make(map[digest.Digest]bool)
 			for _, blob := range tc.present {
@@ -1580,6 +1581,7 @@ func TestDownloadActionOutputsConcurrency(t *testing.T) {
 				for _, b := range blobs {
 					fake.Put(b.blob)
 				}
+				c.RunBackgroundTasks()
 
 				eg, eCtx := errgroup.WithContext(ctx)
 				for i := 0; i < 100; i++ {

--- a/go/pkg/client/cas_upload.go
+++ b/go/pkg/client/cas_upload.go
@@ -246,9 +246,28 @@ func (c *Client) uploadUnified(ctx context.Context, entries ...*uploadinfo.Entry
 		return nil, 0, err
 	}
 	wait := make(chan *uploadResponse, uploads)
-	var missing []digest.Digest
+	var dgs []digest.Digest
+	dedupDgs := make(map[digest.Digest]bool, uploads)
+	for _, ue := range entries {
+		if _, ok := dedupDgs[ue.Digest]; !ok {
+			dgs = append(dgs, ue.Digest)
+			dedupDgs[ue.Digest] = true
+		}
+	}
+	missing, err := c.MissingBlobs(ctx, dgs)
+	if err != nil {
+		return nil, 0, err
+	}
+	missingDgs := make(map[digest.Digest]bool)
+	for _, dg := range missing {
+		missingDgs[dg] = true
+	}
 	var reqs []*uploadRequest
 	for _, ue := range entries {
+		if _, ok := missingDgs[ue.Digest]; !ok {
+			uploads--
+			continue
+		}
 		if ue.Digest.IsEmpty() {
 			uploads--
 			LogContextInfof(ctx, log.Level(2), "Skipping upload of empty entry %s", ue.Digest)
@@ -390,26 +409,16 @@ func (c *Client) upload(reqs []*uploadRequest) {
 		}
 		return
 	}
-	missing, present, err := c.findBlobState(ctx, newUploads)
-	if err != nil {
-		for _, st := range newStates {
-			updateAndNotify(st, 0, err, false)
-		}
-		return
-	}
-	for _, dg := range present {
-		updateAndNotify(newStates[dg], 0, nil, false)
-	}
 
-	LogContextInfof(ctx, log.Level(2), "%d new items to store", len(missing))
+	LogContextInfof(ctx, log.Level(2), "%d new items to store", len(newUploads))
 	var batches [][]digest.Digest
 	if c.useBatchOps {
-		batches = c.makeBatches(ctx, missing, true)
+		batches = c.makeBatches(ctx, newUploads, true)
 	} else {
 		LogContextInfof(ctx, log.Level(2), "Uploading them individually")
-		for i := range missing {
-			LogContextInfof(ctx, log.Level(3), "Creating single batch of blob %s", missing[i])
-			batches = append(batches, missing[i:i+1])
+		for i := range newUploads {
+			LogContextInfof(ctx, log.Level(3), "Creating single batch of blob %s", newUploads[i])
+			batches = append(batches, newUploads[i:i+1])
 		}
 	}
 
@@ -468,21 +477,6 @@ func (c *Client) upload(reqs []*uploadRequest) {
 			}
 		}()
 	}
-}
-
-func (c *Client) findBlobState(ctx context.Context, dgs []digest.Digest) (missing []digest.Digest, present []digest.Digest, err error) {
-	dgMap := make(map[digest.Digest]bool)
-	for _, d := range dgs {
-		dgMap[d] = true
-	}
-	missing, err = c.MissingBlobs(ctx, dgs)
-	for _, d := range missing {
-		delete(dgMap, d)
-	}
-	for d := range dgMap {
-		present = append(present, d)
-	}
-	return missing, present, err
 }
 
 // This function is only used when UnifiedUploads is false. It will be removed


### PR DESCRIPTION
This PR removes the behavior to batch FindMissingBlobs calls as part of unified uploads. This behavior has been benchmarked to slow builds down by ~2x. FindMissingBlobs is cheap and calling it per UploadIfMissing call is a reasonable way to prune upload requests going into a buffer, specially that the blob cache hit rate is expected to be very high.

This PR also fixes the handling of UnifiedUploads / UnifiedDownloads client options to avoid complicated restart logic.