### PR TITLE
add a round robin grpc balancer

### DIFF
--- a/go/pkg/balancer/BUILD.bazel
+++ b/go/pkg/balancer/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "gcp_balancer.go",
         "gcp_interceptor.go",
         "gcp_picker.go",
+        "roundrobin.go",
     ],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/balancer",
     visibility = ["//visibility:public"],

--- a/go/pkg/balancer/roundrobin.go
+++ b/go/pkg/balancer/roundrobin.go
@@ -1,0 +1,56 @@
+package balancer
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync/atomic"
+
+	"google.golang.org/grpc"
+)
+
+type roundRobinConnPool struct {
+	grpc.ClientConnInterface
+	io.Closer
+
+	conns []*grpc.ClientConn
+	idx   uint32 // access via sync/atomic
+}
+
+func (p *roundRobinConnPool) Conn() *grpc.ClientConn {
+	i := atomic.AddUint32(&p.idx, 1)
+	return p.conns[i%uint32(len(p.conns))]
+}
+
+func (p *roundRobinConnPool) Close() error {
+	var errs error
+	for _, conn := range p.conns {
+		if err := conn.Close(); err != nil {
+			errs = errors.Join(errs, err)
+		}
+	}
+	return errs
+}
+
+func (p *roundRobinConnPool) Invoke(ctx context.Context, method string, args interface{}, reply interface{}, opts ...grpc.CallOption) error {
+	return p.Conn().Invoke(ctx, method, args, reply, opts...)
+}
+
+func (p *roundRobinConnPool) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	return p.Conn().NewStream(ctx, desc, method, opts...)
+}
+
+type DialFunc func(ctx context.Context) (*grpc.ClientConn, error)
+
+func NewRoundRobinBalancer(ctx context.Context, poolSize int, dialFn DialFunc) (grpc.ClientConnInterface, error) {
+	pool := &roundRobinConnPool{}
+	for i := 0; i < poolSize; i++ {
+		conn, err := dialFn(ctx)
+		if err != nil {
+			defer pool.Close()
+			return nil, err
+		}
+		pool.conns = append(pool.conns, conn)
+	}
+	return pool, nil
+}

