### PR TITLE
casng, query processor

### DIFF
--- a/go/pkg/casng/BUILD.bazel
+++ b/go/pkg/casng/BUILD.bazel
@@ -5,6 +5,8 @@ go_library(
     srcs = [
         "batching.go",
         "config.go",
+        "pubsub.go",
+        "streaming_query.go",
         "throttler.go",
         "uploader.go",
     ],
@@ -32,6 +34,8 @@ go_test(
     name = "cas_test",
     srcs = [
         "batching_query_test.go",
+        "batching_write_bytes_test.go",
+        "streaming_query_test.go",
         "uploader_test.go",
     ],
     data = glob(["testdata/**"]),

--- a/go/pkg/casng/config.go
+++ b/go/pkg/casng/config.go
@@ -168,7 +168,7 @@ type Stats struct {
 	// EffectiveBytesMoved is the total number of bytes moved over the wire, excluding retries.
 	// This may not be accurate since a gRPC call may be interrupted in which case this number may be higher than the real one.
 	// For failures, this is reported as 0.
-	// It may be higher than BytesRequested (compression headers), but never higher than BytesMoved.
+	// It may be higher than BytesRequested (compression headers), but never higher than TotalBytesMoved.
 	EffectiveBytesMoved int64
 
 	// LogicalBytesCached is the total number of bytes not moved over the wire due to caching (either remotely or locally).

--- a/go/pkg/casng/pubsub.go
+++ b/go/pkg/casng/pubsub.go
@@ -1,0 +1,209 @@
+package casng
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	log "github.com/golang/glog"
+	"github.com/pborman/uuid"
+)
+
+// tag identifies a pubsub channel for routing purposes.
+// Producers tag messages and consumers subscribe to tags.
+type tag string
+
+// pubsub provides a simple pubsub implementation to route messages and wait for them.
+type pubsub struct {
+	subs    map[tag]chan any
+	mu      sync.RWMutex
+	timeout time.Duration
+	// A signalling channel that gets a message everytime the broker hits 0 subscriptions.
+	// Unlike sync.WaitGroup, this allows the broker to accept more subs while a client is waiting for signal.
+	done chan struct{}
+}
+
+// sub returns a routing tag and a channel to the subscriber to read messages from.
+//
+// Only messages associated with the returned tag are sent on the returned channel.
+// This allows the subscriber to send a tagged message (request) that propagates across the system and eventually
+// receive related messages (responses) from publishers on the returned channel.
+//
+// The subscriber must continue draining the returned channel until it's closed.
+// The returned channel is unbuffered and closed only when unsub is called with the returned tag.
+//
+// To properly terminate the subscription, the subscriber must wait until all expected responses are received
+// on the returned channel before unsubscribing.
+// Once unsubscribed, any tagged messages for this subscription are dropped.
+func (ps *pubsub) sub() (tag, <-chan any) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	t := tag(uuid.New())
+	subscriber := make(chan any)
+	ps.subs[t] = subscriber
+
+	log.V(3).Infof("[casng] pubsub.sub: tag=%s", t)
+	return t, subscriber
+}
+
+// unsub removes the subscription for tag, if any, and closes the corresponding channel.
+func (ps *pubsub) unsub(t tag) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	subscriber, ok := ps.subs[t]
+	if !ok {
+		return
+	}
+	delete(ps.subs, t)
+	close(subscriber)
+	if len(ps.subs) == 0 {
+		close(ps.done)
+		ps.done = make(chan struct{})
+	}
+	log.V(3).Infof("[casng] pubsub.unsub: tag=%s", t)
+}
+
+// pub is a blocking call that fans-out a response to all specified (by tag) subscribers concurrently.
+//
+// Returns when all active subscribers have received their copies or timed out.
+// Inactive subscribers (expired by cancelling their context) are skipped (their copies are dropped).
+//
+// A busy subscriber does not block others from receiving their copies, but will delay this call by up to the specified timeout on the broker.
+//
+// A pool of workers of the same size of tags is used. Each worker attempts to deliver the message to the corresponding subscriber.
+// The pool size is a function of the client's concurrency.
+// E.g. if 500 workers are publishing messages, with an average of 10 clients per message, the pool size will be 5,000.
+// The maximum theoretical pool size for n publishers publishing every message to m subscribers is nm.
+// However, the expected average case is few clients per message so the pool size should be close to the concurrency limit.
+func (ps *pubsub) pub(m any, tags ...tag) {
+	_ = ps.pubN(m, len(tags), tags...)
+}
+
+// mpub (multi-publish) delivers the "once" message to a single subscriber then delivers the "rest" message to the rest of the subscribers.
+// It's useful for cases where the message holds shared information that should not be duplicated among subscribers, such as stats.
+func (ps *pubsub) mpub(once any, rest any, tags ...tag) {
+	t := ps.pubOnce(once, tags...)
+	_ = ps.pubN(rest, len(tags)-1, excludeTag(tags, t)...)
+}
+
+// pubOnce is like pub, but delivers the message to a single subscriber.
+// The tag of the subscriber that got the message is returned.
+func (ps *pubsub) pubOnce(m any, tags ...tag) tag {
+	received := ps.pubN(m, 1, tags...)
+	if len(received) == 0 {
+		return ""
+	}
+	return received[0]
+}
+
+// pubN is like pub, but delivers the message to no more than n subscribers. The tags of the subscribers that got the message are returned.
+func (ps *pubsub) pubN(m any, n int, tags ...tag) []tag {
+	if log.V(3) {
+		startTime := time.Now()
+		defer func() {
+			log.Infof("[casng] pubsub.duration: start=%d, end=%d", startTime.UnixNano(), time.Now().UnixNano())
+		}()
+	}
+	if len(tags) == 0 {
+		log.Warning("[casng] pubsub.pub: called without tags, dropping message")
+		log.V(4).Infof("[casng] pubsub.pub: called without tags for msg=%v", m)
+		return nil
+	}
+	if n <= 0 {
+		log.Warningf("[casng] pubsub.pub: nothing published because n=%d", n)
+		return nil
+	}
+
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+
+	log.V(4).Infof("[casng] pubsub.pub.msg: type=%[1]T, value=%[1]v", m)
+	ctx, ctxCancel := context.WithTimeout(context.Background(), ps.timeout)
+	defer ctxCancel()
+
+	// Optimize for the usual case of a single receiver.
+	if len(tags) == 1 {
+		t := tags[0]
+		s := ps.subs[t]
+		select {
+		case s <- m:
+		case <-ctx.Done():
+			log.Errorf("pubsub timeout for %s", t)
+			return nil
+		}
+		return tags
+	}
+
+	wg := sync.WaitGroup{}
+	received := make([]tag, 0, len(tags))
+	r := make(chan tag)
+	go func() {
+		for t := range r {
+			received = append(received, t)
+		}
+		wg.Done()
+	}()
+	for _, t := range tags {
+		s := ps.subs[t]
+		wg.Add(1)
+		go func(t tag) {
+			defer wg.Done()
+			select {
+			case s <- m:
+				r <- t
+			case <-ctx.Done():
+				log.Errorf("pubsub timeout for %s", t)
+			}
+		}(t)
+	}
+
+	// Wait for subscribers.
+	wg.Wait()
+
+	// Wait for the aggregator.
+	wg.Add(1)
+	close(r)
+	wg.Wait()
+	return received
+}
+
+// wait blocks until all existing subscribers unsubscribe.
+// The signal is a snapshot. The broker my get more subscribers after returning from this call.
+func (ps *pubsub) wait() {
+	<-ps.done
+}
+
+// len returns the number of active subscribers.
+func (ps *pubsub) len() int {
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+	return len(ps.subs)
+}
+
+// newPubSub initializes a new instance where subscribers must receive messages within timeout.
+func newPubSub(timeout time.Duration) *pubsub {
+	return &pubsub{
+		subs:    make(map[tag]chan any),
+		timeout: timeout,
+		done:    make(chan struct{}),
+	}
+}
+
+// excludeTag is used by mpub to filter out the tag that received the "once" message.
+func excludeTag(tags []tag, et tag) []tag {
+	if len(tags) == 0 {
+		return []tag{}
+	}
+	ts := make([]tag, 0, len(tags)-1)
+	// Only exclude the tag once.
+	excluded := false
+	for _, t := range tags {
+		if !excluded && t == et {
+			excluded = true
+			continue
+		}
+		ts = append(ts, t)
+	}
+	return ts
+}

