### PR TITLE
introduce the file system walker package

### DIFF
--- a/go/pkg/io/walker/BUILD.bazel
+++ b/go/pkg/io/walker/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "walker",
+    srcs = [
+        "filter.go",
+        "stack.go",
+        "walker.go",
+    ],
+    importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/io/walker",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go/pkg/errors",
+        "//go/pkg/io/impath",
+    ],
+)
+
+go_test(
+    name = "walker_test",
+    srcs = [
+        "filter_test.go",
+        "walker_test.go",
+    ],
+    deps = [
+        ":walker",
+        "//go/pkg/errors",
+        "//go/pkg/io/impath",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+    ],
+)

--- a/go/pkg/io/walker/filter.go
+++ b/go/pkg/io/walker/filter.go
@@ -1,0 +1,79 @@
+package walker
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+)
+
+// Filter specifies a filter for paths during traversal.
+// The zero value matches nothing.
+type Filter struct {
+	// Regexp specifies what paths should match with this filter.
+	//
+	// The file separator must be the forwrad slash. All paths will have
+	// their separators converted to forward slash before matching with this regexp.
+	//
+	// If nil, any path will match.
+	Regexp *regexp.Regexp
+
+	// Mode is matched using the equality operator.
+	Mode fs.FileMode
+}
+
+// Path is used when the filter is a regexp only.
+//
+// If the filter's mode is set (not zero), false is returned regardless of the regexp value.
+// If the regexp is nil, false is returned.
+// If path matches the regexp, true is returned.
+func (f Filter) Path(path string) bool {
+	if f.Regexp == nil || f.Mode != 0 {
+		return false
+	}
+	return f.match(path, f.Mode)
+}
+
+// File matches path and mode.
+//
+// If either of the filter's regexp or mode is not set, false is returned.
+// Only if both path and mode match the filter's, true is returned.
+func (f Filter) File(path string, mode fs.FileMode) bool {
+	if f.Regexp == nil || f.Mode == 0 {
+		return false
+	}
+	return f.match(path, mode)
+}
+
+func (f Filter) match(path string, mode fs.FileMode) bool {
+	return mode == f.Mode && f.Regexp.MatchString(filepath.ToSlash(path))
+}
+
+// String returns a string representation of the filter.
+//
+// If this is a zero or a nil filter, the empty string is returned.
+// A zero filter has regexp compiled from the empty string and 0 mode.
+//
+// It can be used as a stable identifier. However, keep in mind that
+// multiple regular expressions may yield the same automaton. I.e. even
+// if two filters have different identifiers, they may still yield the same
+// traversal result.
+func (f Filter) String() string {
+	// zero filter: ""
+	// regexp only: "<regexp>"
+	// mode only: ";<mode>"
+	// both: "<regexp>;<mode>"
+
+	if f.Regexp == nil && f.Mode == 0 {
+		return ""
+	}
+
+	reStr := ""
+	if f.Regexp != nil {
+		reStr = f.Regexp.String()
+	}
+	if f.Mode == 0 {
+		return reStr
+	}
+	return fmt.Sprintf("%s;%d", reStr, f.Mode)
+}