--- a/go/pkg/cas/client.go
+++ b/go/pkg/cas/client.go
@@ -28,7 +28,7 @@ import (
 //
 // All fields are considered immutable, and should not be changed.
 type Client struct {
-	conn *grpc.ClientConn
+	conn grpc.ClientConnInterface
 	// InstanceName is the full name of the RBE instance.
 	InstanceName string
 
@@ -234,12 +234,12 @@ func (c *RPCConfig) validate() error {
 
 // NewClient creates a new client with the default configuration.
 // Use client.Dial to create a connection.
-func NewClient(ctx context.Context, conn *grpc.ClientConn, instanceName string) (*Client, error) {
+func NewClient(ctx context.Context, conn grpc.ClientConnInterface, instanceName string) (*Client, error) {
 	return NewClientWithConfig(ctx, conn, instanceName, DefaultClientConfig())
 }
 
 // NewClientWithConfig creates a new client and accepts a configuration.
-func NewClientWithConfig(ctx context.Context, conn *grpc.ClientConn, instanceName string, config ClientConfig) (*Client, error) {
+func NewClientWithConfig(ctx context.Context, conn grpc.ClientConnInterface, instanceName string, config ClientConfig) (*Client, error) {
 	switch err := config.Validate(); {
 	case err != nil:
 		return nil, errors.Wrap(err, "invalid config")

--- a/go/pkg/cas/client.go
+++ b/go/pkg/cas/client.go
@@ -28,7 +28,7 @@ import (
 //
 // All fields are considered immutable, and should not be changed.
 type Client struct {
-	conn grpc.ClientConnInterface
+	conn *grpc.ClientConn
 	// InstanceName is the full name of the RBE instance.
 	InstanceName string
 
@@ -234,12 +234,12 @@ func (c *RPCConfig) validate() error {
 
 // NewClient creates a new client with the default configuration.
 // Use client.Dial to create a connection.
-func NewClient(ctx context.Context, conn grpc.ClientConnInterface, instanceName string) (*Client, error) {
+func NewClient(ctx context.Context, conn *grpc.ClientConn, instanceName string) (*Client, error) {
 	return NewClientWithConfig(ctx, conn, instanceName, DefaultClientConfig())
 }
 
 // NewClientWithConfig creates a new client and accepts a configuration.
-func NewClientWithConfig(ctx context.Context, conn grpc.ClientConnInterface, instanceName string, config ClientConfig) (*Client, error) {
+func NewClientWithConfig(ctx context.Context, conn *grpc.ClientConn, instanceName string, config ClientConfig) (*Client, error) {
 	switch err := config.Validate(); {
 	case err != nil:
 		return nil, errors.Wrap(err, "invalid config")

--- a/go/pkg/client/capabilities.go
+++ b/go/pkg/client/capabilities.go
@@ -65,12 +65,12 @@ func (c *Client) GetCapabilities(ctx context.Context) (res *repb.ServerCapabilit
 // be determined from that; ExecutionCapabilities will always come from the main URL.
 func (c *Client) GetCapabilitiesForInstance(ctx context.Context, instance string) (res *repb.ServerCapabilities, err error) {
 	req := &repb.GetCapabilitiesRequest{InstanceName: instance}
-	caps, err := c.GetBackendCapabilities(ctx, c.Connection, req)
+	caps, err := c.GetBackendCapabilities(ctx, c.Connection(), req)
 	if err != nil {
 		return nil, err
 	}
-	if c.CASConnection != c.Connection {
-		casCaps, err := c.GetBackendCapabilities(ctx, c.CASConnection, req)
+	if c.CASConnection() != c.Connection() {
+		casCaps, err := c.GetBackendCapabilities(ctx, c.CASConnection(), req)
 		if err != nil {
 			return nil, err
 		}

--- a/go/pkg/fakes/server.go
+++ b/go/pkg/fakes/server.go
@@ -83,7 +83,7 @@ func (s *Server) NewTestClient(ctx context.Context) (*rc.Client, error) {
 }
 
 // NewClientConn returns a gRPC client connction to the server.
-func (s *Server) NewClientConn(ctx context.Context) (*grpc.ClientConn, error) {
+func (s *Server) NewClientConn(ctx context.Context) (grpc.ClientConnInterface, error) {
 	p := s.dialParams()
 	conn, _, err := client.Dial(ctx, p.Service, p)
 	return conn, err

--- a/go/pkg/fakes/server.go
+++ b/go/pkg/fakes/server.go
@@ -83,10 +83,13 @@ func (s *Server) NewTestClient(ctx context.Context) (*rc.Client, error) {
 }
 
 // NewClientConn returns a gRPC client connction to the server.
-func (s *Server) NewClientConn(ctx context.Context) (grpc.ClientConnInterface, error) {
+func (s *Server) NewClientConn(ctx context.Context) (*grpc.ClientConn, error) {
 	p := s.dialParams()
-	conn, _, err := client.Dial(ctx, p.Service, p)
-	return conn, err
+	opts, _, err := client.OptsFromParams(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+	return grpc.Dial(p.Service, opts...)
 }
 
 func (s *Server) dialParams() rc.DialParams {

--- a/go/pkg/flags/flags.go
+++ b/go/pkg/flags/flags.go
@@ -76,7 +76,7 @@ var (
 	KeepAlivePermitWithoutStream = flag.Bool("grpc_keepalive_permit_without_stream", false, "If true, client sends keepalive pings even with no active RPCs; otherwise, doesn't send pings even if time and timeout are set. Default is false.")
 	// UseRoundRobinBalancer is a temporary feature flag to rollout a simplified load balancer.
 	// See http://go/remote-apis-sdks/issues/499
-	UseRoundRobinBalancer = flag.Bool("use_simple_balancer", false, "If true, a simple round-robin connection bool is used for gRPC. Otherwise, the existing load balancer is used.")
+	UseRoundRobinBalancer = flag.Bool("use_round_robin_balancer", false, "If true, a round-robin connection bool is used for gRPC. Otherwise, the existing load balancer is used.")
 	// RoundRobinBalancerPoolSize specifies the pool size for the round robin balancer.
 	RoundRobinBalancerPoolSize = flag.Int("round_robin_balancer_pool_size", client.DefaultMaxConcurrentRequests, "pool size for round robin grpc balacner")
 )

--- a/go/pkg/flags/flags.go
+++ b/go/pkg/flags/flags.go
@@ -74,6 +74,11 @@ var (
 	KeepAliveTimeout = flag.Duration("grpc_keepalive_timeout", 20*time.Second, "After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. Default is 20s.")
 	// KeepAlivePermitWithoutStream specifies gRPCs keepalive permitWithoutStream parameter.
 	KeepAlivePermitWithoutStream = flag.Bool("grpc_keepalive_permit_without_stream", false, "If true, client sends keepalive pings even with no active RPCs; otherwise, doesn't send pings even if time and timeout are set. Default is false.")
+	// UseRoundRobinBalancer is a temporary feature flag to rollout a simplified load balancer.
+	// See http://go/remote-apis-sdks/issues/499
+	UseRoundRobinBalancer = flag.Bool("use_simple_balancer", false, "If true, a simple round-robin connection bool is used for gRPC. Otherwise, the existing load balancer is used.")
+	// RoundRobinBalancerPoolSize specifies the pool size for the round robin balancer.
+	RoundRobinBalancerPoolSize = flag.Int("round_robin_balancer_pool_size", client.DefaultMaxConcurrentRequests, "pool size for round robin grpc balacner")
 )
 
 func init() {
@@ -145,5 +150,7 @@ func NewClientFromFlags(ctx context.Context, opts ...client.Opt) (*client.Client
 		TLSClientAuthKey:      *TLSClientAuthKey,
 		MaxConcurrentRequests: uint32(*MaxConcurrentRequests),
 		MaxConcurrentStreams:  uint32(*MaxConcurrentStreams),
+		RoundRobinBalancer:    *UseRoundRobinBalancer,
+		RoundRobinPoolSize:    *RoundRobinBalancerPoolSize,
 	}, opts...)
 }

--- a/go/pkg/tool/tool.go
+++ b/go/pkg/tool/tool.go
@@ -287,7 +287,7 @@ func (c *Client) UploadBlob(ctx context.Context, path string) error {
 
 // UploadBlobV2 uploads a blob from the specified path into the remote cache using newer cas implementation.
 func (c *Client) UploadBlobV2(ctx context.Context, path string) error {
-	casC, err := cas.NewClient(ctx, c.GrpcClient.Connection, c.GrpcClient.InstanceName)
+	casC, err := cas.NewClient(ctx, c.GrpcClient.Connection(), c.GrpcClient.InstanceName)
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
This replaces the current load balancer which was copied over from the gcp repo which uses experimental APIs from grpc-go.

Depending on experimental APIs marks the SDK as experimental as well. It also complicates importing the SDK to google3 where everything must be compatbile at head.

This major difference between this simple implementation and the existing one is the maximum number of streams allowed on a single connection.
The existing balancer limits streams to 3 by default and allows configuring that limit.
The new simpler implementation does not enforce any limit.

I have tested the simple balancer by building chromium and android with and without it enabled. I observed no difference in build latency.