### PR TITLE
Enclose Go Version in Workflow File

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,9 +12,15 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.20" # Must be a string, see https://github.com/onsi/ginkgo/issues/1169#issuecomment-1483839892
+
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/bazelbuild/remote-apis-sdks
 
+// When you update the go version here, you have to also update the 
+// go version in the .github/workflows/golangci-lint.yml file.
 go 1.20
 
 require (


### PR DESCRIPTION
This fix will unblock https://github.com/bazelbuild/remote-apis-sdks/pull/616