### PR TITLE
Add missing formatting directives

### DIFF
--- a/go/pkg/tool/tool.go
+++ b/go/pkg/tool/tool.go
@@ -381,7 +381,7 @@ func (c *Client) DownloadAction(ctx context.Context, actionDigest, outputPath st
 	if err != nil {
 		return fmt.Errorf("error creating the directory: %v", err)
 	}
-	log.Infof("Directory created:", outputPath)
+	log.Infof("Directory created: %v", outputPath)
 
 	if err := c.writeProto(actionProto, filepath.Join(outputPath, "ac.textproto")); err != nil {
 		return err


### PR DESCRIPTION
```
compilepkg: nogo: errors found by nogo during build-time code analysis:
go/pkg/tool/tool.go:384:11: github.com/google/glog.Infof call has arguments but no formatting directives (printf)
```