### PR TITLE
use fqn for sdk deps starlark function

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,7 +7,7 @@ gazelle(
     name = "gazelle-external-deps",
     args = [
         "-from_file=go.mod",
-        "-to_macro=go_deps.bzl%go_dependencies",
+        "-to_macro=go_deps.bzl%remote_apis_sdks_go_deps",
         "-prune",
     ],
     command = "update-repos",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,10 +48,11 @@ go_repository(
 # Insert go_repostiry rules before this one to override specific deps.
 gazelle_dependencies()
 
-load("//:go_deps.bzl", "go_dependencies")
+load("//:go_deps.bzl", "remote_apis_sdks_go_deps")
 
-# gazelle:repository_macro go_deps.bzl%go_dependencies
-go_dependencies()
+# gazelle:repository_macro go_deps.bzl%remote_apis_sdks_go_deps
+remote_apis_sdks_go_deps()
+
 
 # protobuf.
 http_archive(
@@ -100,4 +101,5 @@ go_repository(
 )
 
 load("@com_github_bazelbuild_remote_apis//:remote_apis_deps.bzl", "remote_apis_go_deps")
+
 remote_apis_go_deps()

--- a/go_deps.bzl
+++ b/go_deps.bzl
@@ -1,6 +1,6 @@
 load("@bazel_gazelle//:deps.bzl", "go_repository")
 
-def go_dependencies():
+def remote_apis_sdks_go_deps():
     go_repository(
         name = "co_honnef_go_tools",
         importpath = "honnef.co/go/tools",


### PR DESCRIPTION
It is clearer when the sdk is not the only go module being imported into a workspace.