### PR TITLE
casng, fix resolving remote paths

### DIFF
--- a/go/pkg/casng/batching_upload_test.go
+++ b/go/pkg/casng/batching_upload_test.go
@@ -562,3 +562,80 @@ func TestUpload_BatchingDigestTree(t *testing.T) {
 		t.Errorf("stats mismatch, (-want +got): %s", diff)
 	}
 }
+
+func TestUpload_ReplaceWorkingDir(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     impath.Absolute
+		root     impath.Absolute
+		wd       impath.Relative
+		rwd      impath.Relative
+		wantPath impath.Absolute
+		wantErr  bool
+	}{
+		{
+			name:     "both_set",
+			path:     impath.MustAbs("/root/wd/foo"),
+			root:     impath.MustAbs("/root"),
+			wd:       impath.MustRel("wd"),
+			rwd:      impath.MustRel("rwd"),
+			wantPath: impath.MustAbs("/root/rwd/foo"),
+		},
+		{
+			name:     "both_empty",
+			path:     impath.MustAbs("/root/foo"),
+			root:     impath.MustAbs("/root"),
+			wd:       impath.MustRel(""),
+			rwd:      impath.MustRel(""),
+			wantPath: impath.MustAbs("/root/foo"),
+		},
+		{
+			name:     "wd_empty",
+			path:     impath.MustAbs("/root/foo"),
+			root:     impath.MustAbs("/root"),
+			wd:       impath.MustRel(""),
+			rwd:      impath.MustRel("rwd"),
+			wantPath: impath.MustAbs("/root/rwd/foo"),
+		},
+		{
+			name:     "rwd_empty",
+			path:     impath.MustAbs("/root/wd/foo"),
+			root:     impath.MustAbs("/root"),
+			wd:       impath.MustRel("wd"),
+			rwd:      impath.MustRel(""),
+			wantPath: impath.MustAbs("/root/foo"),
+		},
+		{
+			name:     "root_not_prefix",
+			path:     impath.MustAbs("/root/wd/foo"),
+			root:     impath.MustAbs("/root2"),
+			wd:       impath.MustRel("wd"),
+			rwd:      impath.MustRel("rwd"),
+			wantPath: impath.Absolute{},
+			wantErr:  true,
+		},
+		{
+			name:     "outside_wd",
+			path:     impath.MustAbs("/root/out/foo"),
+			root:     impath.MustAbs("/root"),
+			wd:       impath.MustRel("out/src"),
+			rwd:      impath.MustRel("rwd/a/b"),
+			wantPath: impath.MustAbs("/root/rwd/a/foo"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p, err := casng.ReplaceWorkingDir(test.path, test.root, test.wd, test.rwd)
+			if err != nil && !test.wantErr {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if err == nil && test.wantErr {
+				t.Errorf("expected an error, but didn't get one")
+			}
+			if test.wantPath.String() != p.String() {
+				t.Errorf("Path mismatch: want: %q, got %q", test.wantPath, p)
+			}
+		})
+	}
+}

--- a/go/pkg/io/impath/impath.go
+++ b/go/pkg/io/impath/impath.go
@@ -116,7 +116,7 @@ func MustAbs(elements ...string) Absolute {
 //
 // If the specified elements do not join to a valid relative path, ErrNotRelative is returned.
 func Rel(elements ...string) (Relative, error) {
-	p := strings.Join(elements, string(os.PathSeparator))
+	p := strings.Join(filterNotEmpty(elements...), string(os.PathSeparator))
 	if filepath.IsAbs(p) {
 		return zeroRel, errors.Join(ErrNotRelative, fmt.Errorf("path %q", p))
 	}
@@ -219,4 +219,14 @@ func dirty(path string) bool {
 		prevRune = r
 	}
 	return false
+}
+
+func filterNotEmpty(strs ...string) []string {
+	filtered := make([]string, 0, len(strs))
+	for _, elm := range strs {
+		if elm != "" {
+			filtered = append(filtered, elm)
+		}
+	}
+	return filtered
 }

--- a/go/pkg/io/impath/impath_test.go
+++ b/go/pkg/io/impath/impath_test.go
@@ -33,6 +33,12 @@ func Test_Abs(t *testing.T) {
 			want:  filepath.Join(impath.Root, "foo", "baz"),
 			err:   nil,
 		},
+		{
+			name:  "some_empty",
+			parts: []string{impath.Root, "", "foo", "", "bar", "..", "baz"},
+			want:  filepath.Join(impath.Root, "foo", "baz"),
+			err:   nil,
+		},
 	}
 
 	for _, test := range tests {
@@ -71,6 +77,12 @@ func Test_Rel(t *testing.T) {
 		{
 			name:  "not_clean",
 			parts: []string{"foo", "bar", "..", "baz"},
+			want:  filepath.Join("foo", "baz"),
+			err:   nil,
+		},
+		{
+			name:  "some_empty",
+			parts: []string{"", "foo", "", "bar", "..", "baz"},
 			want:  filepath.Join("foo", "baz"),
 			err:   nil,
 		},


### PR DESCRIPTION
A few corner cases were not handeled properly.
The original one was not removing the leading slash after stripping
workingDir.
However, a more interesting one was that paths being outside workingDir,
but still under root, which could translate to partial replacements of
the workingDir path, which is a valid case, contrary to what I thought.
Reverted to using proper filepath APIs.
