### PR TITLE
support filedigest input with xattr

### DIFF
--- a/go/pkg/filemetadata/filemetadata.go
+++ b/go/pkg/filemetadata/filemetadata.go
@@ -4,6 +4,7 @@ package filemetadata
 import (
 	"errors"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
@@ -112,8 +113,14 @@ func Compute(filename string) *Metadata {
 		}
 		xattrValue, err := XattrAccess.getXAttr(filename, XattrDigestName)
 		if err == nil {
+			xattrStr := string(xattrValue)
+
+			if strings.Contains(xattrStr, "/") {
+				md.Digest, md.Err = digest.NewFromString(xattrStr)
+				return md
+			}
 			md.Digest = digest.Digest{
-				Hash: string(xattrValue),
+				Hash: xattrStr,
 				Size: file.Size(),
 			}
 			return md


### PR DESCRIPTION
This change allows user to use a slash separated xattrValue string, i.e. "ed968e840d10d2d313a870bc131a4e2c311d7ad09bdf32b3418147221f51a6e2/5" to tell the RBE both the hash and the size of the input file digest. The string before the slash is treated as the hash value for the input file digest, and the string after the slash is treated as the size of the digest.

Currently, When user run reproxy and provide the xattrValue with a input file, we are using this xattrValue as the hash value for the input file digest, and actively calculating the actual size of the digest via file.Size(). Customer will have to fill the stub file with dummy content to the actually size to make the RBE believes the local copy (the stub file) is the same as the one RBE has . 