### PR TITLE
remotetool: add --json output

### DIFF
--- a/go/cmd/remotetool/main.go
+++ b/go/cmd/remotetool/main.go
@@ -69,7 +69,7 @@ var (
 	overwrite    = flag.Bool("overwrite", false, "Overwrite the output path if it already exist.")
 	actionRoot   = flag.String("action_root", "", "For execute_action: the root of the action spec, containing ac.textproto (Action proto), cmd.textproto (Command proto), and input/ (root of the input tree).")
 	execAttempts = flag.Int("exec_attempts", 10, "For check_determinism: the number of times to remotely execute the action and check for mismatches.")
-	jsonOutput   = flag.String("json_output", "", "Path to output operation result as JSON. Currently supported for \"upload_dir\", and includes various upload metadata (see UploadStats).")
+	jsonOutput   = flag.String("json", "", "Path to output operation result as JSON. Currently supported for \"upload_dir\", and includes various upload metadata (see UploadStats).")
 	_            = flag.String("input_root", "", "Deprecated. Use action root instead.")
 )
 
@@ -150,9 +150,13 @@ func main() {
 		us, err := c.UploadDirectory(ctx, getPathFlag())
 		if *jsonOutput != "" {
 			js, _ := json.MarshalIndent(us, "", "  ")
-			log.Infof("Outputting JSON results to %s", *jsonOutput)
-			if err := os.WriteFile(*jsonOutput, []byte(js), 0o666); err != nil {
-				log.Exitf("Error writing JSON output to file: %v", err)
+			if *jsonOutput == "-" {
+				fmt.Printf("%s\n", js)
+			} else {
+				log.Infof("Outputting JSON results to %s", *jsonOutput)
+				if err := os.WriteFile(*jsonOutput, []byte(js), 0o666); err != nil {
+					log.Exitf("Error writing JSON output to file: %v", err)
+				}
 			}
 		}
 		if err != nil {

--- a/go/cmd/remotetool/main.go
+++ b/go/cmd/remotetool/main.go
@@ -69,7 +69,7 @@ var (
 	overwrite    = flag.Bool("overwrite", false, "Overwrite the output path if it already exist.")
 	actionRoot   = flag.String("action_root", "", "For execute_action: the root of the action spec, containing ac.textproto (Action proto), cmd.textproto (Command proto), and input/ (root of the input tree).")
 	execAttempts = flag.Int("exec_attempts", 10, "For check_determinism: the number of times to remotely execute the action and check for mismatches.")
-	jsonOutput   = flag.Bool("json", false, "If set, output operation result as JSON. Currently supported for \"upload_dir\": includes the \"digest\" key for the root digest of the uploaded directory.")
+	jsonOutput   = flag.Bool("json", false, "If set, output operation result as JSON. Currently supported for \"upload_dir\", and includes various upload metadata (see UploadStats).")
 	_            = flag.String("input_root", "", "Deprecated. Use action root instead.")
 )
 
@@ -147,13 +147,13 @@ func main() {
 		}
 
 	case uploadDir:
-		dg, err := c.UploadDirectory(ctx, getPathFlag())
+		us, err := c.UploadDirectory(ctx, getPathFlag())
 		if err != nil {
 			log.Exitf("error uploading directory for path %s: %v", getPathFlag(), err)
 		}
 		if *jsonOutput {
-			d, _ := json.Marshal(map[string]string{"digest": dg.String()})
-			fmt.Printf("%s\n", d)
+			js, _ := json.MarshalIndent(us, "", "  ")
+			fmt.Printf("%s\n", js)
 		}
 
 	default:

--- a/go/cmd/remotetool/main.go
+++ b/go/cmd/remotetool/main.go
@@ -69,7 +69,7 @@ var (
 	overwrite    = flag.Bool("overwrite", false, "Overwrite the output path if it already exist.")
 	actionRoot   = flag.String("action_root", "", "For execute_action: the root of the action spec, containing ac.textproto (Action proto), cmd.textproto (Command proto), and input/ (root of the input tree).")
 	execAttempts = flag.Int("exec_attempts", 10, "For check_determinism: the number of times to remotely execute the action and check for mismatches.")
-	jsonOutput   = flag.Bool("json", false, "If set, output operation result as JSON. Currently supported for \"upload_dir\", and includes various upload metadata (see UploadStats).")
+	jsonOutput   = flag.String("json_output", "", "Path to output operation result as JSON. Currently supported for \"upload_dir\", and includes various upload metadata (see UploadStats).")
 	_            = flag.String("input_root", "", "Deprecated. Use action root instead.")
 )
 
@@ -148,9 +148,12 @@ func main() {
 
 	case uploadDir:
 		us, err := c.UploadDirectory(ctx, getPathFlag())
-		if *jsonOutput {
+		if *jsonOutput != "" {
 			js, _ := json.MarshalIndent(us, "", "  ")
-			fmt.Printf("%s\n", js)
+			log.Infof("Outputting JSON results to %s", *jsonOutput)
+			if err := os.WriteFile(*jsonOutput, []byte(js), 0o666); err != nil {
+				log.Exitf("Error writing JSON output to file: %v", err)
+			}
 		}
 		if err != nil {
 			log.Exitf("error uploading directory for path %s: %v", getPathFlag(), err)

--- a/go/cmd/remotetool/main.go
+++ b/go/cmd/remotetool/main.go
@@ -148,12 +148,12 @@ func main() {
 
 	case uploadDir:
 		us, err := c.UploadDirectory(ctx, getPathFlag())
-		if err != nil {
-			log.Exitf("error uploading directory for path %s: %v", getPathFlag(), err)
-		}
 		if *jsonOutput {
 			js, _ := json.MarshalIndent(us, "", "  ")
 			fmt.Printf("%s\n", js)
+		}
+		if err != nil {
+			log.Exitf("error uploading directory for path %s: %v", getPathFlag(), err)
 		}
 
 	default:

--- a/go/cmd/remotetool/main.go
+++ b/go/cmd/remotetool/main.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -68,6 +69,7 @@ var (
 	overwrite    = flag.Bool("overwrite", false, "Overwrite the output path if it already exist.")
 	actionRoot   = flag.String("action_root", "", "For execute_action: the root of the action spec, containing ac.textproto (Action proto), cmd.textproto (Command proto), and input/ (root of the input tree).")
 	execAttempts = flag.Int("exec_attempts", 10, "For check_determinism: the number of times to remotely execute the action and check for mismatches.")
+	jsonOutput   = flag.Bool("json", false, "If set, output operation result as JSON. Currently supported for \"upload_dir\": includes the \"digest\" key for the root digest of the uploaded directory.")
 	_            = flag.String("input_root", "", "Deprecated. Use action root instead.")
 )
 
@@ -145,8 +147,13 @@ func main() {
 		}
 
 	case uploadDir:
-		if err := c.UploadDirectory(ctx, getPathFlag()); err != nil {
+		dg, err := c.UploadDirectory(ctx, getPathFlag())
+		if err != nil {
 			log.Exitf("error uploading directory for path %s: %v", getPathFlag(), err)
+		}
+		if *jsonOutput {
+			d, _ := json.Marshal(map[string]string{"digest": dg.String()})
+			fmt.Printf("%s\n", d)
 		}
 
 	default:

--- a/go/pkg/tool/tool.go
+++ b/go/pkg/tool/tool.go
@@ -327,17 +327,17 @@ func (c *Client) DownloadDirectory(ctx context.Context, rootDigest, path string)
 }
 
 // UploadDirectory uploads a directory from the specified path as a Merkle-tree to the remote cache.
-func (c *Client) UploadDirectory(ctx context.Context, path string) error {
+func (c *Client) UploadDirectory(ctx context.Context, path string) (digest.Digest, error) {
 	log.Infof("Computing Merkle tree rooted at %s", path)
 	root, blobs, stats, err := c.GrpcClient.ComputeMerkleTree(ctx, path, "", "", &command.InputSpec{Inputs: []string{"."}}, filemetadata.NewNoopCache())
 	if err != nil {
-		return err
+		return digest.Empty, err
 	}
 	log.Infof("Directory root digest: %v", root)
 	log.Infof("Directory stats: %d files, %d directories, %d symlinks, %d total bytes", stats.InputFiles, stats.InputDirectories, stats.InputSymlinks, stats.TotalInputBytes)
 	log.Infof("Uploading directory %v rooted at %s to CAS.", root, path)
 	_, _, err = c.GrpcClient.UploadIfMissing(ctx, blobs...)
-	return err
+	return root, err
 }
 
 func (c *Client) writeProto(m proto.Message, baseName string) error {

--- a/go/pkg/tool/tool.go
+++ b/go/pkg/tool/tool.go
@@ -330,10 +330,10 @@ func (c *Client) DownloadDirectory(ctx context.Context, rootDigest, path string)
 type UploadStats struct {
 	rc.TreeStats
 	RootDigest       digest.Digest
-	TotalNumBlobs    int64
-	NumCacheMisses   int64
+	CountBlobs       int64
+	CountCacheMisses int64
 	BytesTransferred int64
-	CacheMissesBytes int64
+	BytesCacheMisses int64
 	Error            string
 }
 
@@ -345,9 +345,9 @@ func (c *Client) UploadDirectory(ctx context.Context, path string) (*UploadStats
 		return &UploadStats{Error: err.Error()}, err
 	}
 	us := &UploadStats{
-		TreeStats:     *stats,
-		RootDigest:    root,
-		TotalNumBlobs: int64(len(blobs)),
+		TreeStats:  *stats,
+		RootDigest: root,
+		CountBlobs: int64(len(blobs)),
 	}
 	log.Infof("Directory root digest: %v", root)
 	log.Infof("Directory stats: %d files, %d directories, %d symlinks, %d total bytes", stats.InputFiles, stats.InputDirectories, stats.InputSymlinks, stats.TotalInputBytes)
@@ -361,9 +361,9 @@ func (c *Client) UploadDirectory(ctx context.Context, path string) (*UploadStats
 	for _, d := range missing {
 		sumMissingBytes += d.Size
 	}
-	us.NumCacheMisses = int64(len(missing))
+	us.CountCacheMisses = int64(len(missing))
 	us.BytesTransferred = n
-	us.CacheMissesBytes = sumMissingBytes
+	us.BytesCacheMisses = sumMissingBytes
 	return us, nil
 }
 

--- a/go/pkg/tool/tool.go
+++ b/go/pkg/tool/tool.go
@@ -326,18 +326,43 @@ func (c *Client) DownloadDirectory(ctx context.Context, rootDigest, path string)
 	return err
 }
 
+// UploadStats contains various metadata of a directory upload.
+type UploadStats struct {
+	rc.TreeStats
+	RootDigest              digest.Digest
+	TotalNumBlobs           int64
+	NumCacheMisses          int64
+	CompressedBytesUploaded int64
+	CacheMissesBytes        int64
+}
+
 // UploadDirectory uploads a directory from the specified path as a Merkle-tree to the remote cache.
-func (c *Client) UploadDirectory(ctx context.Context, path string) (digest.Digest, error) {
+func (c *Client) UploadDirectory(ctx context.Context, path string) (*UploadStats, error) {
 	log.Infof("Computing Merkle tree rooted at %s", path)
 	root, blobs, stats, err := c.GrpcClient.ComputeMerkleTree(ctx, path, "", "", &command.InputSpec{Inputs: []string{"."}}, filemetadata.NewNoopCache())
 	if err != nil {
-		return digest.Empty, err
+		return nil, err
 	}
 	log.Infof("Directory root digest: %v", root)
 	log.Infof("Directory stats: %d files, %d directories, %d symlinks, %d total bytes", stats.InputFiles, stats.InputDirectories, stats.InputSymlinks, stats.TotalInputBytes)
 	log.Infof("Uploading directory %v rooted at %s to CAS.", root, path)
-	_, _, err = c.GrpcClient.UploadIfMissing(ctx, blobs...)
-	return root, err
+	missing, n, err := c.GrpcClient.UploadIfMissing(ctx, blobs...)
+	if err != nil {
+		return nil, err
+	}
+	var sumMissingBytes int64
+	for _, d := range missing {
+		sumMissingBytes += d.Size
+	}
+	us := &UploadStats{
+		TreeStats:               *stats,
+		RootDigest:              root,
+		TotalNumBlobs:           int64(len(blobs)),
+		NumCacheMisses:          int64(len(missing)),
+		CompressedBytesUploaded: n,
+		CacheMissesBytes:        sumMissingBytes,
+	}
+	return us, nil
 }
 
 func (c *Client) writeProto(m proto.Message, baseName string) error {


### PR DESCRIPTION
Followup to https://github.com/bazelbuild/remote-apis-sdks/pull/532

This does the simplest thing possible for now -- we can always add more keys by creating a custom struct that we return from all tool operations, and marshalling that as json.