### PR TITLE
fix resource names with empty instance name

### DIFF
--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -1062,10 +1062,14 @@ func (u *uploader) streamFromReader(ctx context.Context, r io.Reader, digest *re
 	}()
 
 	req := &bspb.WriteRequest{}
+	instanceSegment := u.InstanceName + "/"
+	if instanceSegment == "/" {
+		instanceSegment = ""
+	}
 	if compressed {
-		req.ResourceName = fmt.Sprintf("%s/uploads/%s/compressed-blobs/zstd/%s/%d", u.InstanceName, uuid.New(), digest.Hash, digest.SizeBytes)
+		req.ResourceName = fmt.Sprintf("%suploads/%s/compressed-blobs/zstd/%s/%d", instanceSegment, uuid.New(), digest.Hash, digest.SizeBytes)
 	} else {
-		req.ResourceName = fmt.Sprintf("%s/uploads/%s/blobs/%s/%d", u.InstanceName, uuid.New(), digest.Hash, digest.SizeBytes)
+		req.ResourceName = fmt.Sprintf("%suploads/%s/blobs/%s/%d", instanceSegment, uuid.New(), digest.Hash, digest.SizeBytes)
 	}
 
 	buf := u.streamBufs.Get().(*[]byte)

--- a/go/pkg/client/bytestream.go
+++ b/go/pkg/client/bytestream.go
@@ -111,7 +111,11 @@ func (c *Client) ReadResourceTo(ctx context.Context, name string, w io.Writer) (
 //
 // The number of bytes read is returned.
 func (c *Client) ReadResourceToFile(ctx context.Context, name, fpath string) (int64, error) {
-	return c.readToFile(ctx, c.InstanceName+name, fpath)
+	rname, err := c.ResourceName(name)
+	if err != nil {
+		return 0, err
+	}
+	return c.readToFile(ctx, rname, fpath)
 }
 
 func (c *Client) readToFile(ctx context.Context, name string, fpath string) (int64, error) {

--- a/go/pkg/client/cas_download.go
+++ b/go/pkg/client/cas_download.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 
@@ -947,13 +948,15 @@ type writeDummyCloser struct {
 func (w *writeDummyCloser) Close() error { return nil }
 
 func (c *Client) resourceNameRead(hash string, sizeBytes int64) string {
-	return fmt.Sprintf("%s/blobs/%s/%d", c.InstanceName, hash, sizeBytes)
+	rname, _ := c.ResourceName("blobs", hash, strconv.FormatInt(sizeBytes, 10))
+	return rname
 }
 
 // TODO(rubensf): Converge compressor to proto in https://github.com/bazelbuild/remote-apis/pull/168 once
 // that gets merged in.
 func (c *Client) resourceNameCompressedRead(hash string, sizeBytes int64) string {
-	return fmt.Sprintf("%s/compressed-blobs/zstd/%s/%d", c.InstanceName, hash, sizeBytes)
+	rname, _ := c.ResourceName("compressed-blobs", "zstd", hash, strconv.FormatInt(sizeBytes, 10))
+	return rname
 }
 
 // maybeCompressReadBlob will, depending on the client configuration, set the blobs to be

--- a/go/pkg/client/cas_upload.go
+++ b/go/pkg/client/cas_upload.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -201,14 +202,16 @@ func (c *Client) BatchWriteBlobs(ctx context.Context, blobs map[digest.Digest][]
 
 // ResourceNameWrite generates a valid write resource name.
 func (c *Client) ResourceNameWrite(hash string, sizeBytes int64) string {
-	return fmt.Sprintf("%s/uploads/%s/blobs/%s/%d", c.InstanceName, uuid.New(), hash, sizeBytes)
+	rname, _ := c.ResourceName("uploads", uuid.New(), "blobs", hash, strconv.FormatInt(sizeBytes, 10))
+	return rname
 }
 
 // ResourceNameCompressedWrite generates a valid write resource name.
 // TODO(rubensf): Converge compressor to proto in https://github.com/bazelbuild/remote-apis/pull/168 once
 // that gets merged in.
 func (c *Client) ResourceNameCompressedWrite(hash string, sizeBytes int64) string {
-	return fmt.Sprintf("%s/uploads/%s/compressed-blobs/zstd/%s/%d", c.InstanceName, uuid.New(), hash, sizeBytes)
+	rname, _ := c.ResourceName("uploads", uuid.New(), "compressed-blobs", "zstd", hash, strconv.FormatInt(sizeBytes, 10))
+	return rname
 }
 
 func (c *Client) writeRscName(ue *uploadinfo.Entry) string {

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -46,6 +46,11 @@ const (
 	HomeDirMacro = "${HOME}"
 )
 
+var (
+	// ErrEmptySegement indicates an attempt to construct a resource name with an empty segment.
+	ErrEmptySegment = errors.New("empty segment in resoure name")
+)
+
 // AuthType indicates the type of authentication being used.
 type AuthType int
 
@@ -113,6 +118,8 @@ func (ce *InitError) Error() string {
 type Client struct {
 	// InstanceName is the instance name for the targeted remote execution instance; e.g. for Google
 	// RBE: "projects/<foo>/instances/default_instance".
+	// It should NOT be used to construct resource names, but rather only for reusing the instance name as is.
+	// Use the ResourceName method to create correctly formatted resource names.
 	InstanceName string
 	actionCache  regrpc.ActionCacheClient
 	byteStream   bsgrpc.ByteStreamClient
@@ -531,7 +538,7 @@ func createGRPCInterceptor(p DialParams) *balancer.GCPInterceptor {
 			MaxConcurrentStreamsLowWatermark: p.MaxConcurrentStreams,
 		},
 		Method: []*configpb.MethodConfig{
-			&configpb.MethodConfig{
+			{
 				Name: []string{".*"},
 				Affinity: &configpb.AffinityConfig{
 					Command:     configpb.AffinityConfig_BIND,
@@ -789,6 +796,23 @@ var DefaultRPCTimeouts = map[string]time.Duration{
 	// timeout at above 0; most users should use the Action Timeout instead.
 	"Execute":       0,
 	"WaitExecution": 0,
+}
+
+// ResourceName constructs a correctly formatted resource name as defined in the spec.
+// No keyword validation is performed since the semantics of the path are defined by the server.
+// See: https://github.com/bazelbuild/remote-apis/blob/cb8058798964f0adf6dbab2f4c2176ae2d653447/build/bazel/remote/execution/v2/remote_execution.proto#L223
+func (c *Client) ResourceName(segments ...string) (string, error) {
+	segs := make([]string, 0, len(segments)+1)
+	if c.InstanceName != "" {
+		segs = append(segs, c.InstanceName)
+	}
+	for _, s := range segments {
+		if s == "" {
+			return "", ErrEmptySegment
+		}
+		segs = append(segs, s)
+	}
+	return strings.Join(segs, "/"), nil
 }
 
 // RPCOpts returns the default RPC options that should be used for calls made with this client.

--- a/go/pkg/rexec/rexec.go
+++ b/go/pkg/rexec/rexec.go
@@ -356,7 +356,7 @@ func (ec *Context) ExecuteRemotely() {
 				streamWg.Add(1)
 				go func() {
 					defer streamWg.Done()
-					path := fmt.Sprintf("%s/logstreams/%s", ec.client.GrpcClient.InstanceName, name)
+					path, _ := ec.client.GrpcClient.ResourceName("logstreams", name)
 					log.V(1).Infof("%s %s> Streaming to stdout from %q", cmdID, executionID, path)
 					// Ignoring the error here since the net result is downloading the full stream after the fact.
 					n, err := ec.client.GrpcClient.ReadResourceTo(ec.ctx, path, outerr.NewOutWriter(ec.oe))
@@ -372,7 +372,7 @@ func (ec *Context) ExecuteRemotely() {
 				streamWg.Add(1)
 				go func() {
 					defer streamWg.Done()
-					path := fmt.Sprintf("%s/logstreams/%s", ec.client.GrpcClient.InstanceName, name)
+					path, _ := ec.client.GrpcClient.ResourceName("logstreams", name)
 					log.V(1).Infof("%s %s> Streaming to stdout from %q", cmdID, executionID, path)
 					// Ignoring the error here since the net result is downloading the full stream after the fact.
 					n, err := ec.client.GrpcClient.ReadResourceTo(ec.ctx, path, outerr.NewErrWriter(ec.oe))


### PR DESCRIPTION
According to the spec, the leading slash must be omitted if the instance name is empty. Fixes #489