### PR TITLE
Ignore domain sockets

### DIFF
--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -543,7 +543,7 @@ func (u *uploader) visitPath(ctx context.Context, absPath string, info os.FileIn
 			return nil, err
 		}
 	}
-	
+
 	cacheKey := makeFSCacheKey(absPath, info.Mode().IsRegular(), pathExclude)
 	cached, err := u.fsCache.LoadOrStore(cacheKey, func() (interface{}, error) {
 		switch {

--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -534,6 +534,7 @@ func (u *uploader) visitPath(ctx context.Context, absPath string, info os.FileIn
 	if pathExclude != nil && pathExclude.MatchString(filepath.ToSlash(absPath)) {
 		return nil, nil
 	}
+
 	// Call the Prelude only after checking the pathExclude.
 	if u.Prelude != nil {
 		switch err := u.Prelude(absPath, info.Mode()); {
@@ -544,6 +545,11 @@ func (u *uploader) visitPath(ctx context.Context, absPath string, info os.FileIn
 		}
 	}
 
+	// Ignore domain sockets (as used by git fsmonitor(.
+	if info.Mode()&os.ModeSocket == os.ModeSocket {
+		return nil, nil
+	}
+	
 	cacheKey := makeFSCacheKey(absPath, info.Mode().IsRegular(), pathExclude)
 	cached, err := u.fsCache.LoadOrStore(cacheKey, func() (interface{}, error) {
 		switch {


### PR DESCRIPTION
On the Mac, git fsmonitor uses a domain socket in the .git/ folder to keep track of the fsmonitor process. cas chokes on that (see https://crbug.com/40270112).

Therefore, ignore domain sockets.