### PR TITLE
Fix GetTree fakes

### DIFF
--- a/go/pkg/fakes/cas.go
+++ b/go/pkg/fakes/cas.go
@@ -542,27 +542,12 @@ func (f *CAS) GetTree(req *repb.GetTreeRequest, stream regrpc.ContentAddressable
 	rootDir := &repb.Directory{}
 	proto.Unmarshal(blob, rootDir)
 
-	res := []*repb.Directory{rootDir}
+	res := []*repb.Directory{}
 	queue := []*repb.Directory{rootDir}
 	for len(queue) > 0 {
 		ele := queue[0]
 		res = append(res, ele)
 		queue = queue[1:]
-
-		for _, inpFile := range ele.GetFiles() {
-			fd, err := digest.NewFromProto(inpFile.GetDigest())
-			if err != nil {
-				return fmt.Errorf("unable to parse file digest %v", inpFile.GetDigest())
-			}
-			blob, ok := f.Get(fd)
-			if !ok {
-				return fmt.Errorf("file digest %v not found", fd)
-			}
-			dir := &repb.Directory{}
-			proto.Unmarshal(blob, dir)
-			queue = append(queue, dir)
-			res = append(res, dir)
-		}
 
 		for _, dir := range ele.GetDirectories() {
 			fd, err := digest.NewFromProto(dir.GetDigest())
@@ -576,7 +561,6 @@ func (f *CAS) GetTree(req *repb.GetTreeRequest, stream regrpc.ContentAddressable
 			directory := &repb.Directory{}
 			proto.Unmarshal(blob, directory)
 			queue = append(queue, directory)
-			res = append(res, directory)
 		}
 	}
 


### PR DESCRIPTION
`GetTree` was iterating over the `FileNode`s and trying to parse the blob as a `Directory`, it should only need to iterate over the `DirectoryNode`s. It was also adding the `Directory` to the `res`ult list when adding and removing the `Directory` from the queue, doubling the output.

The output now matches the RBE server, at least for a simple example.