### PR TITLE
fix timeout in stream calls

### DIFF
--- a/go/pkg/client/cas_test.go
+++ b/go/pkg/client/cas_test.go
@@ -435,6 +435,9 @@ func TestMissingBlobs(t *testing.T) {
 }
 
 func TestUploadConcurrent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow test because short is set")
+	}
 	t.Parallel()
 	blobs := make([][]byte, 50)
 	for i := range blobs {

--- a/go/pkg/client/retries_test.go
+++ b/go/pkg/client/retries_test.go
@@ -306,6 +306,9 @@ func TestWriteRetries(t *testing.T) {
 }
 
 func TestRetryWriteBytesAtRemoteOffset(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow test because short is set")
+	}
 	tests := []struct {
 		description   string
 		initialOffset int64
@@ -441,6 +444,9 @@ func TestBatchWriteBlobsRpcRetriesExhausted(t *testing.T) {
 }
 
 func TestGetTreeRetries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow test because short is set")
+	}
 	t.Parallel()
 	f := setup(t)
 	defer f.shutDown()


### PR DESCRIPTION
The chunked streaming calls from gRPC do not take a context. The timeout implementation doesn't really timeout because the context is not used. This PR makes it so that the entire gRPC streaming call times out if any individual chunk times out.