### PR TITLE
Get input output list with symlinks

### DIFF
--- a/go/pkg/fakes/server.go
+++ b/go/pkg/fakes/server.go
@@ -28,7 +28,7 @@ import (
 	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	bsgrpc "google.golang.org/genproto/googleapis/bytestream"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
-	anypb "google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/anypb"
 	dpb "google.golang.org/protobuf/types/known/durationpb"
 	tspb "google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -302,6 +302,21 @@ func (f *InputFile) apply(ac *repb.ActionResult, s *Server, execRoot string) err
 	}
 	s.CAS.Put(bytes)
 	return nil
+}
+
+// InputSymlink to be made available to the fake action.
+type InputSymlink struct {
+	Path    string // newname
+	Content string
+	Target  string // oldname
+}
+
+// Apply puts the target file in the fake CAS and create a symlink in OS.
+func (ins *InputSymlink) apply(ac *repb.ActionResult, s *Server, execRoot string) error {
+	inf := InputFile{Path: ins.Target, Contents: ins.Content}
+	inf.apply(ac, s, execRoot)
+	// create a symlink from oldname to newname
+	return os.Symlink(filepath.Join(execRoot, ins.Target), filepath.Join(execRoot, ins.Path))
 }
 
 // OutputFile is to be added as an output of the fake action.


### PR DESCRIPTION
Add a function, GetIO, to return list of inputs and outputs. 

Note that symlinks with new name: my_sym_link (path), point to a old name: my_origional_file (target) will be represent as a string `my_sym_link->my_origional_file` (from path to target)