### PR TITLE
Add auxiliary metadata for cache hit actions

### DIFF
--- a/go/pkg/rexec/rexec.go
+++ b/go/pkg/rexec/rexec.go
@@ -283,6 +283,7 @@ func (ec *Context) GetCachedResult() {
 		ec.resPb = resPb
 	}
 	if ec.resPb != nil {
+		setAuxiliaryMetadata(ec.Metadata, ec.resPb.GetExecutionMetadata())
 		ec.Result = command.NewResultFromExitCode((int)(ec.resPb.ExitCode))
 		ec.setOutputMetadata()
 		cmdID, executionID := ec.cmd.Identifiers.ExecutionID, ec.cmd.Identifiers.CommandID


### PR DESCRIPTION
Add auxiliary metadata for cache hit actions as well. Previously we only have this for remote execution actions.

Test: run 2 actions with cmake, check the log to see the auxiliary metadata is avaliable for cache hit actions. https://paste.googleplex.com/5312315578908672