### PR TITLE
Do not enforce headers

### DIFF
--- a/go/pkg/credshelper/credshelper.go
+++ b/go/pkg/credshelper/credshelper.go
@@ -282,9 +282,6 @@ func parseTokenExpiryFromOutput(out string) (*credshelperOutput, error) {
 		return nil, fmt.Errorf("no token was printed by the credentials helper")
 	}
 	credsOut.tk = &oauth2.Token{AccessToken: jsonOut.Token}
-	if len(jsonOut.Headers) == 0 {
-		return nil, fmt.Errorf("no headers were printed by the credentials helper")
-	}
 	credsOut.hdrs = jsonOut.Headers
 	if jsonOut.Expiry != "" {
 		expiry, err := time.Parse(time.UnixDate, jsonOut.Expiry)

--- a/go/pkg/credshelper/credshelper_test.go
+++ b/go/pkg/credshelper/credshelper_test.go
@@ -157,8 +157,7 @@ func TestNewExternalCredentials(t *testing.T) {
 		credshelperOut string
 	}{{
 		name:           "No Headers",
-		wantErr:        true,
-		credshelperOut: `{"headers":"","token":"","expiry":"","refresh_expiry":""}`,
+		credshelperOut: fmt.Sprintf(`{"token":"%v","expiry":"","refresh_expiry":""}`, testToken),
 	}, {
 		name:           "No Token",
 		wantErr:        true,


### PR DESCRIPTION
Removing the requirement for headers to be non-empty since it is possible to authenticate directly through token as well.