--- a/go/pkg/casng/streaming_query.go
+++ b/go/pkg/casng/streaming_query.go
@@ -1,0 +1,323 @@
+// The query processor provides a streaming interface to query the CAS for digests.
+//
+// Multiple concurrent clients can use the same uploader instance at the same time.
+// The processor bundles requests from multiple concurrent clients to amortize the cost of querying
+// the batching API. That is, it attempts to bundle the maximum possible number of digests in a single gRPC call.
+//
+// This is done using 3 factors: the size (bytes) limit, the items limit, and a time limit.
+// If any of these limits is reached, the processor will dispatch the call and start a new bundle.
+// This means that a request can be delayed by the processor (not including network and server time) up to the time limit.
+// However, in high throughput sessions, the processor will dispatch calls sooner.
+//
+// To properly manage multiple concurrent clients while providing the bundling behaviour, the processor becomes a serialization point.
+// That is, all requests go through a single channel. To minimize blocking and leverage server concurrency, the processor loop
+// is optimized for high throughput and it launches gRPC calls concurrently.
+// In other words, it's many-one-many relationship, where many clients send to one processor which sends to many workers.
+//
+// To avoid forcing another serialization point through the processor, each worker notifies relevant clients of the results
+// it acquired from the server. In this case, it's a one-many relationship, where one worker sends to many clients.
+//
+// All in all, the design implements a many-one-many-one-many pipeline.
+// Many clients send to one processor, which sends to many workers; each worker sends to many clients.
+//
+// Each client is provided with a channel they send their requests on. The handler of that channel, marks each request
+// with a unique tag and forwards it to the processor.
+//
+// The processor receives multiple requests, each potentially with a different tag.
+// Each worker receives a bundle of requests that may contain multiple tags.
+//
+// To facilitate the routing between workers and clients, a simple pubsub implementation is used.
+// Each instance, a broker, manages routing messages between multiple subscribers (clients) and multiple publishers (workers).
+// Each client gets their own channel on which they receive messages marked for them.
+// Each publisher specifies which clients the messages should be routed to.
+// The broker attempts at-most-once delivery.
+//
+// The client handler manages the pubsub subscription by waiting until a matching number of responses was received, after which
+// it cancels the subscription.
+package casng
+
+import (
+	"context"
+	"time"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/contextmd"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/errors"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/retry"
+	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+	log "github.com/golang/glog"
+	"google.golang.org/protobuf/proto"
+)
+
+// MissingBlobsResponse represents a query result for a single digest.
+//
+// If Err is not nil, Missing is false.
+type MissingBlobsResponse struct {
+	Digest  digest.Digest
+	Missing bool
+	Err     error
+}
+
+// missingBlobRequest associates a digest with its requester's context.
+type missingBlobRequest struct {
+	digest digest.Digest
+	tag    tag
+	ctx    context.Context
+}
+
+// missingBlobRequestBundle is a set of digests, each is associated with multiple tags (requesters).
+// It is used for unified requests when multiple concurrent requesters share seats in the same bundle.
+type missingBlobRequestBundle = map[digest.Digest][]tag
+
+// MissingBlobs is a non-blocking call that queries the CAS for incoming digests.
+//
+// This method is useful when digests are calculated and dispatched on the fly.
+// For a large list of known digests, consider using the batching uploader.
+//
+// To properly stop this call, close in and cancel ctx, then wait for the returned channel to close.
+// The channel in must be closed as a termination signal. Cancelling ctx is not enough.
+// The uploader's context is used to make remote calls using metadata from ctx.
+// Metadata unification assumes all requests share the same correlated invocation ID.
+//
+// The digests are unified (aggregated/bundled) based on ItemsLimit, BytesLimit and BundleTimeout of the gRPC config.
+// The returned channel is unbuffered and will be closed after the input channel is closed and all sent requests get their corresponding responses.
+// This could indicate completion or cancellation (in case the context was canceled).
+// Slow consumption speed on the returned channel affects the consumption speed on in.
+//
+// This method must not be called after cancelling the uploader's context.
+func (u *StreamingUploader) MissingBlobs(ctx context.Context, in <-chan digest.Digest) <-chan MissingBlobsResponse {
+	pipeIn := make(chan missingBlobRequest)
+	out := u.missingBlobsPipe(pipeIn)
+	u.clientSenderWg.Add(1)
+	go func() {
+		defer u.clientSenderWg.Done()
+		defer close(pipeIn)
+		for d := range in {
+			pipeIn <- missingBlobRequest{digest: d, ctx: ctx}
+		}
+	}()
+	return out
+}
+
+// missingBlobsPipe is a shared implementation between batching and streaming interfaces.
+func (u *uploader) missingBlobsPipe(in <-chan missingBlobRequest) <-chan MissingBlobsResponse {
+	ch := make(chan MissingBlobsResponse)
+
+	// If this was called after the the uploader was terminated, short the circuit and return.
+	select {
+	case <-u.ctx.Done():
+		go func() {
+			defer close(ch)
+			res := MissingBlobsResponse{Err: ErrTerminatedUploader}
+			for req := range in {
+				res.Digest = req.digest
+				ch <- res
+			}
+		}()
+		return ch
+	default:
+	}
+
+	tag, resCh := u.queryPubSub.sub()
+	pendingCh := make(chan int)
+
+	// Sender. It terminates when in is closed, at which point it sends 0 as a termination signal to the counter.
+	u.querySenderWg.Add(1)
+	go func() {
+		defer u.querySenderWg.Done()
+
+		log.V(1).Info("[casng] query.streamer.sender.start")
+		defer log.V(1).Info("[casng] query.streamer.sender.stop")
+
+		for r := range in {
+			r.tag = tag
+			u.queryCh <- r
+			pendingCh <- 1
+		}
+		pendingCh <- 0
+	}()
+
+	// Receiver. It terminates with resCh is closed, at which point it closes the returned channel.
+	u.receiverWg.Add(1)
+	go func() {
+		defer u.receiverWg.Done()
+		defer close(ch)
+
+		log.V(1).Info("[casng] query.streamer.receiver.start")
+		defer log.V(1).Info("[casng] query.streamer.receiver.stop")
+
+		// Continue to drain until the broker closes the channel.
+		for {
+			r, ok := <-resCh
+			if !ok {
+				return
+			}
+			ch <- r.(MissingBlobsResponse)
+			pendingCh <- -1
+		}
+	}()
+
+	// Counter. It terminates when count hits 0 after receiving a done signal from the sender.
+	// Upon termination, it sends a signal to pubsub to terminate the subscription which closes resCh.
+	u.workerWg.Add(1)
+	go func() {
+		defer u.workerWg.Done()
+		defer u.queryPubSub.unsub(tag)
+
+		log.V(1).Info("[casng] query.streamer.counter.start")
+		defer log.V(1).Info("[casng] query.streamer.counter.stop")
+
+		pending := 0
+		done := false
+		for x := range pendingCh {
+			if x == 0 {
+				done = true
+			}
+			pending += x
+			// If the sender is done and all the requests are done, let the receiver and the broker terminate.
+			if pending == 0 && done {
+				return
+			}
+		}
+	}()
+
+	return ch
+}
+
+// queryProcessor is the fan-in handler that manages the bundling and dispatching of incoming requests.
+func (u *uploader) queryProcessor() {
+	log.V(1).Info("[casng] query.processor.start")
+	defer log.V(1).Info("[casng] query.processor.stop")
+
+	bundle := make(missingBlobRequestBundle)
+	ctx := u.ctx // context with unified metadata.
+	bundleSize := u.queryRequestBaseSize
+
+	handle := func() {
+		if len(bundle) < 1 {
+			return
+		}
+		// Block the entire processor if the concurrency limit is reached.
+		startTime := time.Now()
+		if !u.queryThrottler.acquire(u.ctx) {
+			// Ensure responses are dispatched before aborting.
+			for d := range bundle {
+				u.queryPubSub.pub(MissingBlobsResponse{
+					Digest: d,
+					Err:    u.ctx.Err(),
+				}, bundle[d]...)
+			}
+			return
+		}
+		log.V(3).Infof("[casng] query.throttle.duration: start=%d, end=%d", startTime.UnixNano(), time.Now().UnixNano())
+
+		u.workerWg.Add(1)
+		go func(ctx context.Context, b missingBlobRequestBundle) {
+			defer u.workerWg.Done()
+			defer u.queryThrottler.release()
+			u.callMissingBlobs(ctx, b)
+		}(ctx, bundle)
+
+		bundle = make(missingBlobRequestBundle)
+		bundleSize = u.queryRequestBaseSize
+		ctx = u.ctx
+	}
+
+	bundleTicker := time.NewTicker(u.queryRPCCfg.BundleTimeout)
+	defer bundleTicker.Stop()
+	for {
+		select {
+		case req, ok := <-u.queryCh:
+			if !ok {
+				return
+			}
+			startTime := time.Now()
+
+			log.V(3).Infof("[casng] query.processor.req: digest=%s, tag=%s, bundle=%d", req.digest, req.tag, len(bundle))
+			dSize := proto.Size(req.digest.ToProto())
+
+			// Check oversized items.
+			if u.queryRequestBaseSize+dSize > u.queryRPCCfg.BytesLimit {
+				u.queryPubSub.pub(MissingBlobsResponse{
+					Digest: req.digest,
+					Err:    ErrOversizedItem,
+				}, req.tag)
+				// Covers waiting on subscribers.
+				log.V(3).Infof("[casng] query.pub.duration: start=%d, end=%d", startTime.UnixNano(), time.Now().UnixNano())
+				continue
+			}
+
+			// Check size threshold.
+			if bundleSize+dSize >= u.queryRPCCfg.BytesLimit {
+				handle()
+			}
+
+			// Duplicate tags are allowed to ensure the requester can match the number of responses to the number of requests.
+			bundle[req.digest] = append(bundle[req.digest], req.tag)
+			bundleSize += dSize
+			ctx, _ = contextmd.FromContexts(ctx, req.ctx) // ignore non-essential error.
+
+			// Check length threshold.
+			if len(bundle) >= u.queryRPCCfg.ItemsLimit {
+				handle()
+			}
+		case <-bundleTicker.C:
+			handle()
+		}
+	}
+}
+
+// callMissingBlobs calls the gRPC endpoint and notifies requesters of the results.
+// It assumes ownership of the bundle argument.
+func (u *uploader) callMissingBlobs(ctx context.Context, bundle missingBlobRequestBundle) {
+	digests := make([]*repb.Digest, 0, len(bundle))
+	for d := range bundle {
+		digests = append(digests, d.ToProto())
+	}
+
+	req := &repb.FindMissingBlobsRequest{
+		InstanceName: u.instanceName,
+		BlobDigests:  digests,
+	}
+
+	var res *repb.FindMissingBlobsResponse
+	var err error
+	startTime := time.Now()
+	err = retry.WithPolicy(ctx, u.queryRPCCfg.RetryPredicate, u.queryRPCCfg.RetryPolicy, func() error {
+		ctx, ctxCancel := context.WithTimeout(ctx, u.queryRPCCfg.Timeout)
+		defer ctxCancel()
+		res, err = u.cas.FindMissingBlobs(ctx, req)
+		return err
+	})
+	log.V(3).Infof("[casng] query.grpc.duration: start=%d, end=%d", startTime.UnixNano(), time.Now().UnixNano())
+
+	var missing []*repb.Digest
+	if res != nil {
+		missing = res.MissingBlobDigests
+	}
+	if err != nil {
+		err = errors.Join(ErrGRPC, err)
+		missing = digests
+	}
+
+	startTime = time.Now()
+	// Report missing.
+	for _, dpb := range missing {
+		d := digest.NewFromProtoUnvalidated(dpb)
+		u.queryPubSub.pub(MissingBlobsResponse{
+			Digest:  d,
+			Missing: err == nil,
+			Err:     err,
+		}, bundle[d]...)
+		delete(bundle, d)
+	}
+
+	// Report non-missing.
+	for d := range bundle {
+		u.queryPubSub.pub(MissingBlobsResponse{
+			Digest:  d,
+			Missing: false,
+		}, bundle[d]...)
+	}
+	log.V(3).Infof("[casng] query.pub.duration: start=%d, end=%d", startTime.UnixNano(), time.Now().UnixNano())
+}

