### PR TITLE
Ignore unexpected file modes

### DIFF
--- a/go/pkg/cas/upload.go
+++ b/go/pkg/cas/upload.go
@@ -562,10 +562,13 @@ func (u *uploader) visitPath(ctx context.Context, absPath string, info os.FileIn
 		// Ignore all non-expected modes (e.g. domain sockets as used by git
 		// fsmonitor).
 		default:
-			return nil, nil
+			return nil, ErrSkip
 		}
 	})
-	if err != nil {
+	switch {
+	case errors.Is(err, ErrSkip):
+		return nil, nil
+	case err != nil:
 		return nil, err
 	}
 	return cached.(*digested), nil


### PR DESCRIPTION
Correct #549.

The intention was to skip the file with an unexpected mode, but the “nil, nil” return was actually done in a nested function.

Return ErrSkip to escape the nested function, and correctly return “nil, nil” from visitPath, as was intended.