### PR TITLE
Extend Virtual Inputs to allow digests

### DIFF
--- a/go/pkg/client/cas_upload.go
+++ b/go/pkg/client/cas_upload.go
@@ -287,7 +287,7 @@ func (c *Client) uploadUnified(ctx context.Context, entries ...*uploadinfo.Entry
 			contextmd.Infof(ctx, log.Level(2), "Skipping upload of empty entry %s", ue.Digest)
 			continue
 		}
-		if ue.IsVirtualInputWithDigest() {
+		if ue.IsVirtualFile() {
 			return nil, 0, fmt.Errorf("virtual input with digest: %s provided, but does not exist in CAS", ue.Digest)
 		}
 		req := &uploadRequest{

--- a/go/pkg/client/cas_upload.go
+++ b/go/pkg/client/cas_upload.go
@@ -287,6 +287,9 @@ func (c *Client) uploadUnified(ctx context.Context, entries ...*uploadinfo.Entry
 			contextmd.Infof(ctx, log.Level(2), "Skipping upload of empty entry %s", ue.Digest)
 			continue
 		}
+		if ue.IsVirtualInput && ue.IsFile() {
+			return nil, 0, fmt.Errorf("virtual input with digest: %s provided, but does not exist in CAS", ue.Digest)
+		}
 		req := &uploadRequest{
 			ue:   ue,
 			meta: meta,

--- a/go/pkg/client/cas_upload.go
+++ b/go/pkg/client/cas_upload.go
@@ -288,7 +288,7 @@ func (c *Client) uploadUnified(ctx context.Context, entries ...*uploadinfo.Entry
 			continue
 		}
 		if ue.IsVirtualFile() {
-			return nil, 0, fmt.Errorf("virtual input with digest: %s provided, but does not exist in CAS", ue.Digest)
+			return nil, 0, fmt.Errorf("virtual input with digest %q provided, but does not exist in CAS", ue.Digest)
 		}
 		req := &uploadRequest{
 			ue:   ue,

--- a/go/pkg/client/cas_upload.go
+++ b/go/pkg/client/cas_upload.go
@@ -287,7 +287,7 @@ func (c *Client) uploadUnified(ctx context.Context, entries ...*uploadinfo.Entry
 			contextmd.Infof(ctx, log.Level(2), "Skipping upload of empty entry %s", ue.Digest)
 			continue
 		}
-		if ue.IsVirtualInput && ue.IsFile() {
+		if ue.IsVirtualInputWithDigest() {
 			return nil, 0, fmt.Errorf("virtual input with digest: %s provided, but does not exist in CAS", ue.Digest)
 		}
 		req := &uploadRequest{

--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -445,7 +445,7 @@ func (c *Client) ComputeMerkleTree(ctx context.Context, execRoot, workingDir, re
 		}
 		entry := uploadinfo.EntryFromBlob(i.Contents)
 		if i.InputDigest != "" {
-			dg, err := digest.NewFromString(i.InputDigest);
+			dg, err := digest.NewFromString(i.InputDigest)
 			if err != nil {
 				return digest.Empty, nil, nil, err
 			}

--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -440,16 +440,18 @@ func (c *Client) ComputeMerkleTree(ctx context.Context, execRoot, workingDir, re
 			}
 			continue
 		}
-		if i.InputDigest != "" && i.Contents != nil {
+		if i.InputDigest != "" && len(i.Contents) > 0 {
 			return digest.Empty, nil, nil, errors.New("digest and file content cannot be provided for the same virtual input")
 		}
-		entry := uploadinfo.EntryFromBlob(i.Contents)
+		var entry *uploadinfo.Entry
 		if i.InputDigest != "" {
 			dg, err := digest.NewFromString(i.InputDigest)
 			if err != nil {
 				return digest.Empty, nil, nil, err
 			}
-			entry = uploadinfo.EntryFromFile(dg, normPath)
+			entry = uploadinfo.EntryFromRemoteFile(dg, normPath)
+		} else {
+			entry = uploadinfo.EntryFromBlob(i.Contents)
 		}
 		entry.IsVirtualInput = true
 		fs[remoteNormPath] = &fileSysNode{

--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -440,9 +440,21 @@ func (c *Client) ComputeMerkleTree(ctx context.Context, execRoot, workingDir, re
 			}
 			continue
 		}
+		if i.InputDigest != "" && i.Contents != nil {
+			return digest.Empty, nil, nil, errors.New("digest and file content cannot be provided for the same virtual input")
+		}
+		entry := uploadinfo.EntryFromBlob(i.Contents)
+		if i.InputDigest != "" {
+			dg, err := digest.NewFromString(i.InputDigest);
+			if err != nil {
+				return digest.Empty, nil, nil, err
+			}
+			entry = uploadinfo.EntryFromFile(dg, normPath)
+		}
+		entry.IsVirtualInput = true
 		fs[remoteNormPath] = &fileSysNode{
 			file: &fileNode{
-				ue:           uploadinfo.EntryFromBlob(i.Contents),
+				ue:           entry,
 				isExecutable: i.IsExecutable,
 			},
 			nodeProperties: np,

--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -440,20 +440,19 @@ func (c *Client) ComputeMerkleTree(ctx context.Context, execRoot, workingDir, re
 			}
 			continue
 		}
-		if i.InputDigest != "" && len(i.Contents) > 0 {
+		if i.Digest != "" && len(i.Contents) > 0 {
 			return digest.Empty, nil, nil, errors.New("digest and file content cannot be provided for the same virtual input")
 		}
 		var entry *uploadinfo.Entry
-		if i.InputDigest != "" {
-			dg, err := digest.NewFromString(i.InputDigest)
+		if i.Digest != "" {
+			dg, err := digest.NewFromString(i.Digest)
 			if err != nil {
 				return digest.Empty, nil, nil, err
 			}
-			entry = uploadinfo.EntryFromRemoteFile(dg, normPath)
+			entry = uploadinfo.EntryFromVirtualFile(dg, normPath)
 		} else {
 			entry = uploadinfo.EntryFromBlob(i.Contents)
 		}
-		entry.IsVirtualInput = true
 		fs[remoteNormPath] = &fileSysNode{
 			file: &fileNode{
 				ue:           entry,

--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -449,7 +449,8 @@ func (c *Client) ComputeMerkleTree(ctx context.Context, execRoot, workingDir, re
 			if err != nil {
 				return digest.Empty, nil, nil, err
 			}
-			entry = uploadinfo.EntryFromVirtualFile(dg, normPath)
+			absPath := filepath.Join(execRoot, normPath)
+			entry = uploadinfo.EntryFromVirtualFile(dg, absPath)
 		} else {
 			entry = uploadinfo.EntryFromBlob(i.Contents)
 		}

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -1467,8 +1467,8 @@ func TestComputeMerkleTree(t *testing.T) {
 			desc: "Virtual inputs with digests",
 			spec: &command.InputSpec{
 				VirtualInputs: []*command.VirtualInput{
-					&command.VirtualInput{Path: "fooDir/foo", InputDigest: fooDg.String(), IsExecutable: true},
-					&command.VirtualInput{Path: "barDir/bar", InputDigest: barDg.String()},
+					&command.VirtualInput{Path: "fooDir/foo", Digest: fooDg.String(), IsExecutable: true},
+					&command.VirtualInput{Path: "barDir/bar", Digest: barDg.String()},
 				},
 				InputNodeProperties: map[string]*cpb.NodeProperties{"fooDir/foo": fooProperties},
 			},
@@ -1590,7 +1590,7 @@ func TestComputeMerkleTree(t *testing.T) {
 				t.Errorf("ComputeMerkleTree(...) = gave error %q, want success", err)
 			}
 			for _, ue := range inputs {
-				if ue.IsVirtualInputWithDigest() {
+				if ue.IsVirtualFile() {
 					gotBlobs[ue.Digest] = tc.digesttoBlob[ue.Digest]
 					continue
 				}
@@ -1654,7 +1654,7 @@ func TestComputeMerkleTreeErrors(t *testing.T) {
 			desc: "virtual input specifies content and digest",
 			spec: &command.InputSpec{
 				VirtualInputs: []*command.VirtualInput{
-					&command.VirtualInput{Path: "", Contents: fooBlob, InputDigest: fooDg.String()},
+					&command.VirtualInput{Path: "", Contents: fooBlob, Digest: fooDg.String()},
 				},
 			},
 		},
@@ -1662,7 +1662,7 @@ func TestComputeMerkleTreeErrors(t *testing.T) {
 			desc: "virtual input has invalid digest",
 			spec: &command.InputSpec{
 				VirtualInputs: []*command.VirtualInput{
-					&command.VirtualInput{Path: "", InputDigest: "Not a real digest"},
+					&command.VirtualInput{Path: "", Digest: "Not a real digest"},
 				},
 			},
 		},

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -1476,7 +1476,7 @@ func TestComputeMerkleTree(t *testing.T) {
 				{Name: "barDir", Digest: barDirDgPb},
 				{Name: "fooDir", Digest: fooDirDgPb},
 			}},
-			additionalBlobs: [][]byte{fooBlob, barBlob, fooDirBlob, barDirBlob},
+			additionalBlobs: [][]byte{fooDirBlob, barDirBlob},
 			digesttoBlob: map[digest.Digest][]byte{
 				fooDg: fooBlob,
 				barDg: barBlob,
@@ -1591,7 +1591,6 @@ func TestComputeMerkleTree(t *testing.T) {
 			}
 			for _, ue := range inputs {
 				if ue.IsVirtualFile() {
-					gotBlobs[ue.Digest] = tc.digesttoBlob[ue.Digest]
 					continue
 				}
 				ch, err := chunker.New(ue, false, int(e.Client.GrpcClient.ChunkMaxSize))

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -1590,7 +1590,7 @@ func TestComputeMerkleTree(t *testing.T) {
 				t.Errorf("ComputeMerkleTree(...) = gave error %q, want success", err)
 			}
 			for _, ue := range inputs {
-				if ue.IsVirtualInput && ue.IsFile() {
+				if ue.IsVirtualInputWithDigest() {
 					gotBlobs[ue.Digest] = tc.digesttoBlob[ue.Digest]
 					continue
 				}

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -462,7 +462,6 @@ func TestComputeMerkleTree(t *testing.T) {
 		// blobs.
 		rootDir         *repb.Directory
 		additionalBlobs [][]byte
-		digesttoBlob    map[digest.Digest][]byte
 		wantCacheCalls  map[string]int
 		// The expected wantStats.TotalInputBytes is calculated by adding the marshalled rootDir size.
 		wantStats *client.TreeStats
@@ -1477,10 +1476,6 @@ func TestComputeMerkleTree(t *testing.T) {
 				{Name: "fooDir", Digest: fooDirDgPb},
 			}},
 			additionalBlobs: [][]byte{fooDirBlob, barDirBlob},
-			digesttoBlob: map[digest.Digest][]byte{
-				fooDg: fooBlob,
-				barDg: barBlob,
-			},
 			wantStats: &client.TreeStats{
 				InputDirectories: 3,
 				InputFiles:       2,

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -462,6 +462,7 @@ func TestComputeMerkleTree(t *testing.T) {
 		// blobs.
 		rootDir         *repb.Directory
 		additionalBlobs [][]byte
+		digesttoBlob	map[digest.Digest][]byte
 		wantCacheCalls  map[string]int
 		// The expected wantStats.TotalInputBytes is calculated by adding the marshalled rootDir size.
 		wantStats *client.TreeStats
@@ -1463,6 +1464,30 @@ func TestComputeMerkleTree(t *testing.T) {
 			},
 		},
 		{
+			desc: "Virtual inputs with digests",
+			spec: &command.InputSpec{
+				VirtualInputs: []*command.VirtualInput{
+					&command.VirtualInput{Path: "fooDir/foo", InputDigest: fooDg.String(), IsExecutable: true},
+					&command.VirtualInput{Path: "barDir/bar", InputDigest: barDg.String()},
+				},
+				InputNodeProperties: map[string]*cpb.NodeProperties{"fooDir/foo": fooProperties},
+			},
+			rootDir: &repb.Directory{Directories: []*repb.DirectoryNode{
+				{Name: "barDir", Digest: barDirDgPb},
+				{Name: "fooDir", Digest: fooDirDgPb},
+			}},
+			additionalBlobs: [][]byte{fooBlob, barBlob, fooDirBlob, barDirBlob},
+			digesttoBlob: map[digest.Digest][]byte{
+				fooDg: fooBlob,
+				barDg: barBlob,
+			},
+			wantStats: &client.TreeStats{
+				InputDirectories: 3,
+				InputFiles:       2,
+				TotalInputBytes:  fooDg.Size + fooDirDg.Size + barDg.Size + barDirDg.Size,
+			},
+		},
+		{
 			// NOTE: The use of maps in our implementation means that the traversal order is unstable. The
 			// outputs are required to be in lexicographic order, so if ComputeMerkleTree is not sorting
 			// correctly, this test will fail (except in the rare occasion the traversal order is
@@ -1565,6 +1590,10 @@ func TestComputeMerkleTree(t *testing.T) {
 				t.Errorf("ComputeMerkleTree(...) = gave error %q, want success", err)
 			}
 			for _, ue := range inputs {
+				if ue.IsVirtualInput && ue.IsFile() {
+					gotBlobs[ue.Digest] = tc.digesttoBlob[ue.Digest]
+					continue
+				}
 				ch, err := chunker.New(ue, false, int(e.Client.GrpcClient.ChunkMaxSize))
 				if err != nil {
 					t.Fatalf("chunker.New(ue): failed to create chunker from UploadEntry: %v", err)
@@ -1618,6 +1647,22 @@ func TestComputeMerkleTreeErrors(t *testing.T) {
 			spec: &command.InputSpec{
 				VirtualInputs: []*command.VirtualInput{
 					&command.VirtualInput{Path: "", Contents: []byte("foo")},
+				},
+			},
+		},
+		{
+			desc: "virtual input specifies content and digest",
+			spec: &command.InputSpec{
+				VirtualInputs: []*command.VirtualInput{
+					&command.VirtualInput{Path: "", Contents: fooBlob, InputDigest: fooDg.String()},
+				},
+			},
+		},
+		{
+			desc: "virtual input has invalid digest",
+			spec: &command.InputSpec{
+				VirtualInputs: []*command.VirtualInput{
+					&command.VirtualInput{Path: "", InputDigest: "Not a real digest"},
 				},
 			},
 		},

--- a/go/pkg/client/tree_test.go
+++ b/go/pkg/client/tree_test.go
@@ -462,7 +462,7 @@ func TestComputeMerkleTree(t *testing.T) {
 		// blobs.
 		rootDir         *repb.Directory
 		additionalBlobs [][]byte
-		digesttoBlob	map[digest.Digest][]byte
+		digesttoBlob    map[digest.Digest][]byte
 		wantCacheCalls  map[string]int
 		// The expected wantStats.TotalInputBytes is calculated by adding the marshalled rootDir size.
 		wantStats *client.TreeStats

--- a/go/pkg/command/command.go
+++ b/go/pkg/command/command.go
@@ -90,7 +90,7 @@ type VirtualInput struct {
 
 	// The digest of the virtual input that is expected to exist in the CAS.
 	// Should not be used together with Contents.
-	InputDigest string
+	Digest string
 
 	// Whether the file should be staged as executable.
 	IsExecutable bool

--- a/go/pkg/command/command.go
+++ b/go/pkg/command/command.go
@@ -88,6 +88,10 @@ type VirtualInput struct {
 	// The byte contents of the file to be staged.
 	Contents []byte
 
+	// The digest of the virtual input that is expected to exist in the CAS.
+	// Should not be used together with Contents.
+	InputDigest string
+
 	// Whether the file should be staged as executable.
 	IsExecutable bool
 

--- a/go/pkg/uploadinfo/entry.go
+++ b/go/pkg/uploadinfo/entry.go
@@ -19,6 +19,7 @@ type Entry struct {
 	Digest   digest.Digest
 	Contents []byte
 	Path     string
+	IsVirtualInput bool
 
 	ueType int
 }

--- a/go/pkg/uploadinfo/entry.go
+++ b/go/pkg/uploadinfo/entry.go
@@ -16,9 +16,9 @@ const (
 // Should be created using constructor. Only Contents or Path must be set.
 // In case of a malformed entry, Contents takes precedence over Path.
 type Entry struct {
-	Digest   digest.Digest
-	Contents []byte
-	Path     string
+	Digest         digest.Digest
+	Contents       []byte
+	Path           string
 	IsVirtualInput bool
 
 	ueType int

--- a/go/pkg/uploadinfo/entry.go
+++ b/go/pkg/uploadinfo/entry.go
@@ -10,6 +10,7 @@ import (
 const (
 	ueBlob = iota
 	uePath
+	ueFile
 )
 
 // Entry should remain immutable upon creation.
@@ -72,7 +73,7 @@ func EntryFromVirtualFile(dg digest.Digest, path string) *Entry {
 	return &Entry{
 		Digest:      dg,
 		Path:        path,
-		ueType:      ueBlob,
+		ueType:      ueFile,
 		virtualFile: true,
 	}
 }

--- a/go/pkg/uploadinfo/entry.go
+++ b/go/pkg/uploadinfo/entry.go
@@ -10,7 +10,6 @@ import (
 const (
 	ueBlob = iota
 	uePath
-	ueFile
 )
 
 // Entry should remain immutable upon creation.
@@ -73,7 +72,7 @@ func EntryFromVirtualFile(dg digest.Digest, path string) *Entry {
 	return &Entry{
 		Digest:      dg,
 		Path:        path,
-		ueType:      ueFile,
+		ueType:      uePath,
 		virtualFile: true,
 	}
 }

--- a/go/pkg/uploadinfo/entry.go
+++ b/go/pkg/uploadinfo/entry.go
@@ -34,6 +34,12 @@ func (ue *Entry) IsFile() bool {
 	return ue.ueType == uePath
 }
 
+// IsVirtualInputWithDigest returns whether this Entry is a
+// VirtualInput that was provided with a digest and no Content.
+func (ue *Entry) IsVirtualInputWithDigest() bool {
+	return ue.IsVirtualInput && !(len(ue.Contents) > 0)
+}
+
 // EntryFromBlob creates an Entry from an in memory blob.
 func EntryFromBlob(blob []byte) *Entry {
 	return &Entry{
@@ -58,5 +64,15 @@ func EntryFromFile(dg digest.Digest, path string) *Entry {
 		Digest: dg,
 		Path:   path,
 		ueType: uePath,
+	}
+}
+
+// EntryFromRemoteFile creates an entry from a file not on disk.
+// The digest is expected to exist in the CAS.
+func EntryFromRemoteFile(dg digest.Digest, path string) *Entry {
+	return &Entry{
+		Digest: dg,
+		Path:   path,
+		ueType: ueBlob,
 	}
 }

--- a/go/pkg/uploadinfo/entry.go
+++ b/go/pkg/uploadinfo/entry.go
@@ -16,12 +16,12 @@ const (
 // Should be created using constructor. Only Contents or Path must be set.
 // In case of a malformed entry, Contents takes precedence over Path.
 type Entry struct {
-	Digest         digest.Digest
-	Contents       []byte
-	Path           string
-	IsVirtualInput bool
+	Digest   digest.Digest
+	Contents []byte
+	Path     string
 
-	ueType int
+	ueType      int
+	virtualFile bool
 }
 
 // IsBlob returns whether this Entry is for a blob in memory.
@@ -34,10 +34,9 @@ func (ue *Entry) IsFile() bool {
 	return ue.ueType == uePath
 }
 
-// IsVirtualInputWithDigest returns whether this Entry is a
-// VirtualInput that was provided with a digest and no Content.
-func (ue *Entry) IsVirtualInputWithDigest() bool {
-	return ue.IsVirtualInput && !(len(ue.Contents) > 0)
+// IsVirtualFile returns whether this Entry is a virtual file.
+func (ue *Entry) IsVirtualFile() bool {
+	return ue.virtualFile
 }
 
 // EntryFromBlob creates an Entry from an in memory blob.
@@ -67,12 +66,13 @@ func EntryFromFile(dg digest.Digest, path string) *Entry {
 	}
 }
 
-// EntryFromRemoteFile creates an entry from a file not on disk.
+// EntryFromVirtualFile creates an entry from a file not on disk.
 // The digest is expected to exist in the CAS.
-func EntryFromRemoteFile(dg digest.Digest, path string) *Entry {
+func EntryFromVirtualFile(dg digest.Digest, path string) *Entry {
 	return &Entry{
-		Digest: dg,
-		Path:   path,
-		ueType: ueBlob,
+		Digest:      dg,
+		Path:        path,
+		ueType:      ueBlob,
+		virtualFile: true,
 	}
 }


### PR DESCRIPTION
Allows virtual inputs to be used with digests. If Contents is provided with InputDigest or the digest does not exist in the CAS, return an error.

Bug: b/324349357, https://github.com/bazelbuild/remote-apis-sdks/issues/525