### PR TITLE
Add support for streaming stdout/stderr.

### DIFF
--- a/go/pkg/client/bytestream.go
+++ b/go/pkg/client/bytestream.go
@@ -99,6 +99,11 @@ func (c *Client) ReadBytes(ctx context.Context, name string) ([]byte, error) {
 	return buf.Bytes(), err
 }
 
+// ReadResourceTo writes a resource's contents to a Writer.
+func (c *Client) ReadResourceTo(ctx context.Context, name string, w io.Writer) (int64, error) {
+	return c.readStreamedRetried(ctx, name, 0, 0, w)
+}
+
 // ReadResourceToFile fetches a resource's contents, saving it into a file.
 //
 // The provided resource name must be a child resource of this client's instance,

--- a/go/pkg/command/command.go
+++ b/go/pkg/command/command.go
@@ -309,12 +309,17 @@ type ExecutionOptions struct {
 	// Preserve mtimes for unchanged outputs when downloading. Defaults to false.
 	PreserveUnchangedOutputMtime bool
 
-	// Download command stdout and stderr. Defaults to true.
+	// Download command stdout and stderr. Defaults to true. If StreamOutErr is also set, this value
+	// is ignored for uncached actions if the server provides log streams for both stdout and stderr.
+	// For cached action results, or if the server does not provide log streams for stdout or stderr,
+	// this value will determine whether stdout and stderr is downloaded.
 	DownloadOutErr bool
 
-	// Stream command to stdout and stderr. Defaults to false. If both this and
-	// DownloadOutErr are set, execution will stream stdout and stderr and
-	// fetching a cached result will download stdout and stderr.
+	// Request that stdout and stderr be streamed back to the client while the action is running.
+	// Defaults to false. If either stream is not provided by the server, the client will fall back to
+	// downloading the corresponding streams after the action has completed, provided DownloadOutErr
+	// is also set. The client may expect a delay in this scenario as the streams are downloaded after
+	// the fact.
 	StreamOutErr bool
 }
 

--- a/go/pkg/command/command.go
+++ b/go/pkg/command/command.go
@@ -311,6 +311,11 @@ type ExecutionOptions struct {
 
 	// Download command stdout and stderr. Defaults to true.
 	DownloadOutErr bool
+
+	// Stream command to stdout and stderr. Defaults to false. If both this and
+	// DownloadOutErr are set, execution will stream stdout and stderr and
+	// fetching a cached result will download stdout and stderr.
+	StreamOutErr bool
 }
 
 // DefaultExecutionOptions returns the recommended ExecutionOptions.
@@ -321,6 +326,7 @@ func DefaultExecutionOptions() *ExecutionOptions {
 		DownloadOutputs:              true,
 		PreserveUnchangedOutputMtime: false,
 		DownloadOutErr:               true,
+		StreamOutErr:                 false,
 	}
 }
 

--- a/go/pkg/fakes/BUILD.bazel
+++ b/go/pkg/fakes/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "ac.go",
         "cas.go",
         "exec.go",
+        "logstreams.go",
         "server.go",
     ],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/fakes",

