### PR TITLE
Handle symlinks in packageDirectories

### DIFF
--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -529,6 +529,12 @@ func packageDirectories(t *treeNode) (root *repb.Directory, files map[digest.Dig
 		files[dg] = fn.ue
 	}
 	sort.Slice(root.Files, func(i, j int) bool { return root.Files[i].Name < root.Files[j].Name })
+
+	for name, sym := range t.symlinks {
+		root.Symlinks = append(root.Symlinks, &repb.SymlinkNode{Name: name, Target: sym.target})
+	}
+	sort.Slice(root.Symlinks, func(i, j int) bool { return root.Symlinks[i].Name < root.Symlinks[j].Name })
+
 	return root, files, treePb, nil
 }
 


### PR DESCRIPTION
Very similar to the handling of `t.files`, seems to have just been missed in this case.