### PR TITLE
tool: quote args and handle docker args

### DIFF
--- a/go/pkg/tool/tool.go
+++ b/go/pkg/tool/tool.go
@@ -498,7 +498,15 @@ func (c *Client) writeExecScript(ctx context.Context, cmd *repb.Command, filenam
 	var runActionScript bytes.Buffer
 	runActionFilename := filepath.Join(filepath.Dir(filename), "run_command.sh")
 	wd := cmd.WorkingDirectory
-	execCmd := strings.Join(cmd.GetArguments(), " ")
+	cmdArgs := make([]string, len(cmd.GetArguments()))
+	for i, arg := range cmd.GetArguments() {
+		if strings.Contains(arg, " ") {
+			cmdArgs[i] = fmt.Sprintf("'%s'", arg)
+			continue
+		}
+		cmdArgs[i] = arg
+	}
+	execCmd := strings.Join(cmdArgs, " ")
 	runActionScript.WriteString(shellSprintf("#!/bin/bash\n\n"))
 	runActionScript.WriteString(shellSprintf("# This script is meant to be called by %v.\n", filename))
 	if wd != "" {
@@ -521,16 +529,21 @@ func (c *Client) writeExecScript(ctx context.Context, cmd *repb.Command, filenam
 	}
 
 	var container string
+	var dockerParams string
 	for _, property := range cmd.Platform.GetProperties() {
 		if property.Name == "container-image" {
 			container = strings.TrimPrefix(property.Value, "docker://")
+			continue
+		}
+		if property.Name == "dockerPrivileged" {
+			dockerParams = "--privileged"
 		}
 	}
 	if container == "" {
 		return fmt.Errorf("container-image platform property missing from command proto: %v", cmd)
 	}
 	var execScript bytes.Buffer
-	dockerCmd := shellSprintf("docker run -i -t -w /b/f/w -v `pwd`/input:/b/f/w -v `pwd`/run_command.sh:/b/f/w/run_command.sh %v ./run_command.sh\n", container)
+	dockerCmd := shellSprintf("docker run -i -t -w /b/f/w -v `pwd`/input:/b/f/w -v `pwd`/run_command.sh:/b/f/w/run_command.sh %s %s ./run_command.sh\n", dockerParams, container)
 	execScript.WriteString(shellSprintf("#!/bin/bash\n\n"))
 	execScript.WriteString(shellSprintf("# This script can be used to run the action locally on\n"))
 	execScript.WriteString(shellSprintf("# this machine.\n"))


### PR DESCRIPTION
This is a best effort fix to quote arguments that contains spaces and handle dockerPrivileged platform property which bazel supports.