### PR TITLE
Fix stats in BatchDownloadBlobs call

### DIFF
--- a/go/pkg/client/capabilities.go
+++ b/go/pkg/client/capabilities.go
@@ -46,7 +46,7 @@ func (c *Client) CheckCapabilities(ctx context.Context) (err error) {
 		}
 		for _, compressor := range c.serverCaps.CacheCapabilities.SupportedBatchUpdateCompressors {
 			if compressor == repb.Compressor_ZSTD {
-				c.batchCompression = true
+				c.useBatchCompression = UseBatchCompression(true)
 			}
 		}
 	}

--- a/go/pkg/client/cas_upload.go
+++ b/go/pkg/client/cas_upload.go
@@ -139,7 +139,7 @@ func (c *Client) BatchWriteBlobs(ctx context.Context, blobs map[digest.Digest][]
 			Digest: k.ToProto(),
 			Data:   b,
 		}
-		if c.batchCompression && c.shouldCompress(k.Size) {
+		if bool(c.useBatchCompression) && c.shouldCompress(k.Size) {
 			r.Data = zstdEncoder.EncodeAll(r.Data, nil)
 			r.Compressor = repb.Compressor_ZSTD
 			sz += int64(len(r.Data))

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -173,7 +173,8 @@ type Client struct {
 	// UnifiedDownloadTickDuration specifies how often the unified download daemon flushes the pending requests.
 	UnifiedDownloadTickDuration UnifiedDownloadTickDuration
 	// TreeSymlinkOpts controls how symlinks are handled when constructing a tree.
-	TreeSymlinkOpts     *TreeSymlinkOpts
+	TreeSymlinkOpts *TreeSymlinkOpts
+
 	serverCaps          *repb.ServerCapabilities
 	useBatchOps         UseBatchOps
 	casConcurrency      int64
@@ -186,7 +187,7 @@ type Client struct {
 	creds               credentials.PerRPCCredentials
 	uploadOnce          sync.Once
 	downloadOnce        sync.Once
-	batchCompression    bool
+	useBatchCompression UseBatchCompression
 }
 
 const (
@@ -387,6 +388,15 @@ type UseBatchOps bool
 // Apply sets the UseBatchOps flag on a client.
 func (u UseBatchOps) Apply(c *Client) {
 	c.useBatchOps = u
+}
+
+// UseBatchCompression is currently set to true when the server has
+// SupportedBatchUpdateCompressors capability and supports ZSTD compression.
+type UseBatchCompression bool
+
+// Apply sets the batchCompression flag on a client.
+func (u UseBatchCompression) Apply(c *Client) {
+	c.useBatchCompression = u
 }
 
 // CASConcurrency is the number of simultaneous requests that will be issued for CAS upload and


### PR DESCRIPTION
Previously, BatchDownloadBlobs() wasn't properly recording the compressed download size. To fix it, I've introduced a new public interface called BatchDowloadBlobsWithStats(), which will return statistics on the downloaded blob size in addition to the actual content.

As part of this, I also realized that tests are non-existent for compressed BatchDownloadBlobs() and added them.

In a subsequent change, I'll fix BatchUploadBlobs() as well.

TESTED: Unit test