### PR TITLE
Add tool version to rpl log

### DIFF
--- a/go/pkg/command/command.go
+++ b/go/pkg/command/command.go
@@ -874,6 +874,7 @@ func ToProto(cmd *Command) *cpb.Command {
 			CommandId:    cmd.Identifiers.CommandID,
 			InvocationId: cmd.Identifiers.InvocationID,
 			ToolName:     cmd.Identifiers.ToolName,
+			ToolVersion:  cmd.Identifiers.ToolVersion,
 			ExecutionId:  cmd.Identifiers.ExecutionID,
 		}
 	}


### PR DESCRIPTION
Add tool version to ToProto() method, so that this information is captured in the rpl log.