### PR TITLE
linter fixes

### DIFF
--- a/go/pkg/cas/config.go
+++ b/go/pkg/cas/config.go
@@ -157,7 +157,7 @@ type Stats struct {
 	// It does not necessarily equal the total number of bytes uploaded/downloaded.
 	BytesRequested int64
 
-	// LogicalBytesMoved is the amount of BytesRequsted that was processed.
+	// LogicalBytesMoved is the amount of BytesRequested that was processed.
 	// It cannot be larger than BytesRequested, but may be smaller in case of a partial response.
 	LogicalBytesMoved int64
 

--- a/go/pkg/io/walker/walker.go
+++ b/go/pkg/io/walker/walker.go
@@ -1,3 +1,4 @@
+// Package walker provides a simple interface for traversing the filesystem by abstracting away IO and implementation naunces.
 package walker
 
 import (

--- a/go/pkg/io/walker/walker_test.go
+++ b/go/pkg/io/walker/walker_test.go
@@ -384,7 +384,7 @@ func validateSequence(t *testing.T, seq []string, fsLayout map[string][]string) 
 	pathVisitCount := pathCount{}
 	pendingParent := map[string]bool{}
 	for _, p := range seq {
-		pathVisitCount[p] += 1
+		pathVisitCount[p]++
 		parent := filepath.Dir(p)
 		// Parent should be visited after this child.
 		pendingParent[parent] = true


### PR DESCRIPTION
Instead of returning a nil context, I changed the signature such that an explicit primary context is provided to derive from or return as is.