--- a/go/pkg/fakes/logstreams.go
+++ b/go/pkg/fakes/logstreams.go
@@ -1,0 +1,63 @@
+package fakes
+
+import (
+	"fmt"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	bsgrpc "google.golang.org/genproto/googleapis/bytestream"
+	bspb "google.golang.org/genproto/googleapis/bytestream"
+)
+
+// LogStreams is a fake logstream implementation that implements the bytestream Read command.
+type LogStreams struct {
+	// streams is a map containing the logstreams. Each logstream consists of a list of chunks. When
+	// read, the Read() method will send each chunk one a time.
+	streams map[string][][]byte
+}
+
+// NewLogStreams returns a new empty fake logstream implementation.
+func NewLogStreams() *LogStreams {
+	return &LogStreams{streams: make(map[string][][]byte)}
+}
+
+// Clear() removes all logstreams.
+func (l *LogStreams) Clear() {
+	l.streams = make(map[string][][]byte)
+}
+
+// Put stores a new logstream.
+func (l *LogStreams) Put(name string, chunks ...string) error {
+	if _, ok := l.streams[name]; ok {
+		return fmt.Errorf("stream with name %q already exists", name)
+	}
+	var bs [][]byte
+	for _, chunk := range chunks {
+		bs = append(bs, []byte(chunk))
+	}
+	l.streams[name] = bs
+	return nil
+}
+
+// Read implements the Bytestream Read command. The chunks of the requested logstream are sent one
+// at a time.
+func (l *LogStreams) Read(req *bspb.ReadRequest, stream bsgrpc.ByteStream_ReadServer) error {
+	path := strings.Split(req.ResourceName, "/")
+	if len(path) != 3 || path[0] != "instance" || path[1] != "logstreams" {
+		return status.Error(codes.InvalidArgument, "test fake expected resource name of the form \"instance/logstreams/<name>\"")
+	}
+
+	chunks, ok := l.streams[path[2]]
+	if !ok {
+		return status.Error(codes.NotFound, "logstream not found")
+	}
+
+	for _, chunk := range chunks {
+		if err := stream.Send(&bspb.ReadResponse{Data: chunk}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/go/pkg/outerr/outerr.go
+++ b/go/pkg/outerr/outerr.go
@@ -64,3 +64,39 @@ func (s *RecordingOutErr) Stdout() []byte {
 func (s *RecordingOutErr) Stderr() []byte {
 	return s.err.Bytes()
 }
+
+// outWriter is a Writer that writes to the stdout stream of an OutErr.
+type outWriter struct {
+	OutErr
+}
+
+// NewOutWriter provides an io.Writer implementation for writing to the stdout
+// stream of an OutErr.
+func NewOutWriter(oe OutErr) io.Writer {
+	return &outWriter{OutErr: oe}
+}
+
+// Write writes to the stdout stream of the OutErr. This method always succeeds,
+// returning len(p), nil.
+func (o *outWriter) Write(p []byte) (int, error) {
+	o.WriteOut(p)
+	return len(p), nil
+}
+
+// errWriter is a Writer that writes to the stderr stream of an OutErr.
+type errWriter struct {
+	OutErr
+}
+
+// NewErrWriter provides an io.Writer implementation for writing to the stderr
+// stream of an OutErr.
+func NewErrWriter(oe OutErr) io.Writer {
+	return &errWriter{OutErr: oe}
+}
+
+// Write writes to the stderr stream of the OutErr. This method always succeeds,
+// returning len(p), nil.
+func (e *errWriter) Write(p []byte) (int, error) {
+	e.WriteErr(p)
+	return len(p), nil
+}

--- a/go/pkg/outerr/outerr.go
+++ b/go/pkg/outerr/outerr.go
@@ -65,37 +65,35 @@ func (s *RecordingOutErr) Stderr() []byte {
 	return s.err.Bytes()
 }
 
-// outWriter is a Writer that writes to the stdout stream of an OutErr.
+// outWriter is a Writer that writes to the out stream of an OutErr.
 type outWriter struct {
 	OutErr
 }
 
-// NewOutWriter provides an io.Writer implementation for writing to the stdout
+// NewOutWriter provides an io.Writer implementation for writing to the out
 // stream of an OutErr.
 func NewOutWriter(oe OutErr) io.Writer {
 	return &outWriter{OutErr: oe}
 }
 
-// Write writes to the stdout stream of the OutErr. This method always succeeds,
-// returning len(p), nil.
+// Write writes to the out stream of the OutErr. This method always returns len(p), nil.
 func (o *outWriter) Write(p []byte) (int, error) {
 	o.WriteOut(p)
 	return len(p), nil
 }
 
-// errWriter is a Writer that writes to the stderr stream of an OutErr.
+// errWriter is a Writer that writes to the err stream of an OutErr.
 type errWriter struct {
 	OutErr
 }
 
-// NewErrWriter provides an io.Writer implementation for writing to the stderr
+// NewErrWriter provides an io.Writer implementation for writing to the err
 // stream of an OutErr.
 func NewErrWriter(oe OutErr) io.Writer {
 	return &errWriter{OutErr: oe}
 }
 
-// Write writes to the stderr stream of the OutErr. This method always succeeds,
-// returning len(p), nil.
+// Write writes to the stderr stream of the OutErr. This method always returns len(p), nil.
 func (e *errWriter) Write(p []byte) (int, error) {
 	e.WriteErr(p)
 	return len(p), nil

--- a/go/pkg/outerr/outerr_test.go
+++ b/go/pkg/outerr/outerr_test.go
@@ -58,3 +58,21 @@ func TestSystemOutErr(t *testing.T) {
 		t.Errorf("expected stdout+stderr to equal \"hello world\", got %v", buf.String())
 	}
 }
+
+func TestWriters(t *testing.T) {
+	t.Parallel()
+	oe := NewRecordingOutErr()
+	o, e := NewOutWriter(oe), NewErrWriter(oe)
+	if n, err := o.Write([]byte("hello")); n != 5 || err != nil {
+		t.Errorf("expected o.Write(\"hello\") to return 5, nil; got %d, %v", n, err)
+	}
+	if n, err := e.Write([]byte("world")); n != 5 || err != nil {
+		t.Errorf("expected e.Write(\"world\") to return 5, nil; got %d, %v", n, err)
+	}
+	if got := oe.Stdout(); !bytes.Equal(got, []byte("hello")) {
+		t.Errorf("expected oe.Stdout() to return hello, got %v", got)
+	}
+	if got := oe.Stderr(); !bytes.Equal(got, []byte("world")) {
+		t.Errorf("expected oe.Stderr() to return world, got %v", got)
+	}
+}

--- a/go/pkg/rexec/BUILD.bazel
+++ b/go/pkg/rexec/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "@org_golang_google_protobuf//encoding/prototext:go_default_library",
         "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
         "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )
 


### PR DESCRIPTION
I'm adding support for stdout/stderr log streaming to RBE. This change allows the client to receive stdout/stderr streamed in near-real-time while the action is running, rather than waiting until the action is complete and then downloading stdout/stderr from CAS.

The initial motivation for this PR is that our integration tests and other diagnostic tools use this SDK. So I need support for log streaming here to support those uses.