### PR TITLE
Ignore directories without read permissions

### DIFF
--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -116,7 +116,7 @@ func shouldIgnoreErr(err error) bool {
 	if e, ok := err.(*filemetadata.FileError); ok {
 		return os.IsPermission(e.Err)
 	}
-	return false
+	return os.IsPermission(err)
 }
 
 func getRelPath(base, path string) (string, error) {
@@ -367,6 +367,9 @@ func loadFiles(execRoot, localWorkingDir, remoteWorkingDir string, excl []*comma
 
 			f, err := os.Open(absPath)
 			if err != nil {
+				if shouldIgnoreErr(err) {
+					continue
+				}
 				return err
 			}
 


### PR DESCRIPTION
Currently we check if we can read the metadata from the file/directory. Even if we can stat the file, it does not necessarily mean we have permissions to open the file/directory. This becomes a problem when we try to open the directory when computing the merkle tree and we don't have read permissions.