### PR TITLE
Move targetFile in XAttr test to t.TempDir

### DIFF
--- a/go/pkg/filemetadata/filemetadata_test.go
+++ b/go/pkg/filemetadata/filemetadata_test.go
@@ -296,6 +296,7 @@ func TestComputeSymlinksToDirectory(t *testing.T) {
 }
 
 func createFileWithXattr(t *testing.T, fileContent, xattrName, xattrValue string) string {
+	t.Helper()
 	filePath := filepath.Join(t.TempDir(), targetFile)
 	err := os.WriteFile(filePath, []byte(fileContent), 0666)
 	if err != nil {

--- a/go/pkg/filemetadata/filemetadata_test.go
+++ b/go/pkg/filemetadata/filemetadata_test.go
@@ -181,20 +181,21 @@ func TestComputeFileDigestWithXattr(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			testName := tc.name
+			targetFilePath := filepath.Join(t.TempDir(), testName)
 			// Most Linux operating systems use the tmpfs file system for the /tmp directory, and the tmpfs file system does not support user extended attributes.
 			// Ref: https://man7.org/linux/man-pages/man5/tmpfs.5.html.
 			// Current pipeline's /tmp folder is located on a tmpfs file system, attempt to generate test files under t.TempDir() directory will result in an "Operation not supported" error.
-			err := os.WriteFile(targetFile, []byte(tc.contents), 0666)
+			err := os.WriteFile(targetFilePath, []byte(tc.contents), 0666)
 			if err != nil {
 				t.Fatalf("Failed to write to file: %v\n", err)
 			}
-			t.Cleanup(func() { os.RemoveAll(targetFile) })
+			t.Cleanup(func() { os.RemoveAll(targetFilePath) })
 			if tc.xattrDgStr != "" {
-				if err = xattr.Set(targetFile, xattrDgName, []byte(tc.xattrDgStr)); err != nil {
+				if err = xattr.Set(targetFilePath, xattrDgName, []byte(tc.xattrDgStr)); err != nil {
 					t.Fatalf("Failed to set xattr to file: %v\n", err)
 				}
 			}
-			md := Compute(targetFile)
+			md := Compute(targetFilePath)
 			if tc.wantErr && md.Err == nil {
 				t.Errorf("No error while computing digest for test %v, but error was expected", testName)
 			}


### PR DESCRIPTION
Resolves `Failed to write to file: open test.txt: permission denied` error