### PR TITLE
Prevent side effects in MergeMetadata by creating new instances

### DIFF
--- a/go/pkg/contextmd/contextmd.go
+++ b/go/pkg/contextmd/contextmd.go
@@ -125,15 +125,20 @@ func MergeMetadata(metas ...*Metadata) *Metadata {
 		return &Metadata{}
 	}
 
-	md := metas[0]
 	actionIds := make(map[string]struct{}, len(metas))
 	invocationIds := make(map[string]struct{}, len(metas))
 	for _, m := range metas {
 		actionIds[m.ActionID] = struct{}{}
 		invocationIds[m.InvocationID] = struct{}{}
 	}
-	md.ActionID = mergeSet(actionIds)
-	md.InvocationID = mergeSet(invocationIds)
+	md := &Metadata{
+		ActionID:                mergeSet(actionIds),
+		InvocationID:            mergeSet(invocationIds),
+		CorrelatedInvocationsID: metas[0].CorrelatedInvocationsID,
+		ToolName:                metas[0].ToolName,
+		ToolVersion:             metas[0].ToolVersion,
+	}
+
 	return md
 }
 


### PR DESCRIPTION
This PR modifies the `MergeMetadata` function to create new instances instead of modifying input arguments, preventing unexpected side effects for SDK users.

fixes #606 