--- a/go/pkg/casng/streaming_query_test.go
+++ b/go/pkg/casng/streaming_query_test.go
@@ -1,0 +1,53 @@
+package casng_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/casng"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
+	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+	"google.golang.org/grpc"
+)
+
+func TestMissingBlobs_StreamingAbort(t *testing.T) {
+	fCas := &fakeCAS{findMissingBlobs: func(_ context.Context, _ *repb.FindMissingBlobsRequest, _ ...grpc.CallOption) (*repb.FindMissingBlobsResponse, error) {
+		return &repb.FindMissingBlobsResponse{}, nil
+	}}
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	ctxCancel()
+	_, err := casng.NewStreamingUploader(ctx, fCas, &fakeByteStreamClient{}, "", defaultRPCCfg, defaultRPCCfg, defaultRPCCfg, defaultIOCfg)
+	if err != nil {
+		t.Fatalf("error creating batching uploader: %v", err)
+	}
+}
+
+func TestMissingBlobs_Streaming(t *testing.T) {
+	fCas := &fakeCAS{findMissingBlobs: func(_ context.Context, _ *repb.FindMissingBlobsRequest, _ ...grpc.CallOption) (*repb.FindMissingBlobsResponse, error) {
+		return &repb.FindMissingBlobsResponse{}, nil
+	}}
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	u, err := casng.NewStreamingUploader(ctx, fCas, &fakeByteStreamClient{}, "", defaultRPCCfg, defaultRPCCfg, defaultRPCCfg, defaultIOCfg)
+	if err != nil {
+		t.Fatalf("error creating batching uploader: %v", err)
+	}
+	reqChan := make(chan digest.Digest)
+	ch := u.MissingBlobs(ctx, reqChan)
+
+	go func() {
+		for i := 0; i < 1000; i++ {
+			reqChan <- digest.Digest{Hash: "a"}
+		}
+		close(reqChan)
+	}()
+
+	defer ctxCancel()
+	for r := range ch {
+		if r.Err != nil {
+			t.Errorf("unexpected error: %v", r.Err)
+		}
+		if r.Missing {
+			t.Errorf("unexpected missing: %s", r.Digest.Hash)
+		}
+	}
+}


