### PR TITLE
casng, ensure shared state is set

### DIFF
--- a/go/pkg/io/impath/impath.go
+++ b/go/pkg/io/impath/impath.go
@@ -53,8 +53,8 @@ func (p Relative) Dir() Relative {
 }
 
 // Base is a convenient method that returns the last path element.
-func (p Absolute) Base() Absolute {
-	return Absolute{path: filepath.Base(p.String())}
+func (p Absolute) Base() Relative {
+	return Relative{path: filepath.Base(p.String())}
 }
 
 // Base is a convenient method that returns the last path element.


### PR DESCRIPTION
When casng is used via LERC (local execution remote cahcing), the code expects shared state to be set which I missed while testing with the remote strategy.

Tested with a local LERC build against Android.