### PR TITLE
Use longer timeouts for downloading and uploading data

### DIFF
--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -798,6 +798,8 @@ var DefaultRPCTimeouts = map[string]time.Duration{
 	"GetCapabilities":  5 * time.Second,
 	"BatchUpdateBlobs": time.Minute,
 	"BatchReadBlobs":   time.Minute,
+	"Read":             time.Minute,
+	"Write":            time.Minute,
 	"GetTree":          time.Minute,
 	// Note: due to an implementation detail, WaitExecution will use the same
 	// per-RPC timeout as Execute. It is extremely ill-advised to set the Execute


### PR DESCRIPTION
By default only 20 seconds were used as a timeout.

Read and Write operations should be at least the same as BatchReadBlobs and BatchUpdateBlobs.

In practice it would be best to increase timeouts for Read and Write operations as streaming large objects (like 200-300MB) may take longer on a slow or busy network.