### PR TITLE
fix preserving intermediate symlinks

### DIFF
--- a/go/pkg/client/tree_whitebox_test.go
+++ b/go/pkg/client/tree_whitebox_test.go
@@ -1,9 +1,14 @@
 package client
 
 import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/filemetadata"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestGetTargetRelPath(t *testing.T) {
@@ -74,12 +79,218 @@ func TestGetTargetRelPath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			relExecRoot, relSymDir, err := getTargetRelPath(execRoot, tc.path, tc.symMeta)
+			relExecRoot, relSymDir, err := getTargetRelPath(execRoot, tc.path, tc.symMeta.Target)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("getTargetRelPath(path=%q) error: expected=%v got=%v", tc.path, tc.wantErr, err)
 			}
 			if err == nil && (relExecRoot != tc.wantRelExecRoot || relSymDir != tc.wantRelSymDir) {
 				t.Errorf("getTargetRelPath(path=%q) result: expected=(%v,%v) got=(%v,%v)", tc.path, tc.wantRelExecRoot, tc.wantRelSymDir, relExecRoot, relSymDir)
+			}
+		})
+	}
+}
+
+func TestEvalParentSymlinks(t *testing.T) {
+	cache := filemetadata.NewSingleFlightCache()
+
+	mkPath := func(path string) string {
+		if filepath.Separator == '/' {
+			return path
+		}
+		return filepath.Join(strings.Split(path, "/")...)
+	}
+
+	testCases := []struct {
+		name string
+		// List of relative file (no directories) paths with no intermediate symlinks.
+		// All paths start under the "root" directory. To go outside, use `..`.
+		// To denote a symlink, use the format: "symlink->target", e.g. "a/b->bb".
+		// To denote a symlink with an absolute path for its target, prefix the target with a forward slash. E.g. "a/b->/bb".
+		// Absolute symlinks also start under "root". To go outside, use `..`, e.g. `a/b->/../root2/bb`.
+		fs []string
+		// The path that includes intermediate symlinks.
+		path         string
+		materialize  bool
+		wantPath     string
+		wantSymlinks []string
+		wantErr      bool
+	}{
+		{
+			name: "one_relative_simple",
+			fs: []string{
+				"wd/a->aa",
+				"wd/aa/b.go",
+			},
+			path:         mkPath("wd/a/b.go"),
+			materialize:  false,
+			wantPath:     mkPath("wd/aa/b.go"),
+			wantSymlinks: []string{mkPath("wd/a")},
+		},
+		{
+			name: "one_relative_basename_symlink",
+			fs: []string{
+				"wd/a->aa",
+				"wd/aa/b.go->c.go",
+				"wd/aa/c.go",
+			},
+			path:         mkPath("wd/a/b.go"),
+			materialize:  false,
+			wantPath:     mkPath("wd/aa/b.go"),
+			wantSymlinks: []string{mkPath("wd/a")},
+		},
+		{
+			name: "one_relative",
+			fs: []string{
+				"wd/a->../wd2/aa",
+				"wd2/aa/b.go",
+			},
+			path:         mkPath("wd/a/b.go"),
+			materialize:  false,
+			wantPath:     mkPath("wd2/aa/b.go"),
+			wantSymlinks: []string{mkPath("wd/a")},
+		},
+		{
+			name: "one_absolute_simple",
+			fs: []string{
+				"wd/a->/wd/aa",
+				"wd/aa/b.go",
+			},
+			path:         mkPath("wd/a/b.go"),
+			materialize:  false,
+			wantPath:     mkPath("wd/aa/b.go"),
+			wantSymlinks: []string{mkPath("wd/a")},
+		},
+		{
+			name: "one_absolute",
+			fs: []string{
+				"wd/a->/wd2/aa",
+				"wd2/aa/b.go",
+			},
+			path:         mkPath("wd/a/b.go"),
+			materialize:  false,
+			wantPath:     mkPath("wd2/aa/b.go"),
+			wantSymlinks: []string{mkPath("wd/a")},
+		},
+		{
+			name: "multiple_relative",
+			fs: []string{
+				"wd/a->aa",
+				"wd/aa/b->bb",
+				"wd/aa/bb/c.go",
+			},
+			path:        mkPath("wd/a/b/c.go"),
+			materialize: false,
+			wantPath:    mkPath("wd/aa/bb/c.go"),
+			wantSymlinks: []string{
+				mkPath("wd/a"),
+				mkPath("wd/aa/b"),
+			},
+		},
+		{
+			name: "multiple_absolute",
+			fs: []string{
+				"wd/a->/wd/aa",
+				"wd/aa/b->/wd/aa/bb",
+				"wd/aa/bb/c.go",
+			},
+			path:        mkPath("wd/a/b/c.go"),
+			materialize: false,
+			wantPath:    mkPath("wd/aa/bb/c.go"),
+			wantSymlinks: []string{
+				mkPath("wd/a"),
+				mkPath("wd/aa/b"),
+			},
+		},
+		{
+			name: "one_relative_materialize_simple",
+			fs: []string{
+				"wd/a->../../root2/aa",
+				"../root2/aa/b.go",
+			},
+			path:         mkPath("wd/a/b.go"),
+			materialize:  true,
+			wantPath:     mkPath("wd/a/b.go"),
+			wantSymlinks: nil,
+		},
+		{
+			name: "one_absolute_materialize_simple",
+			fs: []string{
+				"wd/a->/../root2/aa",
+				"../root2/aa/b.go",
+			},
+			path:         mkPath("wd/a/b.go"),
+			materialize:  true,
+			wantPath:     mkPath("wd/a/b.go"),
+			wantSymlinks: nil,
+		},
+		{
+			name: "multiple_relative_materialize_simple",
+			fs: []string{
+				"wd/a->../../root2/aa",
+				"../root2/aa/b->../../root3/aaa/bb",
+				"../root3/aaa/bb/c.go",
+			},
+			path:         mkPath("wd/a/b/c.go"),
+			materialize:  true,
+			wantPath:     mkPath("wd/a/b/c.go"),
+			wantSymlinks: nil,
+		},
+		{
+			name: "multiple_absolute_materialize_simple",
+			fs: []string{
+				"wd/a->/../root2/aa",
+				"../root2/aa/b->/../root3/aaa/bb",
+				"../root3/aaa/bb/c.go",
+			},
+			path:         mkPath("wd/a/b/c.go"),
+			materialize:  true,
+			wantPath:     mkPath("wd/a/b/c.go"),
+			wantSymlinks: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			root := filepath.Join(tmp, "root")
+			for _, p := range tc.fs {
+				slParts := strings.Split(p, "->")
+				absPath := filepath.Join(root, mkPath(slParts[0]))
+				dir := filepath.Dir(absPath)
+				err := os.MkdirAll(dir, 0777)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				if len(slParts) > 1 {
+					target := mkPath(slParts[1])
+					if target[0] == '/' {
+						target = filepath.Join(root, target[1:])
+					}
+					err = os.Symlink(target, absPath)
+				} else {
+					err = os.WriteFile(absPath, nil, 0777)
+				}
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+
+			evaledPath, symlinks, err := evalParentSymlinks(root, tc.path, tc.materialize, cache)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected an error, but did not get one")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			evaledPath = filepath.Clean(evaledPath)
+			if evaledPath != tc.wantPath {
+				t.Errorf("path mismatch: got %q, want %q", evaledPath, tc.wantPath)
+			}
+			sort.Strings(symlinks)
+			sort.Strings(tc.wantSymlinks)
+			if diff := cmp.Diff(tc.wantSymlinks, symlinks); diff != "" {
+				t.Errorf("symlinks mismatch: got +, want -\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
If a filepath includes a symlink to a directory, that symlink is converted to a directory in the computed Merkle tree. This is fine unless symlink preservation is turned on, in which case any process that expects a symlink might fail.

For example, if `/a/b/c.go` is loaded and `b->bb`, the Merkle tree will only have b as a directory node and it will not include bb. If /a/b and /a/b/c.go are loaded, the server will fail to write both a directory and a symlink to the same path `/a/b`. The symlink comes from loading `/a/b` and the directory comes from loading `/a/b/c.go`.

The correct Merkle tree in this case should look like:
```
a
|_b->bb
|_bb
|_|_c.go
```

That is, any intermediate symlink to a directory appears in the tree exactly once as a symlink. I.e. it never appears as a directory.

This change introduces additional IO overhead for each loaded file. The overhead is proportional to the number of files, the depth of each filepath, and the number of symlinks in each filepath. Additionally, a map is introduced to deduplicate loaded files, which will add memory and GC overhead proportional to the number of loaded files. Both overheads are limited to requests with symlink preservation turned on.