### PR TITLE
tool test: improving coverage, cleanups, minor fixes

### DIFF
--- a/go/pkg/fakes/server.go
+++ b/go/pkg/fakes/server.go
@@ -288,7 +288,7 @@ func (f *InputFile) apply(ac *repb.ActionResult, s *Server, execRoot string) err
 	if err := os.MkdirAll(filepath.Join(execRoot, filepath.Dir(f.Path)), os.ModePerm); err != nil {
 		return fmt.Errorf("failed to create input dir %v: %v", filepath.Dir(f.Path), err)
 	}
-	err := os.WriteFile(filepath.Join(execRoot, f.Path), nil, 0755)
+	err := os.WriteFile(filepath.Join(execRoot, f.Path), bytes, 0755)
 	if err != nil {
 		return fmt.Errorf("failed to setup file %v under temp exec root %v: %v", f.Path, execRoot, err)
 	}

--- a/go/pkg/tool/BUILD.bazel
+++ b/go/pkg/tool/BUILD.bazel
@@ -33,5 +33,6 @@ go_test(
         "//go/pkg/fakes",
         "//go/pkg/outerr",
         "@com_github_google_go_cmp//cmp:go_default_library",
+        "@org_golang_google_protobuf//encoding/prototext:go_default_library",
     ],
 )

--- a/go/pkg/tool/tool_test.go
+++ b/go/pkg/tool/tool_test.go
@@ -83,8 +83,8 @@ Platform
 
 Inputs
 ======
-[Root directory digest: e23e10be0d14b5b2b1b7af32de78dea554a74df5bb22b31ae6c49583c1a8aa0e/75]
-a/b/input.txt: [File digest: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/0]
+[Root directory digest: 1b1d5b9e3eb97866805deca901299fcdde98b5747e147f35187e12c16e120186/75]
+a/b/input.txt: [File digest: c96c6d5be8d08a12e7b5cdc1b207fa6b2430974c86803d8891675e76fd992c20/5]
 
 ------------------------------------------------------------------------
 Action Result


### PR DESCRIPTION
Includes https://github.com/bazelbuild/remote-apis-sdks/pull/473 because I couldn't figure out how to send a PR chain, sorry!

- adds a test for DownloadAction
- uses the `fakes.InputFile` whenever appropriate
- fixes the `ExecuteAction*` tests to not depend on implementation of the fake, and instead to mimics the user journey (downloading the inputs locally, then changing them).
- minor cleanups such as avoiding marshalling protos when unnecessarily, inlining small constants in tests, etc.

What I was actually doing is fixing https://github.com/bazelbuild/remote-apis-sdks/issues/460, but that PR got a bit too big with unrelated fixes and cleanups, so I decided to split these out.

Thank you!