### PR TITLE
Revert "remove redundant imports"

### DIFF
--- a/go/pkg/cas/client.go
+++ b/go/pkg/cas/client.go
@@ -11,11 +11,12 @@ import (
 
 	"github.com/pkg/errors"
 	"golang.org/x/sync/semaphore"
-	bspb "google.golang.org/genproto/googleapis/bytestream"
+	bsgrpc "google.golang.org/genproto/googleapis/bytestream"
 	"google.golang.org/grpc"
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/retry"
+	regrpc "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 )
 
@@ -33,8 +34,8 @@ type Client struct {
 	// Config is the configuration that the client was created with.
 	Config ClientConfig
 
-	byteStream bspb.ByteStreamClient
-	cas        repb.ContentAddressableStorageClient
+	byteStream bsgrpc.ByteStreamClient
+	cas        regrpc.ContentAddressableStorageClient
 
 	// per-RPC semaphores
 
@@ -251,8 +252,8 @@ func NewClientWithConfig(ctx context.Context, conn *grpc.ClientConn, instanceNam
 		InstanceName: instanceName,
 		Config:       config,
 		conn:         conn,
-		byteStream:   bspb.NewByteStreamClient(conn),
-		cas:          repb.NewContentAddressableStorageClient(conn),
+		byteStream:   bsgrpc.NewByteStreamClient(conn),
+		cas:          regrpc.NewContentAddressableStorageClient(conn),
 	}
 	if !client.Config.IgnoreCapabilities {
 		if err := client.checkCapabilities(ctx); err != nil {
@@ -311,7 +312,7 @@ func (c *Client) withRetries(ctx context.Context, f func(context.Context) error)
 // checkCapabilities consults with server-side capabilities and potentially
 // mutates c.ClientConfig.
 func (c *Client) checkCapabilities(ctx context.Context) error {
-	caps, err := repb.NewCapabilitiesClient(c.conn).GetCapabilities(ctx, &repb.GetCapabilitiesRequest{InstanceName: c.InstanceName})
+	caps, err := regrpc.NewCapabilitiesClient(c.conn).GetCapabilities(ctx, &repb.GetCapabilitiesRequest{InstanceName: c.InstanceName})
 	if err != nil {
 		return errors.Wrapf(err, "GetCapabilities RPC")
 	}

--- a/go/pkg/cas/upload_test.go
+++ b/go/pkg/cas/upload_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/fakes"
+	regrpc "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 )
 
@@ -832,7 +833,7 @@ func uploadInputChanFrom(inputs ...*UploadInput) chan *UploadInput {
 }
 
 type fakeCAS struct {
-	repb.ContentAddressableStorageClient
+	regrpc.ContentAddressableStorageClient
 	findMissingBlobs func(ctx context.Context, in *repb.FindMissingBlobsRequest, opts ...grpc.CallOption) (*repb.FindMissingBlobsResponse, error)
 	batchUpdateBlobs func(ctx context.Context, in *repb.BatchUpdateBlobsRequest, opts ...grpc.CallOption) (*repb.BatchUpdateBlobsResponse, error)
 }

--- a/go/pkg/client/batch_retries_test.go
+++ b/go/pkg/client/batch_retries_test.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	regrpc "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 )
@@ -76,7 +77,7 @@ func (f *flakyBatchServer) BatchReadBlobs(ctx context.Context, req *repb.BatchRe
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-func (f *flakyBatchServer) GetTree(req *repb.GetTreeRequest, stream repb.ContentAddressableStorage_GetTreeServer) error {
+func (f *flakyBatchServer) GetTree(req *repb.GetTreeRequest, stream regrpc.ContentAddressableStorage_GetTreeServer) error {
 	return status.Error(codes.Unimplemented, "")
 }
 
@@ -130,7 +131,7 @@ func TestBatchUpdateBlobsIndividualRequestRetries(t *testing.T) {
 	}
 	server := grpc.NewServer()
 	fake := &flakyBatchServer{}
-	repb.RegisterContentAddressableStorageServer(server, fake)
+	regrpc.RegisterContentAddressableStorageServer(server, fake)
 	go server.Serve(listener)
 	ctx := context.Background()
 	client, err := client.NewClient(ctx, instance, client.DialParams{
@@ -204,7 +205,7 @@ func TestBatchReadBlobsIndividualRequestRetries(t *testing.T) {
 	}
 	server := grpc.NewServer()
 	fake := &flakyBatchServer{}
-	repb.RegisterContentAddressableStorageServer(server, fake)
+	regrpc.RegisterContentAddressableStorageServer(server, fake)
 	go server.Serve(listener)
 	ctx := context.Background()
 	client, err := client.NewClient(ctx, instance, client.DialParams{
@@ -291,7 +292,7 @@ func (s *sleepyBatchServer) FindMissingBlobs(ctx context.Context, req *repb.Find
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-func (s *sleepyBatchServer) GetTree(req *repb.GetTreeRequest, stream repb.ContentAddressableStorage_GetTreeServer) error {
+func (s *sleepyBatchServer) GetTree(req *repb.GetTreeRequest, stream regrpc.ContentAddressableStorage_GetTreeServer) error {
 	return status.Error(codes.Unimplemented, "")
 }
 
@@ -333,7 +334,7 @@ func TestBatchReadBlobsDeadlineExceededRetries(t *testing.T) {
 	}
 	server := grpc.NewServer()
 	fake := &sleepyBatchServer{timeout: 200 * time.Millisecond}
-	repb.RegisterContentAddressableStorageServer(server, fake)
+	regrpc.RegisterContentAddressableStorageServer(server, fake)
 	go server.Serve(listener)
 	ctx := context.Background()
 	retrier := client.RetryTransient()
@@ -372,7 +373,7 @@ func TestBatchUpdateBlobsDeadlineExceededRetries(t *testing.T) {
 	}
 	server := grpc.NewServer()
 	fake := &sleepyBatchServer{timeout: 200 * time.Millisecond}
-	repb.RegisterContentAddressableStorageServer(server, fake)
+	regrpc.RegisterContentAddressableStorageServer(server, fake)
 	go server.Serve(listener)
 	ctx := context.Background()
 	retrier := client.RetryTransient()

--- a/go/pkg/client/bytestream_test.go
+++ b/go/pkg/client/bytestream_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
+	bsgrpc "google.golang.org/genproto/googleapis/bytestream"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
@@ -198,7 +199,7 @@ func newServer(t *testing.T) *Server {
 	}
 	s.server = grpc.NewServer()
 	s.fake = &ByteStream{logStreams: make(map[string]*logStream)}
-	bspb.RegisterByteStreamServer(s.server, s.fake)
+	bsgrpc.RegisterByteStreamServer(s.server, s.fake)
 
 	go s.server.Serve(s.listener)
 	s.client, err = NewClient(s.ctx, instance, DialParams{
@@ -221,12 +222,12 @@ func (b *ByteStream) QueryWriteStatus(context.Context, *bspb.QueryWriteStatusReq
 	return &bspb.QueryWriteStatusResponse{}, nil
 }
 
-func (b *ByteStream) Read(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServer) error {
+func (b *ByteStream) Read(req *bspb.ReadRequest, stream bsgrpc.ByteStream_ReadServer) error {
 	return nil
 }
 
 // Write implements the write operation for LogStream Write API.
-func (b *ByteStream) Write(stream bspb.ByteStream_WriteServer) error {
+func (b *ByteStream) Write(stream bsgrpc.ByteStream_WriteServer) error {
 	defer stream.SendAndClose(&bspb.WriteResponse{})
 	req, err := stream.Recv()
 	if err != nil {

--- a/go/pkg/client/cas_test.go
+++ b/go/pkg/client/cas_test.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
-	bspb "google.golang.org/genproto/googleapis/bytestream"
+	bsgrpc "google.golang.org/genproto/googleapis/bytestream"
 )
 
 const (
@@ -60,7 +60,7 @@ func TestSplitEndpoints(t *testing.T) {
 		Chunks:           []int{6},
 		ExpectCompressed: false,
 	}
-	bspb.RegisterByteStreamServer(casServer, fake)
+	bsgrpc.RegisterByteStreamServer(casServer, fake)
 	go execServer.Serve(l1)
 	go casServer.Serve(l2)
 	defer casServer.Stop()
@@ -225,7 +225,7 @@ func TestRead(t *testing.T) {
 			}
 			defer listener.Close()
 			server := grpc.NewServer()
-			bspb.RegisterByteStreamServer(server, &tc.fake)
+			bsgrpc.RegisterByteStreamServer(server, &tc.fake)
 			go server.Serve(listener)
 			defer server.Stop()
 			c, err := client.NewClient(ctx, instance, client.DialParams{
@@ -326,7 +326,7 @@ func TestWrite(t *testing.T) {
 			defer listener.Close()
 			server := grpc.NewServer()
 			fake := &fakes.Writer{}
-			bspb.RegisterByteStreamServer(server, fake)
+			bsgrpc.RegisterByteStreamServer(server, fake)
 			go server.Serve(listener)
 			defer server.Stop()
 			c, err := client.NewClient(ctx, instance, client.DialParams{

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -28,9 +28,12 @@ import (
 	"google.golang.org/grpc/status"
 
 	configpb "github.com/bazelbuild/remote-apis-sdks/go/pkg/balancer/proto"
+	regrpc "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	log "github.com/golang/glog"
+	bsgrpc "google.golang.org/genproto/googleapis/bytestream"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
+	opgrpc "google.golang.org/genproto/googleapis/longrunning"
 	oppb "google.golang.org/genproto/googleapis/longrunning"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
 )
@@ -110,11 +113,11 @@ type Client struct {
 	// InstanceName is the instance name for the targeted remote execution instance; e.g. for Google
 	// RBE: "projects/<foo>/instances/default_instance".
 	InstanceName string
-	actionCache  repb.ActionCacheClient
-	byteStream   bspb.ByteStreamClient
-	cas          repb.ContentAddressableStorageClient
-	execution    repb.ExecutionClient
-	operations   oppb.OperationsClient
+	actionCache  regrpc.ActionCacheClient
+	byteStream   bsgrpc.ByteStreamClient
+	cas          regrpc.ContentAddressableStorageClient
+	execution    regrpc.ExecutionClient
+	operations   opgrpc.OperationsClient
 	// Retrier is the Retrier that is used for RPCs made by this client.
 	//
 	// These fields are logically "protected" and are intended for use by extensions of Client.
@@ -702,11 +705,11 @@ func NewClientFromConnection(ctx context.Context, instanceName string, conn, cas
 	}
 	client := &Client{
 		InstanceName:                  instanceName,
-		actionCache:                   repb.NewActionCacheClient(casConn),
-		byteStream:                    bspb.NewByteStreamClient(casConn),
-		cas:                           repb.NewContentAddressableStorageClient(casConn),
-		execution:                     repb.NewExecutionClient(conn),
-		operations:                    oppb.NewOperationsClient(conn),
+		actionCache:                   regrpc.NewActionCacheClient(casConn),
+		byteStream:                    bsgrpc.NewByteStreamClient(casConn),
+		cas:                           regrpc.NewContentAddressableStorageClient(casConn),
+		execution:                     regrpc.NewExecutionClient(conn),
+		operations:                    opgrpc.NewOperationsClient(conn),
 		rpcTimeouts:                   DefaultRPCTimeouts,
 		Connection:                    conn,
 		CASConnection:                 casConn,
@@ -884,7 +887,7 @@ func (c *Client) UpdateActionResult(ctx context.Context, req *repb.UpdateActionR
 // The wrapper is here for completeness to provide access to the low-level
 // RPCs. Prefer using higher-level functions such as ReadBlob(ToFile) instead,
 // as they include retries/timeouts handling.
-func (c *Client) Read(ctx context.Context, req *bspb.ReadRequest) (res bspb.ByteStream_ReadClient, err error) {
+func (c *Client) Read(ctx context.Context, req *bspb.ReadRequest) (res bsgrpc.ByteStream_ReadClient, err error) {
 	return c.byteStream.Read(ctx, req, c.RPCOpts()...)
 }
 
@@ -892,7 +895,7 @@ func (c *Client) Read(ctx context.Context, req *bspb.ReadRequest) (res bspb.Byte
 // The wrapper is here for completeness to provide access to the low-level
 // RPCs. Prefer using higher-level functions such as WriteBlob(s) instead,
 // as they include retries/timeouts handling.
-func (c *Client) Write(ctx context.Context) (res bspb.ByteStream_WriteClient, err error) {
+func (c *Client) Write(ctx context.Context) (res bsgrpc.ByteStream_WriteClient, err error) {
 	return c.byteStream.Write(ctx, c.RPCOpts()...)
 }
 
@@ -964,7 +967,7 @@ func (c *Client) BatchReadBlobs(ctx context.Context, req *repb.BatchReadBlobsReq
 // The wrapper is here for completeness to provide access to the low-level
 // RPCs. Prefer using higher-level GetDirectoryTree instead,
 // as it includes retries/timeouts handling.
-func (c *Client) GetTree(ctx context.Context, req *repb.GetTreeRequest) (res repb.ContentAddressableStorage_GetTreeClient, err error) {
+func (c *Client) GetTree(ctx context.Context, req *repb.GetTreeRequest) (res regrpc.ContentAddressableStorage_GetTreeClient, err error) {
 	return c.cas.GetTree(ctx, req, c.RPCOpts()...)
 }
 
@@ -972,7 +975,7 @@ func (c *Client) GetTree(ctx context.Context, req *repb.GetTreeRequest) (res rep
 // The wrapper is here for completeness to provide access to the low-level
 // RPCs. Prefer using higher-level ExecuteAndWait instead,
 // as it includes retries/timeouts handling.
-func (c *Client) Execute(ctx context.Context, req *repb.ExecuteRequest) (res repb.Execution_ExecuteClient, err error) {
+func (c *Client) Execute(ctx context.Context, req *repb.ExecuteRequest) (res regrpc.Execution_ExecuteClient, err error) {
 	return c.execution.Execute(ctx, req, c.RPCOpts()...)
 }
 
@@ -980,7 +983,7 @@ func (c *Client) Execute(ctx context.Context, req *repb.ExecuteRequest) (res rep
 // The wrapper is here for completeness to provide access to the low-level
 // RPCs. Prefer using higher-level ExecuteAndWait instead,
 // as it includes retries/timeouts handling.
-func (c *Client) WaitExecution(ctx context.Context, req *repb.WaitExecutionRequest) (res repb.Execution_ExecuteClient, err error) {
+func (c *Client) WaitExecution(ctx context.Context, req *repb.WaitExecutionRequest) (res regrpc.Execution_ExecuteClient, err error) {
 	return c.execution.WaitExecution(ctx, req, c.RPCOpts()...)
 }
 
@@ -990,7 +993,7 @@ func (c *Client) GetBackendCapabilities(ctx context.Context, conn *grpc.ClientCo
 	opts := c.RPCOpts()
 	err = c.Retrier.Do(ctx, func() (e error) {
 		return c.CallWithTimeout(ctx, "GetCapabilities", func(ctx context.Context) (e error) {
-			res, e = repb.NewCapabilitiesClient(conn).GetCapabilities(ctx, req, opts...)
+			res, e = regrpc.NewCapabilitiesClient(conn).GetCapabilities(ctx, req, opts...)
 			return e
 		})
 	})

--- a/go/pkg/client/exec.go
+++ b/go/pkg/client/exec.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	regrpc "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	gerrors "github.com/pkg/errors"
 	oppb "google.golang.org/genproto/googleapis/longrunning"
@@ -237,7 +238,7 @@ func (c *Client) ExecuteAndWaitProgress(ctx context.Context, req *repb.ExecuteRe
 	opError := false // Are we propagating an Operation status as an error for the retrier's benefit?
 	lastOp := &oppb.Operation{}
 	closure := func(ctx context.Context) (e error) {
-		var res repb.Execution_ExecuteClient
+		var res regrpc.Execution_ExecuteClient
 		if wait {
 			res, e = c.WaitExecution(ctx, &repb.WaitExecutionRequest{Name: lastOp.Name})
 		} else {

--- a/go/pkg/client/retries_test.go
+++ b/go/pkg/client/retries_test.go
@@ -22,8 +22,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	regrpc "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+	bsgrpc "google.golang.org/genproto/googleapis/bytestream"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
+	opgrpc "google.golang.org/genproto/googleapis/longrunning"
 	oppb "google.golang.org/genproto/googleapis/longrunning"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
@@ -34,7 +37,7 @@ var zstdEncoder, _ = zstd.NewWriter(nil, zstd.WithZeroFrames(true))
 type flakyServer struct {
 	// TODO(jsharpe): This is a hack to work around WaitOperation not existing in some versions of
 	// the long running operations API that we need to support.
-	oppb.OperationsServer
+	opgrpc.OperationsServer
 	mu               sync.RWMutex     // Protects numCalls.
 	numCalls         map[string]int   // A counter of calls the server encountered thus far, by method.
 	muOffset         sync.RWMutex     // Protects initialOffsets.
@@ -67,7 +70,7 @@ func (f *flakyServer) fetchInitialOffset(name string) int64 {
 	return offset
 }
 
-func (f *flakyServer) Write(stream bspb.ByteStream_WriteServer) error {
+func (f *flakyServer) Write(stream bsgrpc.ByteStream_WriteServer) error {
 	numCalls := f.incNumCalls("Write")
 	if numCalls < 3 {
 		time.Sleep(f.sleepDelay)
@@ -89,7 +92,7 @@ func (f *flakyServer) Write(stream bspb.ByteStream_WriteServer) error {
 	return stream.SendAndClose(&bspb.WriteResponse{CommittedSize: 4})
 }
 
-func (f *flakyServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServer) error {
+func (f *flakyServer) Read(req *bspb.ReadRequest, stream bsgrpc.ByteStream_ReadServer) error {
 	numCalls := f.incNumCalls("Read")
 	if numCalls < 3 {
 		time.Sleep(f.sleepDelay)
@@ -159,7 +162,7 @@ func (f *flakyServer) BatchReadBlobs(ctx context.Context, req *repb.BatchReadBlo
 	return nil, f.flakeAndFail("BatchReadBlobs")
 }
 
-func (f *flakyServer) GetTree(req *repb.GetTreeRequest, stream repb.ContentAddressableStorage_GetTreeServer) error {
+func (f *flakyServer) GetTree(req *repb.GetTreeRequest, stream regrpc.ContentAddressableStorage_GetTreeServer) error {
 	numCalls := f.incNumCalls("GetTree")
 	if numCalls < 3 {
 		return status.Error(codes.Canceled, "transient error!")
@@ -185,7 +188,7 @@ func (f *flakyServer) GetTree(req *repb.GetTreeRequest, stream repb.ContentAddre
 	return stream.Send(resp)
 }
 
-func (f *flakyServer) Execute(req *repb.ExecuteRequest, stream repb.Execution_ExecuteServer) error {
+func (f *flakyServer) Execute(req *repb.ExecuteRequest, stream regrpc.Execution_ExecuteServer) error {
 	numCalls := f.incNumCalls("Execute")
 	if numCalls < 2 {
 		return status.Error(codes.Canceled, "transient error!")
@@ -195,7 +198,7 @@ func (f *flakyServer) Execute(req *repb.ExecuteRequest, stream repb.Execution_Ex
 	return status.Error(codes.Internal, "another transient error!")
 }
 
-func (f *flakyServer) WaitExecution(req *repb.WaitExecutionRequest, stream repb.Execution_WaitExecutionServer) error {
+func (f *flakyServer) WaitExecution(req *repb.WaitExecutionRequest, stream regrpc.Execution_WaitExecutionServer) error {
 	numCalls := f.incNumCalls("WaitExecution")
 	if numCalls < 2 {
 		return status.Error(codes.Canceled, "transient error!")
@@ -247,11 +250,11 @@ func setup(t *testing.T) *flakyFixture {
 	}
 	f.server = grpc.NewServer()
 	f.fake = &flakyServer{numCalls: make(map[string]int), initialOffsets: make(map[string]int64)}
-	bspb.RegisterByteStreamServer(f.server, f.fake)
-	repb.RegisterActionCacheServer(f.server, f.fake)
-	repb.RegisterContentAddressableStorageServer(f.server, f.fake)
-	repb.RegisterExecutionServer(f.server, f.fake)
-	oppb.RegisterOperationsServer(f.server, f.fake)
+	bsgrpc.RegisterByteStreamServer(f.server, f.fake)
+	regrpc.RegisterActionCacheServer(f.server, f.fake)
+	regrpc.RegisterContentAddressableStorageServer(f.server, f.fake)
+	regrpc.RegisterExecutionServer(f.server, f.fake)
+	opgrpc.RegisterOperationsServer(f.server, f.fake)
 	go f.server.Serve(f.listener)
 	f.client, err = client.NewClient(f.ctx, instance, client.DialParams{
 		Service:    f.listener.Addr().String(),

--- a/go/pkg/fakes/exec.go
+++ b/go/pkg/fakes/exec.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	regrpc "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	oppb "google.golang.org/genproto/googleapis/longrunning"
 	anypb "google.golang.org/protobuf/types/known/anypb"
@@ -130,7 +131,7 @@ func (s *Exec) GetCapabilities(ctx context.Context, req *repb.GetCapabilitiesReq
 
 // Execute returns the saved result ActionResult, or a Status. It also puts it in the action cache
 // unless the execute request specified
-func (s *Exec) Execute(req *repb.ExecuteRequest, stream repb.Execution_ExecuteServer) (err error) {
+func (s *Exec) Execute(req *repb.ExecuteRequest, stream regrpc.Execution_ExecuteServer) (err error) {
 	dg, err := digest.NewFromProto(req.ActionDigest)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, fmt.Sprintf("invalid digest received: %v", req.ActionDigest))
@@ -149,6 +150,6 @@ func (s *Exec) Execute(req *repb.ExecuteRequest, stream repb.Execution_ExecuteSe
 }
 
 // WaitExecution is not implemented on this fake.
-func (s *Exec) WaitExecution(req *repb.WaitExecutionRequest, stream repb.Execution_WaitExecutionServer) (err error) {
+func (s *Exec) WaitExecution(req *repb.WaitExecutionRequest, stream regrpc.Execution_WaitExecutionServer) (err error) {
 	return status.Error(codes.Unimplemented, "method WaitExecution not implemented by test fake")
 }

--- a/go/pkg/fakes/server.go
+++ b/go/pkg/fakes/server.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/chunker"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/client"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/command"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/filemetadata"
@@ -20,8 +21,9 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	rc "github.com/bazelbuild/remote-apis-sdks/go/pkg/client"
+	regrpc "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
-	bspb "google.golang.org/genproto/googleapis/bytestream"
+	bsgrpc "google.golang.org/genproto/googleapis/bytestream"
 	dpb "google.golang.org/protobuf/types/known/durationpb"
 	tspb "google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -45,11 +47,11 @@ func NewServer(t testing.TB) (s *Server, err error) {
 		return nil, err
 	}
 	s.srv = grpc.NewServer()
-	bspb.RegisterByteStreamServer(s.srv, s.CAS)
-	repb.RegisterContentAddressableStorageServer(s.srv, s.CAS)
-	repb.RegisterActionCacheServer(s.srv, s.ActionCache)
-	repb.RegisterCapabilitiesServer(s.srv, s.Exec)
-	repb.RegisterExecutionServer(s.srv, s.Exec)
+	bsgrpc.RegisterByteStreamServer(s.srv, s.CAS)
+	regrpc.RegisterContentAddressableStorageServer(s.srv, s.CAS)
+	regrpc.RegisterActionCacheServer(s.srv, s.ActionCache)
+	regrpc.RegisterCapabilitiesServer(s.srv, s.Exec)
+	regrpc.RegisterExecutionServer(s.srv, s.Exec)
 	go s.srv.Serve(s.listener)
 	return s, nil
 }
@@ -75,7 +77,7 @@ func (s *Server) NewTestClient(ctx context.Context) (*rc.Client, error) {
 // NewClientConn returns a gRPC client connction to the server.
 func (s *Server) NewClientConn(ctx context.Context) (*grpc.ClientConn, error) {
 	p := s.dialParams()
-	conn, _, err := rc.Dial(ctx, p.Service, p)
+	conn, _, err := client.Dial(ctx, p.Service, p)
 	return conn, err
 }
 


### PR DESCRIPTION
Reverts bazelbuild/remote-apis-sdks#445

Turns out, these imports have separate internal mappings in google3.