### PR TITLE
Expose Output File Executable Bit

### DIFF
--- a/go/pkg/command/command.go
+++ b/go/pkg/command/command.go
@@ -543,6 +543,8 @@ type Metadata struct {
 	TotalOutputBytes int64
 	// Output File digests.
 	OutputFileDigests map[string]digest.Digest
+	// Output File executable bit.
+	OutputFileIsExecutable map[string]bool
 	// Output Directory digests.
 	OutputDirectoryDigests map[string]digest.Digest
 	// Output Symlinks.

--- a/go/pkg/fakes/server.go
+++ b/go/pkg/fakes/server.go
@@ -310,8 +310,9 @@ func (f *InputFile) apply(ac *repb.ActionResult, s *Server, execRoot string) err
 
 // OutputFile is to be added as an output of the fake action.
 type OutputFile struct {
-	Path     string
-	Contents string
+	Path         string
+	Contents     string
+	IsExecutable bool
 }
 
 // Apply puts the file in the fake CAS and the given ActionResult.
@@ -319,7 +320,7 @@ func (f *OutputFile) apply(ac *repb.ActionResult, s *Server, execRoot string) er
 	bytes := []byte(f.Contents)
 	s.Exec.OutputBlobs = append(s.Exec.OutputBlobs, bytes)
 	dg := s.CAS.Put(bytes)
-	ac.OutputFiles = append(ac.OutputFiles, &repb.OutputFile{Path: f.Path, Digest: dg.ToProto()})
+	ac.OutputFiles = append(ac.OutputFiles, &repb.OutputFile{Path: f.Path, Digest: dg.ToProto(), IsExecutable: f.IsExecutable})
 	return nil
 }
 

--- a/go/pkg/rexec/rexec_test.go
+++ b/go/pkg/rexec/rexec_test.go
@@ -86,6 +86,7 @@ func TestExecCacheHit(t *testing.T) {
 					LogicalBytesDownloaded: 12,
 					RealBytesDownloaded:    12,
 					OutputFileDigests:      map[string]digest.Digest{"a/b/out": digest.NewFromBlob([]byte("output"))},
+					OutputFileIsExecutable: map[string]bool{"a/b/out": false},
 					OutputDirectoryDigests: map[string]digest.Digest{},
 					OutputSymlinks:         map[string]string{},
 					StderrDigest:           stderrDg,
@@ -586,7 +587,7 @@ func TestOutputSymlinks(t *testing.T) {
 	}
 	opt := &command.ExecutionOptions{AcceptCached: true, DownloadOutputs: true, DownloadOutErr: false}
 	wantRes := &command.Result{Status: command.CacheHitResultStatus}
-	cmdDg, acDg, stderrDg, stdoutDg := e.Set(cmd, opt, wantRes, fakes.StdOut("stdout"), fakes.StdErr("stderr"), &fakes.OutputFile{Path: "a/b/out", Contents: "output"}, &fakes.OutputSymlink{Path: "a/b/sl", Target: "out"}, fakes.ExecutionCacheHit(true))
+	cmdDg, acDg, stderrDg, stdoutDg := e.Set(cmd, opt, wantRes, fakes.StdOut("stdout"), fakes.StdErr("stderr"), &fakes.OutputFile{Path: "a/b/out", Contents: "output", IsExecutable: true}, &fakes.OutputSymlink{Path: "a/b/sl", Target: "out"}, fakes.ExecutionCacheHit(true))
 	oe := outerr.NewRecordingOutErr()
 
 	res, meta := e.Client.Run(context.Background(), cmd, opt, oe)
@@ -627,6 +628,7 @@ func TestOutputSymlinks(t *testing.T) {
 		LogicalBytesDownloaded: 6,
 		RealBytesDownloaded:    6,
 		OutputFileDigests:      map[string]digest.Digest{"a/b/out": digest.NewFromBlob([]byte("output"))},
+		OutputFileIsExecutable: map[string]bool{"a/b/out": true},
 		OutputDirectoryDigests: map[string]digest.Digest{},
 		OutputSymlinks:         map[string]string{"a/b/sl": "out"},
 		StderrDigest:           stderrDg,


### PR DESCRIPTION
Expose the output file executable bit in the Metadata object.