### PR TITLE
Fix underquoted issues for run_command.sh

### DIFF
--- a/go/pkg/tool/tool.go
+++ b/go/pkg/tool/tool.go
@@ -505,6 +505,10 @@ func (c *Client) writeExecScript(ctx context.Context, cmd *repb.Command, filenam
 			cmdArgs[i] = fmt.Sprintf("'%s'", arg)
 			continue
 		}
+		if strings.HasPrefix(arg, "--cfg") {
+			cmdArgs[i] = fmt.Sprintf("'%s'", arg)
+			continue
+		}
 		cmdArgs[i] = arg
 	}
 	execCmd := strings.Join(cmdArgs, " ")


### PR DESCRIPTION
The --cfg argument can accept these format:
1) '--cfg=key="value"',
2) --cfg='key="value"'
3) --cfg=key=\\"value\\"

but --cfg=key="value" is invalid (no single quote, and also not escaping the double quote).

This CL fix this issue by put the entire --cfg=... string inside of a single quote.