### PR TITLE
Preserve symlinks when using remotetool. This preserves the input tree

### DIFF
--- a/go/pkg/tool/tool.go
+++ b/go/pkg/tool/tool.go
@@ -140,6 +140,7 @@ func (c *Client) prepCommand(ctx context.Context, client *rexec.Client, actionDi
 	cmd := command.FromREProto(commandProto)
 	cmd.InputSpec.Inputs = inputPaths
 	cmd.InputSpec.InputNodeProperties = nodeProperties
+	cmd.InputSpec.SymlinkBehavior = command.PreserveSymlink
 	cmd.ExecRoot = inputRoot
 	if actionProto.Timeout != nil {
 		cmd.Timeout = actionProto.Timeout.AsDuration()


### PR DESCRIPTION
Preserve symlinks in the remotetool to reexecute an action as is, making reproducing actions correct.