### PR DESCRIPTION
The query processor provides a streaming interface to query the CAS for digests.

Multiple concurrent clients can use the same uploader instance at the same time.
The processor bundles requests from multiple concurrent clients to amortize the cost of querying the batching API. That is, it attempts to bundle the maximum possible number of digests in a single gRPC call.
This is done using 3 factors: the size (bytes) limit, the items limit, and a time limit. If any of these limits is reached, the processor will dispatch the call and start a new bundle. This means that a request can be delayed by the processor (not including network and server time) up to the time limit. However, in high throughput sessions, the processor will dispatch calls sooner.

To properly manage multiple concurrent clients while providing the bundling behaviour, the processor becomes a serialization point. That is, all requests go through a single channel. To minimize blocking and leverage server concurrency, the processor loop is optimized for high throughput and it launches gRPC calls concurrently. In other words, it's many-one-many relationship, where many clients send to one processor which sends to many workers.

To avoid forcing another serialization point through the processor, each worker notifies relevant clients of the results it acquired from the server. In this case, it's a one-many relationship, where one worker sends to many clients.

All in all, the design implements a many-one-many-one-many pipeline. Many clients send to one processor, which sends to many workers; each worker sends to many clients.

Each client is provided with a channel they send their requests on. The handler of that channel `missingBlobsPipe`, marks each request with a unique tag and forwards it to the processor.

The processor receives multiple requests, each potentially with a different tag. Each worker receives a bundle of requests that may contain multiple tags.

To facilitate the routing between workers and clients, a simple pubsub implementation is used. Each instance, a broker, manages routing messages between multiple subscribers (clients) and multiple publishers (workers). Each client gets their own channel on which they receive messages marked for them. Each publisher specifies which clients the messages should be routed to. The broker attempts at-most-once delivery.

The client handler `missingBlobsPipe` manages the pubsub subscription by waiting until a matching number of responses was received, after which it cancels the subscription.