### PR TITLE
[go] Add support for authentication via Credential Helper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/bazelbuild/remote-apis-sdks
 go 1.20
 
 require (
+	github.com/EngFlow/credential-helper-go v0.0.0-20230928231836-1ae22fe3da4b
 	github.com/bazelbuild/remote-apis v0.0.0-20230411132548-35aee1c4a425
 	github.com/golang/glog v1.1.0
 	github.com/google/go-cmp v0.5.9
@@ -17,7 +18,7 @@ require (
 	google.golang.org/genproto v0.0.0-20230803162519-f966b187b2e5
 	google.golang.org/genproto/googleapis/bytestream v0.0.0-20230807174057-1744710a1577
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230731190214-cbb8c96f2d6d
-	google.golang.org/grpc v1.58.0-dev.0.20230804151048-7aceafcc52f9
+	google.golang.org/grpc v1.58.0
 	google.golang.org/protobuf v1.31.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2Aawl
 cloud.google.com/go/longrunning v0.5.1 h1:Fr7TXftcqTudoyRJa113hyaqlGdiBQkp0Gq7tErFDWI=
 cloud.google.com/go/longrunning v0.5.1/go.mod h1:spvimkwdz6SPWKEt/XBij79E9fiTkHSQl/fRUUQJYJc=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/EngFlow/credential-helper-go v0.0.0-20230928231836-1ae22fe3da4b h1:mf0b15Wn/T7RzMXjyDW+TKyO80CR1BnM9/B9u05TJ5Q=
+github.com/EngFlow/credential-helper-go v0.0.0-20230928231836-1ae22fe3da4b/go.mod h1:feR+azx/GSHyRcazMg8aGZFtiBkpv3jFdT81w+b+PBM=
 github.com/bazelbuild/remote-apis v0.0.0-20230411132548-35aee1c4a425 h1:Lj8uXWW95oXyYguUSdQDvzywQb4f0jbJWsoLPQWAKTY=
 github.com/bazelbuild/remote-apis v0.0.0-20230411132548-35aee1c4a425/go.mod h1:ry8Y6CkQqCVcYsjPOlLXDX2iRVjOnjogdNwhvHmRcz8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -152,8 +154,8 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.37.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
-google.golang.org/grpc v1.58.0-dev.0.20230804151048-7aceafcc52f9 h1:q+IouZau98MiF17oKDj80j5J4KKnzmcxXsujTA9WGMk=
-google.golang.org/grpc v1.58.0-dev.0.20230804151048-7aceafcc52f9/go.mod h1:eQ5TbWncHnnyuYfjb+hBJFRvLf9SSLgqMR7pVc1on3I=
+google.golang.org/grpc v1.58.0 h1:32JY8YpPMSR45K+c3o6b8VL73V+rR8k+DeMIr4vRH8o=
+google.golang.org/grpc v1.58.0/go.mod h1:tgX3ZQDlNJGU96V6yHh1T/JeoBQ2TXdr43YbYSsCJk0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/go/pkg/client/BUILD.bazel
+++ b/go/pkg/client/BUILD.bazel
@@ -31,6 +31,8 @@ go_library(
         "//go/pkg/retry",
         "//go/pkg/uploadinfo",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:remote_execution_go_proto",
+        "@com_github_engflow_credential_helper_go//:go_default_library",
+        "@com_github_engflow_credential_helper_go//credentialhelpergrpc:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_klauspost_compress//zstd:go_default_library",
         "@com_github_mostynb_zstdpool_syncpool//:go_default_library",

--- a/go/pkg/flags/BUILD.bazel
+++ b/go/pkg/flags/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//go/pkg/balancer",
         "//go/pkg/client",
         "//go/pkg/moreflag",
+        "@com_github_engflow_credential_helper_go//:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//keepalive:go_default_library",

--- a/go_deps.bzl
+++ b/go_deps.bzl
@@ -50,6 +50,13 @@ def remote_apis_sdks_go_deps():
         version = "v1.1.0",
     )
     go_repository(
+        name = "com_github_engflow_credential_helper_go",
+        importpath = "github.com/EngFlow/credential-helper-go",
+        sum = "h1:mf0b15Wn/T7RzMXjyDW+TKyO80CR1BnM9/B9u05TJ5Q=",
+        version = "v0.0.0-20230928231836-1ae22fe3da4b",
+    )
+
+    go_repository(
         name = "com_github_envoyproxy_go_control_plane",
         importpath = "github.com/envoyproxy/go-control-plane",
         sum = "h1:xvqufLtNVwAhN8NMyWklVgxnWohi+wtMGQMhtxexlm0=",


### PR DESCRIPTION
This change adds support for Credential Helpers, similar to Bazel's support for Credential Helpers.