### PR TITLE
noop/cleanup: use fileSysNode in treeNode

### DIFF
--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -378,7 +378,9 @@ func packageTree(t *treeNode, stats *TreeStats) (root digest.Digest, blobs map[d
 			blobs[dg] = n.file.ue
 			stats.InputFiles++
 			stats.TotalInputBytes += dg.Size
-		} else if n.symlink != nil {
+			continue
+		}
+		if n.symlink != nil {
 			dir.Symlinks = append(dir.Symlinks, &repb.SymlinkNode{Name: name, Target: n.symlink.target})
 			stats.InputSymlinks++
 		}
@@ -523,7 +525,9 @@ func packageDirectories(t *treeNode) (root *repb.Directory, files map[digest.Dig
 			dg := n.file.ue.Digest
 			root.Files = append(root.Files, &repb.FileNode{Name: name, Digest: dg.ToProto(), IsExecutable: n.file.isExecutable})
 			files[dg] = n.file.ue
-		} else if n.symlink != nil {
+			continue
+		}
+		if n.symlink != nil {
 			root.Symlinks = append(root.Symlinks, &repb.SymlinkNode{Name: name, Target: n.symlink.target})
 		}
 	}

--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -42,20 +42,6 @@ type fileSysNode struct {
 	symlink              *symlinkNode
 }
 
-func boolToInt(b bool) uint8 {
-	if b {
-		return 1
-	}
-	return 0
-}
-
-func (n *fileSysNode) checkValid() error {
-	if boolToInt(n.file != nil)+boolToInt(n.symlink != nil)+boolToInt(n.emptyDirectoryMarker) != 1 {
-		return fmt.Errorf("a fileSysNode must have exactly one of `file`, `symlink`, or `emptyDirectoryMarker` set, got %v", n)
-	}
-	return nil
-}
-
 // TreeStats contains various stats/metadata of the constructed Merkle tree.
 // Note that these stats count the overall input tree, even if some parts of it are not unique.
 // For example, if a file "foo" of 10 bytes occurs 5 times in the tree, it will be counted as 5
@@ -385,17 +371,14 @@ func packageTree(t *treeNode, stats *TreeStats) (root digest.Digest, blobs map[d
 	sort.Slice(dir.Directories, func(i, j int) bool { return dir.Directories[i].Name < dir.Directories[j].Name })
 
 	for name, n := range t.leaves {
-		if err := n.checkValid(); err != nil {
-			return digest.Empty, nil, err
-		}
+		// A node can have exactly one of file/symlink/emptyDirectoryMarker.
 		if n.file != nil {
 			dg := n.file.ue.Digest
 			dir.Files = append(dir.Files, &repb.FileNode{Name: name, Digest: dg.ToProto(), IsExecutable: n.file.isExecutable})
 			blobs[dg] = n.file.ue
 			stats.InputFiles++
 			stats.TotalInputBytes += dg.Size
-		}
-		if n.symlink != nil {
+		} else if n.symlink != nil {
 			dir.Symlinks = append(dir.Symlinks, &repb.SymlinkNode{Name: name, Target: n.symlink.target})
 			stats.InputSymlinks++
 		}
@@ -535,15 +518,12 @@ func packageDirectories(t *treeNode) (root *repb.Directory, files map[digest.Dig
 	sort.Slice(root.Directories, func(i, j int) bool { return root.Directories[i].Name < root.Directories[j].Name })
 
 	for name, n := range t.leaves {
-		if err := n.checkValid(); err != nil {
-			return nil, nil, nil, err
-		}
+		// A node can have exactly one of file/symlink/emptyDirectoryMarker.
 		if n.file != nil {
 			dg := n.file.ue.Digest
 			root.Files = append(root.Files, &repb.FileNode{Name: name, Digest: dg.ToProto(), IsExecutable: n.file.isExecutable})
 			files[dg] = n.file.ue
-		}
-		if n.symlink != nil {
+		} else if n.symlink != nil {
 			root.Symlinks = append(root.Symlinks, &repb.SymlinkNode{Name: name, Target: n.symlink.target})
 		}
 	}


### PR DESCRIPTION
Tiny cleanup in preparation for fixing https://github.com/bazelbuild/remote-apis-sdks/issues/460