### PR TITLE
Add KeepAlive support

### DIFF
--- a/go/pkg/flags/BUILD.bazel
+++ b/go/pkg/flags/BUILD.bazel
@@ -9,5 +9,8 @@ go_library(
         "//go/pkg/balancer",
         "//go/pkg/client",
         "//go/pkg/moreflag",
+        "@com_github_golang_glog//:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//keepalive:go_default_library",
     ],
 )


### PR DESCRIPTION
KeepAlive functionality sends periodic pings to the server over the transport layer.