### PR TITLE
add stderrDg and stdoutDg in MetaData

### DIFF
--- a/go/pkg/command/command.go
+++ b/go/pkg/command/command.go
@@ -525,6 +525,10 @@ type Metadata struct {
 	// RealBytesDownloaded is the number of bytes that were put on the wire for download (exclusing metadata).
 	// It may differ from LogicalBytesDownloaded due to compression.
 	RealBytesDownloaded int64
+	// StderrDigest is a digest of the standard error after being executed.
+	StderrDigest digest.Digest
+	// StdoutDigest is a digest of the standard output after being executed.
+	StdoutDigest digest.Digest
 	// TODO(olaola): Add a lot of other fields.
 }
 

--- a/go/pkg/rexec/rexec.go
+++ b/go/pkg/rexec/rexec.go
@@ -126,6 +126,12 @@ func (ec *Context) setOutputMetadata() {
 	} else if ec.resPb.StderrDigest != nil {
 		ec.Metadata.TotalOutputBytes += ec.resPb.StderrDigest.SizeBytes
 	}
+	if ec.resPb.StdoutDigest != nil {
+		ec.Metadata.StdoutDigest = digest.NewFromProtoUnvalidated(ec.resPb.StdoutDigest)
+	}
+	if ec.resPb.StderrDigest != nil {
+		ec.Metadata.StderrDigest = digest.NewFromProtoUnvalidated(ec.resPb.StderrDigest)
+	}
 }
 
 func (ec *Context) downloadOutErr() *command.Result {

--- a/go/pkg/tool/tool_test.go
+++ b/go/pkg/tool/tool_test.go
@@ -25,7 +25,7 @@ func TestTool_DownloadActionResult(t *testing.T) {
 	}
 	opt := command.DefaultExecutionOptions()
 	output := "output"
-	_, acDg := e.Set(cmd, opt, &command.Result{Status: command.CacheHitResultStatus}, &fakes.OutputFile{Path: "a/b/out", Contents: output},
+	_, acDg, _, _ := e.Set(cmd, opt, &command.Result{Status: command.CacheHitResultStatus}, &fakes.OutputFile{Path: "a/b/out", Contents: output},
 		fakes.StdOut("stdout"), fakes.StdErr("stderr"))
 
 	toolClient := &Client{GrpcClient: e.Client.GrpcClient}
@@ -65,7 +65,7 @@ func TestTool_ShowAction(t *testing.T) {
 	}
 
 	opt := command.DefaultExecutionOptions()
-	_, acDg := e.Set(cmd, opt, &command.Result{Status: command.CacheHitResultStatus}, &fakes.OutputFile{Path: "a/b/out", Contents: "output"},
+	_, acDg, _, _ := e.Set(cmd, opt, &command.Result{Status: command.CacheHitResultStatus}, &fakes.OutputFile{Path: "a/b/out", Contents: "output"},
 		fakes.StdOut("stdout"), fakes.StdErr("stderr"), &fakes.InputFile{Path: "a/b/input.txt", Contents: "input"})
 
 	toolClient := &Client{GrpcClient: e.Client.GrpcClient}
@@ -122,7 +122,7 @@ func TestTool_CheckDeterminism(t *testing.T) {
 	}
 	out := "output"
 	opt := &command.ExecutionOptions{AcceptCached: false, DownloadOutputs: true, DownloadOutErr: true}
-	_, acDg := e.Set(cmd, opt, &command.Result{Status: command.SuccessResultStatus}, &fakes.OutputFile{Path: "a/b/out", Contents: out})
+	_, acDg, _, _ := e.Set(cmd, opt, &command.Result{Status: command.SuccessResultStatus}, &fakes.OutputFile{Path: "a/b/out", Contents: out})
 
 	client := &Client{GrpcClient: e.Client.GrpcClient}
 	if err := client.CheckDeterminism(context.Background(), acDg.String(), "", 2); err != nil {
@@ -156,7 +156,7 @@ func TestTool_ExecuteAction(t *testing.T) {
 	}
 	out := "output"
 	opt := &command.ExecutionOptions{AcceptCached: false, DownloadOutputs: true, DownloadOutErr: true}
-	_, acDg := e.Set(cmd, opt, &command.Result{Status: command.SuccessResultStatus}, &fakes.OutputFile{Path: "a/b/out", Contents: out},
+	_, acDg, _, _ := e.Set(cmd, opt, &command.Result{Status: command.SuccessResultStatus}, &fakes.OutputFile{Path: "a/b/out", Contents: out},
 		fakes.StdOut("stdout"), fakes.StdErr("stderr"))
 
 	client := &Client{GrpcClient: e.Client.GrpcClient}
@@ -179,7 +179,7 @@ func TestTool_ExecuteAction(t *testing.T) {
 		t.Fatalf("failed creating input file: %v", err)
 	}
 	cmd.ExecRoot = tmpDir
-	_, acDg2 := e.Set(cmd, opt, &command.Result{Status: command.SuccessResultStatus}, &fakes.OutputFile{Path: "a/b/out", Contents: out},
+	_, acDg2, _, _ := e.Set(cmd, opt, &command.Result{Status: command.SuccessResultStatus}, &fakes.OutputFile{Path: "a/b/out", Contents: out},
 		fakes.StdOut("stdout2"), fakes.StdErr("stderr2"))
 	oe = outerr.NewRecordingOutErr()
 	if _, err := client.ExecuteAction(context.Background(), acDg2.String(), "", tmpDir, oe); err != nil {


### PR DESCRIPTION
Introducing two digest fields in Metadata for stderr and stdout. Modified the Set method, so that instead of returning cmdDg, and acDg, it also returns stderrDg and stdoutDG. All the other unit tests are modified accordingly.

Bug: b/172888682
Tested-by: run unit test locally