--- a/go/pkg/io/walker/filter_test.go
+++ b/go/pkg/io/walker/filter_test.go
@@ -1,0 +1,110 @@
+package walker_test
+
+import (
+	"io/fs"
+	"regexp"
+	"testing"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/io/walker"
+)
+
+func TestFilterMatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		filter    walker.Filter
+		paths     []string
+		modes     []fs.FileMode
+		wantsPath []bool
+		wantsFile []bool
+	}{
+		{
+			name:      "zero",
+			filter:    walker.Filter{},
+			paths:     []string{"/foo", "bar/baz"},
+			modes:     []fs.FileMode{1, 2},
+			wantsPath: []bool{false, false},
+			wantsFile: []bool{false, false},
+		},
+		{
+			name:      "regexp_only",
+			filter:    walker.Filter{Regexp: regexp.MustCompile("/bar/")},
+			paths:     []string{"/foo", "/bar/baz"},
+			modes:     []fs.FileMode{1, 2},
+			wantsPath: []bool{false, true},
+			wantsFile: []bool{false, false},
+		},
+		{
+			name:      "mode_only",
+			filter:    walker.Filter{Mode: 4},
+			paths:     []string{"/foo", "/bar/baz"},
+			modes:     []fs.FileMode{1, 4},
+			wantsPath: []bool{false, false},
+			wantsFile: []bool{false, false},
+		},
+		{
+			name:      "regexp_and_mode",
+			filter:    walker.Filter{Regexp: regexp.MustCompile("/bar/"), Mode: 4},
+			paths:     []string{"/foo", "/bar/baz"},
+			modes:     []fs.FileMode{1, 4},
+			wantsPath: []bool{false, false},
+			wantsFile: []bool{false, true},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			for i := 0; i < len(test.paths); i++ {
+				r := test.filter.Path(test.paths[i])
+				if r != test.wantsPath[i] {
+					t.Errorf("result mismatch for path %q: want %t, got %t", test.paths[i], test.wantsPath[i], r)
+				}
+
+				r = test.filter.File(test.paths[i], test.modes[i])
+				if r != test.wantsFile[i] {
+					t.Errorf("result mismatch for file %q with mode %d: want %t, got %t", test.paths[i], test.modes[i], test.wantsFile[i], r)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterString(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter walker.Filter
+		want   string
+	}{
+		{
+			name:   "empty",
+			filter: walker.Filter{},
+			want:   "",
+		},
+		{
+			name:   "regexp_only",
+			filter: walker.Filter{Regexp: regexp.MustCompile("/bar/.*")},
+			want:   "/bar/.*",
+		},
+		{
+			name:   "regexp_and_mode",
+			filter: walker.Filter{Regexp: regexp.MustCompile("/bar/.*"), Mode: 4},
+			want:   "/bar/.*;4",
+		},
+		{
+			name:   "mode_only",
+			filter: walker.Filter{Mode: 4},
+			want:   ";4",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			id := test.filter.String()
+			if id != test.want {
+				t.Errorf("invalid string: want %q, got %q", test.want, id)
+			}
+		})
+	}
+}

--- a/go/pkg/io/walker/stack.go
+++ b/go/pkg/io/walker/stack.go
@@ -1,0 +1,49 @@
+package walker
+
+import "fmt"
+
+type stack struct {
+	stack []any
+}
+
+func (s *stack) push(items ...any) {
+	s.stack = append(s.stack, items...)
+}
+
+func (s *stack) insert(item any, i int) {
+	if i < 0 || i > len(s.stack) {
+		panic(fmt.Errorf("stack index %d out of range with stack length %d", i, len(s.stack)))
+	}
+
+	if i == len(s.stack) {
+		s.stack = append(s.stack, item)
+		return
+	}
+
+	// Duplicate item at index i and shift subsequent items right.
+	s.stack = append(s.stack[:i+1], s.stack[i:]...)
+	// Replace the duplicated item with the specified one.
+	s.stack[i] = item
+}
+
+func (s *stack) pop() any {
+	p := s.peek()
+	if p == nil {
+		return nil
+	}
+	s.stack = s.stack[:len(s.stack)-1]
+	return p
+}
+
+func (s *stack) peek() any {
+	i := len(s.stack) - 1
+	if i < 0 {
+		return nil
+	}
+	p := s.stack[i]
+	return p
+}
+
+func (s *stack) len() int {
+	return len(s.stack)
+}

--- a/go/pkg/io/walker/walker.go
+++ b/go/pkg/io/walker/walker.go
@@ -1,0 +1,308 @@
+package walker
+
+import (
+	"io"
+	"io/fs"
+	"os"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/io/impath"
+)
+
+// Internal shared actions.
+const (
+	aRead = iota
+	aSkip
+	aDefer
+	aReplace
+	aCancel
+)
+
+type (
+	// PreAction is an enum that defines the valid actions for the pre-access callback.
+	PreAction int
+
+	// SymlinkAction is an enum that defines the valid actions for a the symlink callback.
+	SymlinkAction int
+)
+
+const (
+	// Access indicates that the walker should stat the path.
+	Access PreAction = aRead
+
+	// SkipPath indicates that the walker should skip the path and continue traversing.
+	SkipPath PreAction = aSkip
+
+	// Defer indicates that the walker should reschedule the path for another visit and continue traversing.
+	Defer PreAction = aDefer
+
+	// Follow indicates that the walker should follow the symlink.
+	Follow SymlinkAction = aRead
+
+	// Replace indicates that the walker should follow the target of a symlink, but reports every path from that sub-traversal
+	// as a descendant path of the symlink's path.
+	//
+	// For example: if /foo/bar was a symlink to /a/b, the walker would report the path of b as /foo/bar, and the path of a/b/c.d as /foo/bar/c.d.
+	// This behavior is equivalent to copying the entire tree of the target in place of the symlink.
+	Replace SymlinkAction = aReplace
+
+	// SkipSymlink indicates that the walker should continue treversing without following the symlink.
+	SkipSymlink SymlinkAction = aSkip
+)
+
+// Callback defines the implementations that the client should provide for the walker.
+// Returning false from any callback cancels the entire walk.
+//
+// Defining a set of callbacks instead of a single shared one allows ensuring valid actions are returned at compile time.
+// This is more robust than using implicit default actions or propagating errors at runtime.
+type Callback struct {
+	// Pre is called before accessing the path. Returning false cancels the entire walk.
+	Pre func(path impath.Absolute, realPath impath.Absolute) (PreAction, bool)
+
+	// Symlink is called for symlinks. Returning false cancels the entire walk.
+	Symlink func(path impath.Absolute, realPath impath.Absolute, info fs.FileInfo) (SymlinkAction, bool)
+
+	// Post is called for non-symlinks. Returning false cancels the entire walk.
+	Post func(path impath.Absolute, realPath impath.Absolute, info fs.FileInfo) bool
+
+	// Err is called when an io error is encountered. Returning false cancels the entire walk.
+	Err func(path impath.Absolute, realPath impath.Absolute, err error) bool
+}
+
+type elem struct {
+	info fs.FileInfo
+	// realPath is the path used to perform syscalls with.
+	realPath impath.Absolute
+	// path is what a symlink target (or target descendant) should look like when it's replaced. Otherwise, it is identical to realPath.
+	path impath.Absolute
+	// a deferred parent is a directory that has already been pre-accessed and processed, but is still pending a post-access.
+	deferredParent bool
+}
+
+// DepthFirst walks the filesystem tree rooted at the specified root in depth-first-search style traversal.
+// That is, every directory is visited after all its descendants have been visited.
+//
+// Before visiting a path, the Pre callback is called. At this point, the client may instruct the walker to:
+//
+//	Skip the path;
+//	Access and stat the path; or
+//	Defer the path to be vistied after all its siblings have been visited.
+//
+// Deferred paths block traversing back up the tree since a parent requires all its children to be processed before itself to honour the DFS contract.
+//
+// If Pre returns Access, then either Symlink or Post is called after making a syscall to stat the path.
+//
+// If the stat syscall returned an error, it is passed to Err callback to let the client decide whether to skip the path or cancel the entire walk.
+//
+// If Symlink was called, the client may instruct the walker to:
+//
+//	Follow the symlink;
+//	Replace the symlink with its target; or
+//	Continue traversing without following the symlink.
+//
+// The client may at any point return false from any callback to cancel the entire walk.
+func DepthFirst(root impath.Absolute, exclude Filter, cb Callback) {
+	pending := &stack{}
+	pending.push(elem{realPath: root, path: root})
+	// parentIndex keeps track of the last directory so deferred children can be scheduled to be visited before it.
+	parentIndex := &stack{}
+
+	for pending.len() > 0 {
+		e := pending.pop().(elem)
+		pi := -1 // If root is deferred, it would be inserted at index 0.
+		if parentIndex.len() > 0 {
+			pi = parentIndex.peek().(int)
+		}
+
+		// If we're back to processing the directory, remove it from the parenthood chain.
+		if pending.len() == pi {
+			parentIndex.pop()
+		}
+
+		// If it's a previously pre-accessed directory, process its children.
+		if !e.deferredParent && e.info != nil && e.info.IsDir() {
+			deferred, action := processDir(e, exclude, cb)
+			if action == aCancel {
+				return
+			}
+			if action == aSkip {
+				continue
+			}
+			// If there are deferred children, queue them to be visited before their parent.
+			if len(deferred) > 0 {
+				e.deferredParent = true
+				// Remember the parent index to insert deferred children after it in the stack.
+				parentIndex.push(pending.len())
+				// Reschdule the parent to be visited after its children.
+				pending.push(e)
+				// Schedule the children to be visited before their parent.
+				pending.push(deferred...)
+				continue
+			}
+		}
+
+		// For new paths, pre-access.
+		// For pre-accessed paths (including processed directories), post-access.
+		deferredElem, action := visit(e, exclude, cb)
+		if action == aCancel {
+			return
+		}
+		if action == aSkip {
+			continue
+		}
+		if action == aDefer {
+			// Reschedule a visit for this path before its parent.
+			pending.insert(e, pi+1)
+			continue
+		}
+		// If it's a pre-accessed directory or a followed symlink, schedule processing and post-access.
+		if deferredElem != nil {
+			pending.push(*deferredElem)
+			continue
+		}
+	}
+}
+
+// visit performs pre-access, stat, and/or post-access depending on the state of the element.
+//
+// If aDefer is returned, it refers to the element from the arguments, not the returned reference.
+// If the returned element reference is not nil, the returned int (action) is always aRead.
+//
+// Return values:
+//
+//	*elem is nil unless the visit has a deferred path, which is either a directory that was not post-accessed or a symlink target.
+//	int is an action that is one of aRead, aDefer, aSkip, or aCancel.
+func visit(e elem, exclude Filter, cb Callback) (*elem, int) {
+	// If the filter applies to the path only, use it here.
+	if exclude.Path(e.path.String()) {
+		return nil, aSkip
+	}
+
+	// Pre-access.
+	if e.info == nil {
+		if action, ok := cb.Pre(e.path, e.realPath); !ok {
+			return nil, aCancel
+		} else if action == aDefer || action == aSkip {
+			return nil, int(action)
+		}
+
+		info, err := os.Lstat(e.realPath.String())
+		if err != nil {
+			if ok := cb.Err(e.path, e.realPath, err); !ok {
+				return nil, aCancel
+			}
+			return nil, aSkip
+		}
+
+		// If the filter applies to path and mode, use it here.
+		if exclude.File(e.path.String(), info.Mode()) {
+			return nil, aSkip
+		}
+
+		e.info = info
+		// If it's a directory, defer it to process its children before post-accessing it.
+		if info.IsDir() {
+			return &e, aRead
+		}
+	}
+
+	// Post-access.
+	if e.info.Mode()&fs.ModeSymlink != fs.ModeSymlink {
+		if ok := cb.Post(e.path, e.realPath, e.info); !ok {
+			return nil, aCancel
+		}
+		return nil, aRead
+	}
+
+	action, ok := cb.Symlink(e.path, e.realPath, e.info)
+	if !ok {
+		return nil, aCancel
+	}
+	if action == aSkip {
+		return nil, aSkip
+	}
+
+	content, errTarget := os.Readlink(e.realPath.String())
+	if errTarget != nil {
+		if ok := cb.Err(e.path, e.realPath, errTarget); !ok {
+			return nil, aCancel
+		}
+		return nil, aSkip
+	}
+
+	// If the symlink content is a relative path, append it to the symlink's directory to make it absolute.
+	target, errIm := impath.Abs(content)
+	if errIm != nil {
+		target = e.realPath.Dir().Append(impath.MustRel(content))
+	}
+
+	deferredElem := &elem{realPath: target, path: target}
+	if action == Replace {
+		deferredElem.path = e.realPath
+	}
+
+	return deferredElem, aRead
+}
+
+// processDir accepts a pre-accessed directory and visits all of its children.
+//
+// All the files (non-directories) will be completely visited within this call.
+// All the directories will be pre-accessed, but not post-accessed.
+// Return values:
+//
+//	[]any is nil unless the directory had deferred-children, which includes directories and client-deferred paths.
+//	int is an action that is forwarded from the visit.
+func processDir(dirElem elem, exclude Filter, cb Callback) ([]any, int) {
+	var deferred []any
+
+	f, errOpen := os.Open(dirElem.realPath.String())
+	if errOpen != nil {
+		if ok := cb.Err(dirElem.path, dirElem.realPath, errOpen); !ok {
+			return deferred, aCancel
+		}
+		return deferred, aSkip
+	}
+	// Ignoring the error here is acceptable because the file was not modified in any way.
+	// The only bad side effect may be a dangling descriptor that leaks until the process is terminated.
+	defer f.Close()
+
+	for {
+		names, errRead := f.Readdirnames(128)
+
+		if errRead != nil && errRead != io.EOF {
+			if ok := cb.Err(dirElem.path, dirElem.realPath, errOpen); !ok {
+				return deferred, aCancel
+			}
+			return deferred, aSkip
+		}
+
+		// Iterate before checking for EOF to avoid missing the last batch.
+		for _, name := range names {
+			// name is relative.
+			relName := impath.MustRel(name)
+			rp := dirElem.realPath.Append(relName)
+			p := dirElem.path.Append(relName)
+
+			// Pre-access.
+			e := elem{realPath: rp, path: p}
+			deferredElem, action := visit(e, exclude, cb)
+			if action == aCancel {
+				return deferred, aCancel
+			}
+			if action == aSkip {
+				continue
+			}
+			if action == aDefer {
+				deferred = append(deferred, e)
+				continue
+			}
+			if deferredElem != nil {
+				deferred = append(deferred, *deferredElem)
+				continue
+			}
+		}
+
+		if errRead == io.EOF {
+			return deferred, aRead
+		}
+	}
+}

--- a/go/pkg/io/walker/walker_test.go
+++ b/go/pkg/io/walker/walker_test.go
@@ -1,0 +1,403 @@
+package walker_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/io/impath"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/io/walker"
+	"github.com/google/go-cmp/cmp"
+)
+
+const (
+	actionPre = iota
+	actionPost
+	actionSymlink
+)
+
+type (
+	symlinks  = map[string]string
+	actionVal struct {
+		action int
+		cancel bool
+	}
+	actions     = map[int]actionVal
+	pathActions = map[string]actions
+	pathCount   = map[string]int
+)
+
+func TestWalker(t *testing.T) {
+	tests := []struct {
+		name             string
+		paths            []string // Use a trailing slash to mark directories.
+		symlinks         symlinks
+		root             string
+		filter           walker.Filter
+		pathActions      pathActions
+		wantRealCount    pathCount
+		wantDesiredCount pathCount
+		wantErr          error
+	}{
+		{
+			name:          "single_file",
+			paths:         []string{"foo.c"},
+			wantRealCount: pathCount{"foo.c": 2},
+		},
+		{
+			name:          "empty_dir",
+			paths:         []string{"foo"},
+			wantRealCount: pathCount{"foo": 2},
+		},
+		{
+			name:          "dir_single_file",
+			paths:         []string{"foo/bar.c"},
+			wantRealCount: pathCount{"foo": 2, "foo/bar.c": 2},
+		},
+		{
+			name: "single_level",
+			paths: []string{
+				"foo/bar.c",
+				"foo/baz.c",
+			},
+			wantRealCount: pathCount{"foo": 2, "foo/bar.c": 2, "foo/baz.c": 2},
+		},
+		{
+			name: "two_levels_simple",
+			paths: []string{
+				"foo/a.z",
+				"foo/bar/b.z",
+			},
+			wantRealCount: pathCount{"foo": 2, "foo/a.z": 2, "foo/bar": 2, "foo/bar/b.z": 2},
+		},
+		{
+			name: "two_levels",
+			paths: []string{
+				"foo/a.z",
+				"foo/b.z",
+				"foo/bar/c.z",
+				"foo/bar/baz/d.z",
+				"foo/bar/baz/e.z",
+			},
+			wantRealCount: pathCount{
+				"foo":             2,
+				"foo/a.z":         2,
+				"foo/b.z":         2,
+				"foo/bar":         2,
+				"foo/bar/baz":     2,
+				"foo/bar/c.z":     2,
+				"foo/bar/baz/d.z": 2,
+				"foo/bar/baz/e.z": 2,
+			},
+		},
+		{
+			name:          "skip_file_by_path",
+			paths:         []string{"foo.c"},
+			filter:        walker.Filter{Regexp: regexp.MustCompile("foo.c")},
+			wantRealCount: pathCount{},
+		},
+		{
+			name:          "path_cancel",
+			paths:         []string{"foo.c"},
+			pathActions:   pathActions{"foo.c": actions{actionPre: {cancel: true}}},
+			wantRealCount: pathCount{"foo.c": 1},
+		},
+		{
+			name:          "single_file_deferred",
+			paths:         []string{"foo.c"},
+			pathActions:   pathActions{"foo.c": actions{actionPre: {action: int(walker.Defer)}}},
+			wantRealCount: pathCount{"foo.c": 3},
+		},
+		{
+			name:          "single_dir_deferred",
+			paths:         []string{"foo/"},
+			pathActions:   pathActions{"foo": actions{actionPre: {action: int(walker.Defer)}}},
+			wantRealCount: pathCount{"foo": 3},
+		},
+		{
+			name: "deferred",
+			paths: []string{
+				"foo/a.z",
+				"foo/b.z",
+				"foo/bar/c.z",
+				"foo/bar/baz/d.z",
+				"foo/bar/baz/e.z",
+			},
+			pathActions: pathActions{
+				"foo/b.z":         actions{actionPre: {action: int(walker.Defer)}},
+				"foo/bar/baz/e.z": actions{actionPre: {action: int(walker.Defer)}},
+			},
+			wantRealCount: pathCount{
+				"foo":             2,
+				"foo/a.z":         2,
+				"foo/b.z":         3,
+				"foo/bar":         2,
+				"foo/bar/baz":     2,
+				"foo/bar/c.z":     2,
+				"foo/bar/baz/d.z": 2,
+				"foo/bar/baz/e.z": 3,
+			},
+		},
+		{
+			name:     "file_symlink",
+			symlinks: symlinks{"foo.c": "bar.c"},
+			wantRealCount: pathCount{
+				"foo.c": 2,
+				"bar.c": 2,
+			},
+		},
+		{
+			name:     "dir_symlink",
+			paths:    []string{"foo/bar.c"},
+			symlinks: symlinks{"foo.c": "foo/"},
+			root:     "foo.c",
+			wantRealCount: pathCount{
+				"foo.c":     2,
+				"foo/bar.c": 2,
+				"foo":       2,
+			},
+		},
+		{
+			name:     "nested_symlink",
+			paths:    []string{"foo/bar.c"},
+			symlinks: symlinks{"foo/baz.c": "a.z"},
+			root:     "foo", // Otherwise it is nondeterministic which top-level path is selected.
+			wantRealCount: pathCount{
+				"foo":       2,
+				"foo/bar.c": 2,
+				"foo/baz.c": 2,
+				"a.z":       2,
+			},
+		},
+		{
+			name:        "skip_symlink",
+			paths:       []string{"foo/bar.c"},
+			symlinks:    symlinks{"foo.c": "foo/"},
+			pathActions: pathActions{"foo.c": actions{actionSymlink: {action: int(walker.SkipSymlink)}}},
+			wantRealCount: pathCount{
+				"foo.c": 2,
+			},
+		},
+		{
+			name:     "relative_symlink",
+			symlinks: symlinks{"foo/bar.c": "./baz.c"},
+			wantRealCount: pathCount{
+				"foo":       2,
+				"foo/bar.c": 2,
+				"foo/baz.c": 4, // 2 as a child of foo, and 2 as a symlink target.
+			},
+		},
+		{
+			name:        "replace_single_symlink",
+			symlinks:    symlinks{"foo.c": "bar.c"},
+			root:        "foo.c",
+			pathActions: pathActions{"foo.c": actions{actionSymlink: {action: int(walker.Replace)}}},
+			wantRealCount: pathCount{
+				"foo.c": 2,
+				"bar.c": 2,
+			},
+			wantDesiredCount: pathCount{
+				"foo.c": 2,
+			},
+		},
+		{
+			name: "replace_symlink_dir",
+			paths: []string{
+				"bar/a.z",
+				"bar/b.z",
+				"bar/c/d.z",
+			},
+			symlinks:    symlinks{"foo": "bar/"},
+			root:        "foo",
+			pathActions: pathActions{"foo": actions{actionSymlink: {action: int(walker.Replace)}}},
+			wantRealCount: pathCount{
+				"foo":       2,
+				"bar":       2,
+				"bar/a.z":   2,
+				"bar/b.z":   2,
+				"bar/c":     2,
+				"bar/c/d.z": 2,
+			},
+			wantDesiredCount: pathCount{
+				"foo":       2,
+				"foo/a.z":   2,
+				"foo/b.z":   2,
+				"foo/c":     2,
+				"foo/c/d.z": 2,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			tmp, root, fsLayout := makeFs(t, test.paths, test.symlinks)
+			if test.root != "" {
+				root = filepath.Join(tmp, test.root)
+			}
+			var realSeq []string
+			dpvc := pathCount{} // desired path visit count
+			walker.DepthFirst(impath.MustAbs(root), test.filter, walker.Callback{
+				Err: func(_ impath.Absolute, _ impath.Absolute, err error) bool {
+					t.Errorf("unexpected error: %v", err)
+					return false
+				},
+				Pre: func(path impath.Absolute, realPath impath.Absolute) (walker.PreAction, bool) {
+					p, _ := filepath.Rel(tmp, realPath.String())
+					realSeq = append(realSeq, p)
+					dp, _ := filepath.Rel(tmp, path.String())
+					if dp != p {
+						dpvc[dp]++
+					}
+
+					v := test.pathActions[p][actionPre]
+					// Only defer once to avoid infinite loops.
+					if v.action == int(walker.Defer) {
+						test.pathActions[p][actionPre] = actionVal{action: int(walker.Access), cancel: v.cancel}
+					}
+					return walker.PreAction(v.action), !v.cancel
+				},
+				Post: func(path impath.Absolute, realPath impath.Absolute, _ fs.FileInfo) bool {
+					p, _ := filepath.Rel(tmp, realPath.String())
+					realSeq = append(realSeq, p)
+					dp, _ := filepath.Rel(tmp, path.String())
+					if dp != p {
+						dpvc[dp]++
+					}
+					return !test.pathActions[p][actionPost].cancel
+				},
+				Symlink: func(path impath.Absolute, realPath impath.Absolute, _ fs.FileInfo) (walker.SymlinkAction, bool) {
+					p, _ := filepath.Rel(tmp, realPath.String())
+					realSeq = append(realSeq, p)
+					dp, _ := filepath.Rel(tmp, path.String())
+					if dp != p {
+						dpvc[dp]++
+					}
+					v := test.pathActions[p][actionSymlink]
+					return walker.SymlinkAction(v.action), !v.cancel
+				},
+			})
+			pvc := validateSequence(t, realSeq, fsLayout)
+			if diff := cmp.Diff(test.wantRealCount, pvc); diff != "" {
+				t.Errorf("path visit count mismatch (-want +got):\n%s", diff)
+			}
+			if len(test.wantDesiredCount) == 0 && len(dpvc) == 0 {
+				return
+			}
+			if diff := cmp.Diff(test.wantDesiredCount, dpvc); diff != "" {
+				t.Errorf("desired path visit count mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func makeFs(t *testing.T, paths []string, symlinks symlinks) (string, string, map[string][]string) {
+	t.Helper()
+
+	if len(paths) == 0 && len(symlinks) == 0 {
+		t.Fatalf("paths and symlinks cannot be both empty")
+	}
+
+	tmp := t.TempDir()
+
+	// Map each dir to its children.
+	fsLayout := map[string][]string{}
+	for _, p := range paths {
+		createFile(t, tmp, p)
+		parent := filepath.Dir(p)
+		fsLayout[parent] = append(fsLayout[parent], p)
+	}
+	for p, content := range symlinks {
+		trg := content
+		// If the symlink content is relative to the symlink itself, append it to its parent.
+		// Otherwise, make it absolute.
+		if strings.HasPrefix(content, "./") {
+			content = content[2:]
+			trg = filepath.Join(filepath.Dir(p), content)
+		} else {
+			content = filepath.Join(tmp, content)
+		}
+		createFile(t, tmp, trg)
+		err := os.Symlink(content, filepath.Join(tmp, p))
+		if err != nil {
+			t.Errorf("io error: %v", err)
+		}
+
+		parent := filepath.Dir(p)
+		fsLayout[parent] = append(fsLayout[parent], p)
+		parent = filepath.Dir(trg)
+		fsLayout[parent] = append(fsLayout[parent], trg)
+	}
+	// Recursively parse out parents from other parents.
+	// E.g. if the map has the keys foo/bar and bar/baz, it should also include
+	// the keys foo and bar as parent directories.
+	moreParents := true
+	for moreParents {
+		moreParents = false
+		for p := range fsLayout {
+			parent := filepath.Dir(p)
+			c := fsLayout[parent]
+			if len(c) > 0 {
+				continue
+			}
+			if parent != "." {
+				moreParents = true
+			}
+			fsLayout[parent] = append(c, p)
+		}
+	}
+	t.Logf("filesystem layout: %v", fsLayout)
+	// The . must be the root of all directories.
+	if _, ok := fsLayout["."]; !ok {
+		t.Fatalf("root not present in pathChildren at . directory; is there an absolute path in the list? %v", fsLayout)
+	}
+	root := fsLayout["."][0]
+
+	return tmp, filepath.Join(tmp, root), fsLayout
+}
+
+func createFile(t *testing.T, parent, p string) {
+	// Check for suffix before joining since filepath.Join removes trailing slashes.
+	d := p
+	if !strings.HasSuffix(p, "/") {
+		d = filepath.Dir(p)
+	}
+	if err := os.MkdirAll(filepath.Join(parent, d), 0766); err != nil {
+		t.Fatalf("io error: %v", err)
+	}
+	if p == d {
+		return
+	}
+	if err := os.WriteFile(filepath.Join(parent, p), nil, 0666); err != nil {
+		t.Fatalf("io error: %v", err)
+	}
+}
+
+// validateSequence checks that every path is visited after its children.
+func validateSequence(t *testing.T, seq []string, fsLayout map[string][]string) pathCount {
+	t.Helper()
+
+	t.Logf("validating sequence: %v\n", seq)
+	pathVisitCount := pathCount{}
+	pendingParent := map[string]bool{}
+	for _, p := range seq {
+		pathVisitCount[p] += 1
+		parent := filepath.Dir(p)
+		// Parent should be visited after this child.
+		pendingParent[parent] = true
+		// If this child is itself a parent, mark it as done.
+		delete(pendingParent, p)
+	}
+	delete(pendingParent, ".")
+	if len(pendingParent) > 0 {
+		pending := make([]string, 0, len(pendingParent))
+		for p := range pendingParent {
+			pending = append(pending, p)
+		}
+		t.Errorf("some paths were not fully visited: %v", pending)
+	}
+	return pathVisitCount
+}


### PR DESCRIPTION
The package provides an API to walk the file system in depth-first style traversal. This encapsulates IO and implementation naunces and exposes a concise interface for clients.

The DFS traversal and the deferring behaviour is leveraged in the CAS upload implementation that will posted later.