### PR TITLE
Ignore setting PerRPCCreds as clientopts

### DIFF
--- a/go/pkg/flags/flags.go
+++ b/go/pkg/flags/flags.go
@@ -106,12 +106,16 @@ func NewClientFromFlags(ctx context.Context, opts ...client.Opt) (*client.Client
 		opts = append(opts, client.RPCTimeouts(timeouts))
 	}
 	var perRPCCreds *client.PerRPCCreds
+	tOpts := []client.Opt{}
 	for _, opt := range opts {
 		switch opt.(type) {
 		case *client.PerRPCCreds:
 			perRPCCreds = (opt).(*(client.PerRPCCreds))
+		default:
+			tOpts = append(tOpts, opt)
 		}
 	}
+	opts = tOpts
 
 	dialOpts := make([]grpc.DialOption, 0)
 	if *KeepAliveTime > 0*time.Second {


### PR DESCRIPTION
When PerRPCCreds is used, we are already setting it as part of DialParams, so we don't have to once again include it as part of clientopts when creating the connection.
When included again as part of clientopts, it results in gRPC adding duplicate Authorization header to the requests.

Issue: https://github.com/bazelbuild/reclient/issues/27 (thanks to @MarshallOfSound for debugging this)

Tested: I build with this, ran a sample command and confirmed with mitmproxy that authorization header wasn't repeated.

With this fix:
![Screenshot 2024-01-05 at 1 53 26 PM](https://github.com/bazelbuild/remote-apis-sdks/assets/48490842/2ca4af01-c30e-4be1-8115-f14ffb09f693)

Without this fix:
![Screenshot 2024-01-05 at 1 53 40 PM](https://github.com/bazelbuild/remote-apis-sdks/assets/48490842/f8bda291-b9c4-4ebf-ab0b-6a9ab8d5cd05)
