### PR TITLE
Ignore files without read permissions

### DIFF
--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -111,7 +111,7 @@ func shouldIgnore(inp string, t command.InputType, excl []*command.InputExclusio
 
 // shouldIgnoreErr returns whether a given error should be ignored.
 func shouldIgnoreErr(err error) bool {
-	// We should skip files without read permissions. If the user doesn't have read permissions, 
+	// We should skip files without read permissions. If the user doesn't have read permissions,
 	// the file is unlikely to be used in the build in the first place.
 	if e, ok := err.(*filemetadata.FileError); ok {
 		return os.IsPermission(e.Err)

--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -331,6 +331,10 @@ func loadFiles(execRoot, localWorkingDir, remoteWorkingDir string, excl []*comma
 			if shouldIgnore(absPath, command.DirectoryInputType, excl) {
 				continue
 			} else if meta.Err != nil {
+				// Skip files with read permission issues.
+				if e, ok := meta.Err.(*filemetadata.FileError); ok && os.IsPermission(e.Err) {
+					continue
+				}
 				return meta.Err
 			}
 
@@ -358,6 +362,10 @@ func loadFiles(execRoot, localWorkingDir, remoteWorkingDir string, excl []*comma
 			if shouldIgnore(absPath, command.FileInputType, excl) {
 				continue
 			} else if meta.Err != nil {
+				// Skip files with read permission issues.
+				if e, ok := meta.Err.(*filemetadata.FileError); ok && os.IsPermission(e.Err) {
+					continue
+				}
 				return meta.Err
 			}
 

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -2118,85 +2118,70 @@ func TestComputeOutputsToUploadDirectories(t *testing.T) {
 }
 
 func TestComputeOutputsToUploadFileNoPermissions(t *testing.T) {
-	tests := []struct {
-		desc           string
-		input          []*inputPath
-		wd             string
-		paths          []string
-		nodeProperties map[string]*cpb.NodeProperties
-		wantResult     *repb.ActionResult
-		wantBlobs      [][]byte
-		wantCacheCalls map[string]int
-	}{
-		{
-			desc: "foo with permissions, bar without permissions",
-			input: []*inputPath{
-				{path: "wd/foo", fileContents: fooBlob, isExecutable: true},
-				{path: "bar", fileContents: barBlob},
-			},
-			paths:          []string{"foo", "bar"},
-			nodeProperties: map[string]*cpb.NodeProperties{"foo": fooProperties},
-			wd:             "wd",
-			wantBlobs:      [][]byte{fooBlob},
-			wantResult: &repb.ActionResult{
-				OutputFiles: []*repb.OutputFile{
-					&repb.OutputFile{Path: "foo", Digest: fooDgPb, IsExecutable: true, NodeProperties: command.NodePropertiesToAPI(fooProperties)},
-				},
-			},
-			wantCacheCalls: map[string]int{
-				"bar":    1,
-				"wd/foo": 1,
-			},
+	desc := "foo with permissions, bar without permissions"
+	input := []*inputPath{
+		{path: "wd/foo", fileContents: fooBlob, isExecutable: true},
+		{path: "bar", fileContents: barBlob},
+	}
+	paths :=          []string{"foo", "../bar"}
+	nodeProperties := map[string]*cpb.NodeProperties{"foo": fooProperties}
+	wd :=             "wd"
+	wantBlob:=      [][]byte{fooBlob}
+	wantResult:= &repb.ActionResult{
+		OutputFiles: []*repb.OutputFile{
+			&repb.OutputFile{Path: "foo", Digest: fooDgPb, IsExecutable: true, NodeProperties: command.NodePropertiesToAPI(fooProperties)},
 		},
 	}
-
-	for _, tc := range tests {
-		root := t.TempDir()
-		if err := construct(root, tc.input); err != nil {
-			t.Fatalf("failed to construct input dir structure: %v", err)
-		}
-
-		if err := os.Chmod(filepath.Join(root, "bar"), 0100); err != nil {
-			t.Fatalf("failed to set permissions of bar: %v", err)
-		}
-
-		t.Run(tc.desc, func(t *testing.T) {
-			wantBlobs := make(map[digest.Digest][]byte)
-			for _, b := range tc.wantBlobs {
-				wantBlobs[digest.NewFromBlob(b)] = b
-			}
-
-			gotBlobs := make(map[digest.Digest][]byte)
-			cache := newCallCountingMetadataCache(root, t)
-			e, cleanup := fakes.NewTestEnv(t)
-			defer cleanup()
-
-			inputs, gotResult, err := e.Client.GrpcClient.ComputeOutputsToUpload(root, tc.wd, tc.paths, cache, command.UnspecifiedSymlinkBehavior, tc.nodeProperties)
-			if err != nil {
-				t.Errorf("ComputeOutputsToUpload(...) = gave error %v, want success", err)
-			}
-			for _, ue := range inputs {
-				ch, err := chunker.New(ue, false, int(e.Client.GrpcClient.ChunkMaxSize))
-				if err != nil {
-					t.Fatalf("chunker.New(ue): failed to create chunker from UploadEntry: %v", err)
-				}
-				blob, err := ch.FullData()
-				if err != nil {
-					t.Errorf("chunker %v FullData() returned error %v", ch, err)
-				}
-				gotBlobs[ue.Digest] = blob
-			}
-			if diff := cmp.Diff(wantBlobs, gotBlobs); diff != "" {
-				t.Errorf("ComputeOutputsToUpload(...) gave diff (-want +got) on blobs:\n%s", diff)
-			}
-			if diff := cmp.Diff(tc.wantCacheCalls, cache.calls, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("ComputeOutputsToUpload(...) gave diff on file metadata cache access (-want +got) on blobs:\n%s", diff)
-			}
-			if diff := cmp.Diff(tc.wantResult, gotResult, cmp.Comparer(proto.Equal)); diff != "" {
-				t.Errorf("ComputeOutputsToUpload(...) gave diff on action result (-want +got) on blobs:\n%s", diff)
-			}
-		})
+	wantCacheCalls:= map[string]int{
+		"bar":    1,
+		"wd/foo": 1,
 	}
+
+	root := t.TempDir()
+	if err := construct(root, input); err != nil {
+		t.Fatalf("failed to construct input dir structure: %v", err)
+	}
+
+	if err := os.Chmod(filepath.Join(root, "bar"), 0100); err != nil {
+		t.Fatalf("failed to set permissions of bar: %v", err)
+	}
+
+	t.Run(desc, func(t *testing.T) {
+		wantBlobs := make(map[digest.Digest][]byte)
+		for _, b := range wantBlob {
+			wantBlobs[digest.NewFromBlob(b)] = b
+		}
+
+		gotBlobs := make(map[digest.Digest][]byte)
+		cache := newCallCountingMetadataCache(root, t)
+		e, cleanup := fakes.NewTestEnv(t)
+		defer cleanup()
+
+		inputs, gotResult, err := e.Client.GrpcClient.ComputeOutputsToUpload(root, wd, paths, cache, command.UnspecifiedSymlinkBehavior, nodeProperties)
+		if err != nil {
+			t.Errorf("ComputeOutputsToUpload(...) = gave error %v, want success", err)
+		}
+		for _, ue := range inputs {
+			ch, err := chunker.New(ue, false, int(e.Client.GrpcClient.ChunkMaxSize))
+			if err != nil {
+				t.Fatalf("chunker.New(ue): failed to create chunker from UploadEntry: %v", err)
+			}
+			blob, err := ch.FullData()
+			if err != nil {
+				t.Errorf("chunker %v FullData() returned error %v", ch, err)
+			}
+			gotBlobs[ue.Digest] = blob
+		}
+		if diff := cmp.Diff(wantBlobs, gotBlobs); diff != "" {
+			t.Errorf("ComputeOutputsToUpload(...) gave diff (-want +got) on blobs:\n%s", diff)
+		}
+		if diff := cmp.Diff(wantCacheCalls, cache.calls, cmpopts.EquateEmpty()); diff != "" {
+			t.Errorf("ComputeOutputsToUpload(...) gave diff on file metadata cache access (-want +got) on blobs:\n%s", diff)
+		}
+		if diff := cmp.Diff(wantResult, gotResult, cmp.Comparer(proto.Equal)); diff != "" {
+			t.Errorf("ComputeOutputsToUpload(...) gave diff on action result (-want +got) on blobs:\n%s", diff)
+		}
+	})
 }
 
 func randomBytes(randGen *rand.Rand, n int) []byte {

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -2117,6 +2117,88 @@ func TestComputeOutputsToUploadDirectories(t *testing.T) {
 	}
 }
 
+func TestComputeOutputsToUploadFileNoPermissions(t *testing.T) {
+	tests := []struct {
+		desc           string
+		input          []*inputPath
+		wd             string
+		paths          []string
+		nodeProperties map[string]*cpb.NodeProperties
+		wantResult     *repb.ActionResult
+		wantBlobs      [][]byte
+		wantCacheCalls map[string]int
+	}{
+		{
+			desc: "foo with permissions, bar without permissions",
+			input: []*inputPath{
+				{path: "wd/foo", fileContents: fooBlob, isExecutable: true},
+				{path: "bar", fileContents: barBlob},
+			},
+			paths:          []string{"foo", "bar"},
+			nodeProperties: map[string]*cpb.NodeProperties{"foo": fooProperties},
+			wd:             "wd",
+			wantBlobs:      [][]byte{fooBlob},
+			wantResult: &repb.ActionResult{
+				OutputFiles: []*repb.OutputFile{
+					&repb.OutputFile{Path: "foo", Digest: fooDgPb, IsExecutable: true, NodeProperties: command.NodePropertiesToAPI(fooProperties)},
+				},
+			},
+			wantCacheCalls: map[string]int{
+				"bar":    1,
+				"wd/foo": 1,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		root := t.TempDir()
+		if err := construct(root, tc.input); err != nil {
+			t.Fatalf("failed to construct input dir structure: %v", err)
+		}
+
+		if err := os.Chmod(filepath.Join(root, "bar"), 0100); err != nil {
+			t.Fatalf("failed to set permissions of bar: %v", err)
+		}
+
+		t.Run(tc.desc, func(t *testing.T) {
+			wantBlobs := make(map[digest.Digest][]byte)
+			for _, b := range tc.wantBlobs {
+				wantBlobs[digest.NewFromBlob(b)] = b
+			}
+
+			gotBlobs := make(map[digest.Digest][]byte)
+			cache := newCallCountingMetadataCache(root, t)
+			e, cleanup := fakes.NewTestEnv(t)
+			defer cleanup()
+
+			inputs, gotResult, err := e.Client.GrpcClient.ComputeOutputsToUpload(root, tc.wd, tc.paths, cache, command.UnspecifiedSymlinkBehavior, tc.nodeProperties)
+			if err != nil {
+				t.Errorf("ComputeOutputsToUpload(...) = gave error %v, want success", err)
+			}
+			for _, ue := range inputs {
+				ch, err := chunker.New(ue, false, int(e.Client.GrpcClient.ChunkMaxSize))
+				if err != nil {
+					t.Fatalf("chunker.New(ue): failed to create chunker from UploadEntry: %v", err)
+				}
+				blob, err := ch.FullData()
+				if err != nil {
+					t.Errorf("chunker %v FullData() returned error %v", ch, err)
+				}
+				gotBlobs[ue.Digest] = blob
+			}
+			if diff := cmp.Diff(wantBlobs, gotBlobs); diff != "" {
+				t.Errorf("ComputeOutputsToUpload(...) gave diff (-want +got) on blobs:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantCacheCalls, cache.calls, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("ComputeOutputsToUpload(...) gave diff on file metadata cache access (-want +got) on blobs:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantResult, gotResult, cmp.Comparer(proto.Equal)); diff != "" {
+				t.Errorf("ComputeOutputsToUpload(...) gave diff on action result (-want +got) on blobs:\n%s", diff)
+			}
+		})
+	}
+}
+
 func randomBytes(randGen *rand.Rand, n int) []byte {
 	b := make([]byte, n)
 	randGen.Read(b)

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -2123,16 +2123,16 @@ func TestComputeOutputsToUploadFileNoPermissions(t *testing.T) {
 		{path: "wd/foo", fileContents: fooBlob, isExecutable: true},
 		{path: "bar", fileContents: barBlob},
 	}
-	paths :=          []string{"foo", "../bar"}
+	paths := []string{"foo", "../bar"}
 	nodeProperties := map[string]*cpb.NodeProperties{"foo": fooProperties}
-	wd :=             "wd"
-	wantBlob:=      [][]byte{fooBlob}
-	wantResult:= &repb.ActionResult{
+	wd := "wd"
+	wantBlob := [][]byte{fooBlob}
+	wantResult := &repb.ActionResult{
 		OutputFiles: []*repb.OutputFile{
 			&repb.OutputFile{Path: "foo", Digest: fooDgPb, IsExecutable: true, NodeProperties: command.NodePropertiesToAPI(fooProperties)},
 		},
 	}
-	wantCacheCalls:= map[string]int{
+	wantCacheCalls := map[string]int{
 		"bar":    1,
 		"wd/foo": 1,
 	}


### PR DESCRIPTION
We want to ignore files that don't have read permissions rather than returning an error, as it is likely that the file is not needed if it can't be read.

Bug: b/308481142