### PR TITLE
Always return error when exit code not zero

### DIFF
--- a/go/pkg/rexec/rexec.go
+++ b/go/pkg/rexec/rexec.go
@@ -701,7 +701,7 @@ func (ec *Context) ExecuteRemotely() {
 				}
 			}
 		}
-		if ec.Result.Err == nil && ec.opt.DownloadOutputs {
+		if ec.Result.IsDownloadable() && ec.opt.DownloadOutputs {
 			log.V(1).Infof("%s %s> Downloading outputs...", cmdID, executionID)
 			stats, res := ec.downloadOutputs(ec.cmd.ExecRoot)
 			ec.Metadata.LogicalBytesDownloaded += stats.LogicalMoved

--- a/go/pkg/rexec/rexec_test.go
+++ b/go/pkg/rexec/rexec_test.go
@@ -264,7 +264,7 @@ func TestExecRemoteFailureDownloadsPartialResults(t *testing.T) {
 	}{
 		{
 			name:    "non zero exit",
-			wantRes: &command.Result{ExitCode: 52, Status: command.NonZeroExitResultStatus},
+			wantRes: &command.Result{ExitCode: 52, Status: command.NonZeroExitResultStatus, Err: command.ErrNonZeroExit},
 		},
 		{
 			name:    "remote error",
@@ -340,7 +340,7 @@ func TestDoNotDownloadOutputs(t *testing.T) {
 		{
 			name:     "non zero exit",
 			exitCode: 11,
-			wantRes:  &command.Result{ExitCode: 11, Status: command.NonZeroExitResultStatus},
+			wantRes:  &command.Result{ExitCode: 11, Status: command.NonZeroExitResultStatus, Err: command.ErrNonZeroExit},
 		},
 		{
 			name:    "timeout",
@@ -481,7 +481,7 @@ func TestStreamOutErr(t *testing.T) {
 			hasStdOutStream: true,
 			hasStdErrStream: true,
 			exitCode:        11,
-			wantRes:         &command.Result{ExitCode: 11, Status: command.NonZeroExitResultStatus},
+			wantRes:         &command.Result{ExitCode: 11, Status: command.NonZeroExitResultStatus, Err: command.ErrNonZeroExit},
 			wantStdOut:      "streaming-stdout",
 			wantStdErr:      "streaming-stderr",
 		},


### PR DESCRIPTION
Always return some error when exit code is not zero, so re-client can use the err to assert if the remote action successes or not.

Test: Unit test