### PR TITLE
Separate PerRPCCreds from Oauth creds to eliminate undefined behavior

### DIFF
--- a/go/pkg/balancer/BUILD.bazel
+++ b/go/pkg/balancer/BUILD.bazel
@@ -1,14 +1,11 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "balancer",
-    srcs = [
-        "roundrobin.go",
-    ],
+    srcs = ["roundrobin.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/balancer",
     visibility = ["//visibility:public"],
     deps = [
         "@org_golang_google_grpc//:go_default_library",
     ],
 )
-

--- a/go/pkg/credshelper/BUILD.bazel
+++ b/go/pkg/credshelper/BUILD.bazel
@@ -2,32 +2,20 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "credshelper",
-    srcs = [
-        "credshelper.go",
-    ],
+    srcs = ["credshelper.go"],
     importpath = "github.com/bazelbuild/remote-apis-sdks/go/pkg/credshelper",
     visibility = ["//visibility:public"],
     deps = [
-        "//go/api/credshelper",
-	"//go/pkg/digest",
+        "//go/pkg/digest",
         "@com_github_golang_glog//:glog",
-        "@com_github_hectane_go_acl//:go-acl",
+        "@org_golang_google_grpc//credentials",
         "@org_golang_google_grpc//credentials/oauth",
-        "@org_golang_google_protobuf//encoding/prototext",
-        "@org_golang_google_protobuf//types/known/timestamppb",
         "@org_golang_x_oauth2//:oauth2",
-        "@org_golang_x_oauth2//google",
     ],
 )
 
 go_test(
     name = "credshelper_test",
-    srcs = [
-        "credshelper_test.go",
-    ],
+    srcs = ["credshelper_test.go"],
     embed = [":credshelper"],
-    deps = [
-        "@com_github_google_go_cmp//cmp",
-        "@org_golang_x_oauth2//:oauth2",
-    ],
 )

--- a/go/pkg/flags/flags.go
+++ b/go/pkg/flags/flags.go
@@ -121,7 +121,7 @@ func NewClientFromFlags(ctx context.Context, opts ...client.Opt) (*client.Client
 		if err != nil {
 			return nil, fmt.Errorf("credentials helper failed. Please try again or use another method of authentication:%v", err)
 		}
-		perRPCCreds = &client.PerRPCCreds{Creds: creds.TokenSource()}
+		perRPCCreds = &client.PerRPCCreds{Creds: creds.PerRPCCreds()}
 	}
 	opts = tOpts
 


### PR DESCRIPTION
The credentials helper interface now requires that either a token or a headers or both be provided and then creates grpc.credentials.oauth.TokenSource and grpc.credentials.PerRPCCredentials accordingly.