### PR TITLE
fix regression in downloading out/err streams

### DIFF
--- a/go/pkg/rexec/rexec.go
+++ b/go/pkg/rexec/rexec.go
@@ -14,7 +14,6 @@ import (
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/filemetadata"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/outerr"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/uploadinfo"
-	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/prototext"
@@ -76,15 +75,20 @@ func (c *Client) NewContext(ctx context.Context, cmd *command.Command, opt *comm
 	}, nil
 }
 
-func (ec *Context) downloadStream(raw []byte, dgPb *repb.Digest, write func([]byte)) error {
+// downloadStream reads the blob for the digest dgPb into memory and forwards the bytes to the write function.
+func (ec *Context) downloadStream(raw []byte, dgPb *repb.Digest, offset int64, write func([]byte)) error {
 	if raw != nil {
-		write(raw)
+		o := int(offset)
+		if int64(o) != offset || o > len(raw) {
+			return fmt.Errorf("offset %d is out of range for length %d", offset, len(raw))
+		}
+		write(raw[o:])
 	} else if dgPb != nil {
 		dg, err := digest.NewFromProto(dgPb)
 		if err != nil {
 			return err
 		}
-		bytes, stats, err := ec.client.GrpcClient.ReadBlob(ec.ctx, dg)
+		bytes, stats, err := ec.client.GrpcClient.ReadBlobRange(ec.ctx, dg, offset, 0)
 		if err != nil {
 			return err
 		}
@@ -137,10 +141,10 @@ func (ec *Context) setOutputMetadata() {
 }
 
 func (ec *Context) downloadOutErr() *command.Result {
-	if err := ec.downloadStream(ec.resPb.StdoutRaw, ec.resPb.StdoutDigest, ec.oe.WriteOut); err != nil {
+	if err := ec.downloadStream(ec.resPb.StdoutRaw, ec.resPb.StdoutDigest, 0, ec.oe.WriteOut); err != nil {
 		return command.NewRemoteErrorResult(err)
 	}
-	if err := ec.downloadStream(ec.resPb.StderrRaw, ec.resPb.StderrDigest, ec.oe.WriteErr); err != nil {
+	if err := ec.downloadStream(ec.resPb.StderrRaw, ec.resPb.StderrDigest, 0, ec.oe.WriteErr); err != nil {
 		return command.NewRemoteErrorResult(err)
 	}
 	return command.NewResultFromExitCode((int)(ec.resPb.ExitCode))
@@ -332,9 +336,12 @@ func (ec *Context) ExecuteRemotely() {
 	ec.Metadata.RealBytesUploaded = bytesMoved
 	log.V(1).Infof("%s %s> Executing remotely...\n%s", cmdID, executionID, strings.Join(ec.cmd.Args, " "))
 	ec.Metadata.EventTimes[command.EventExecuteRemotely] = &command.TimeInterval{From: time.Now()}
-	eg, ctx := errgroup.WithContext(ec.ctx)
+	// Initiate each streaming request once at most.
 	var streamOut, streamErr sync.Once
-	op, err := ec.client.GrpcClient.ExecuteAndWaitProgress(ctx, &repb.ExecuteRequest{
+	var streamWg sync.WaitGroup
+	// These variables are owned by the progress callback (which is async but not concurrent) until the execution returns.
+	var nOutStreamed, nErrStreamed int64
+	op, err := ec.client.GrpcClient.ExecuteAndWaitProgress(ec.ctx, &repb.ExecuteRequest{
 		InstanceName:    ec.client.GrpcClient.InstanceName,
 		SkipCacheLookup: !ec.opt.AcceptCached || ec.opt.DoNotCache,
 		ActionDigest:    ec.Metadata.ActionDigest.ToProto(),
@@ -342,35 +349,49 @@ func (ec *Context) ExecuteRemotely() {
 		if !ec.opt.StreamOutErr {
 			return
 		}
+		// The server may return either, both, or neither of the stream names, and not necessarily in the same or first call.
+		// The streaming request for each must be initiated once at most.
 		if name := md.GetStdoutStreamName(); name != "" {
 			streamOut.Do(func() {
-				eg.Go(func() error {
+				streamWg.Add(1)
+				go func() {
+					defer streamWg.Done()
 					path := fmt.Sprintf("%s/logstreams/%s", ec.client.GrpcClient.InstanceName, name)
 					log.V(1).Infof("%s %s> Streaming to stdout from %q", cmdID, executionID, path)
-					_, err = ec.client.GrpcClient.ReadResourceTo(ctx, path, outerr.NewOutWriter(ec.oe))
-					return err
-				})
+					// Ignoring the error here since the net result is downloading the full stream after the fact.
+					n, err := ec.client.GrpcClient.ReadResourceTo(ec.ctx, path, outerr.NewOutWriter(ec.oe))
+					if err != nil {
+						log.Errorf("%s %s> error streaming stdout: %v", cmdID, executionID, err)
+					}
+					nOutStreamed += n
+				}()
 			})
 		}
 		if name := md.GetStderrStreamName(); name != "" {
 			streamErr.Do(func() {
-				eg.Go(func() error {
+				streamWg.Add(1)
+				go func() {
+					defer streamWg.Done()
 					path := fmt.Sprintf("%s/logstreams/%s", ec.client.GrpcClient.InstanceName, name)
 					log.V(1).Infof("%s %s> Streaming to stdout from %q", cmdID, executionID, path)
-					_, err = ec.client.GrpcClient.ReadResourceTo(ctx, path, outerr.NewErrWriter(ec.oe))
-					return err
-				})
+					// Ignoring the error here since the net result is downloading the full stream after the fact.
+					n, err := ec.client.GrpcClient.ReadResourceTo(ec.ctx, path, outerr.NewErrWriter(ec.oe))
+					if err != nil {
+						log.Errorf("%s %s> error streaming stderr: %v", cmdID, executionID, err)
+					}
+					nErrStreamed += n
+				}()
 			})
 		}
 	})
 	ec.Metadata.EventTimes[command.EventExecuteRemotely].To = time.Now()
+	// This will always be called after both of the Add calls above if any, because the execution call above returns
+	// after all invokations of the progress callback.
+	// The server will terminate the streams when the execution finishes, regardless of its result, which will ensure the goroutines
+	// will have terminated at this point.
+	streamWg.Wait()
 	if err != nil {
 		ec.Result = command.NewRemoteErrorResult(err)
-		return
-	}
-
-	if err := eg.Wait(); err != nil {
-		ec.Result = command.NewRemoteErrorResult(fmt.Errorf("failure writing output streams: %v", err))
 		return
 	}
 
@@ -397,16 +418,16 @@ func (ec *Context) ExecuteRemotely() {
 		ec.setOutputMetadata()
 		ec.Result = command.NewResultFromExitCode((int)(ec.resPb.ExitCode))
 		if ec.opt.DownloadOutErr {
-			streamOut.Do(func() {
-				if err := ec.downloadStream(ec.resPb.StdoutRaw, ec.resPb.StdoutDigest, ec.oe.WriteOut); err != nil {
+			if ec.resPb.StdoutDigest == nil || ec.resPb.StdoutDigest.SizeBytes > nOutStreamed {
+				if err := ec.downloadStream(ec.resPb.StdoutRaw, ec.resPb.StdoutDigest, nOutStreamed, ec.oe.WriteOut); err != nil {
 					ec.Result = command.NewRemoteErrorResult(err)
 				}
-			})
-			streamErr.Do(func() {
-				if err := ec.downloadStream(ec.resPb.StderrRaw, ec.resPb.StderrDigest, ec.oe.WriteErr); err != nil {
+			}
+			if ec.resPb.StderrDigest == nil || ec.resPb.StderrDigest.SizeBytes > nErrStreamed {
+				if err := ec.downloadStream(ec.resPb.StderrRaw, ec.resPb.StderrDigest, nErrStreamed, ec.oe.WriteErr); err != nil {
 					ec.Result = command.NewRemoteErrorResult(err)
 				}
-			})
+			}
 		}
 		if ec.Result.Err == nil && ec.opt.DownloadOutputs {
 			log.V(1).Infof("%s %s> Downloading outputs...", cmdID, executionID)

--- a/go/pkg/tool/tool.go
+++ b/go/pkg/tool/tool.go
@@ -439,6 +439,8 @@ func (c *Client) ExecuteAction(ctx context.Context, actionDigest, actionRoot, ou
 	fmt.Printf("---------------\n")
 	fmt.Printf("Action digest: %v\n", ec.Metadata.ActionDigest.String())
 	fmt.Printf("Command digest: %v\n", ec.Metadata.CommandDigest.String())
+	fmt.Printf("Stdout digest: %v\n", ec.Metadata.StdoutDigest.String())
+	fmt.Printf("Stderr digest: %v\n", ec.Metadata.StderrDigest.String())
 	fmt.Printf("Number of Input Files: %v\n", ec.Metadata.InputFiles)
 	fmt.Printf("Number of Input Dirs: %v\n", ec.Metadata.InputDirectories)
 	fmt.Printf("Number of Output Files: %v\n", ec.Metadata.OutputFiles)


### PR DESCRIPTION
The server may terminate the streaming request before sending available
bytes, which prevents the download fallback from getting them.

This change implements a resuming fallback to download the remainder of
the streams.

Additionally, the digests of the out and err streams will be printed in
the output of `execution_action` command to allow the user to access
them even if the remote execution fails, in which case they will not be
retrievable by `show_action`.