### PR TITLE
Fix readStreamedRetried retry in bytestream

### DIFF
--- a/go/pkg/client/bytestream.go
+++ b/go/pkg/client/bytestream.go
@@ -182,7 +182,7 @@ func (c *Client) readStreamed(ctx context.Context, name string, offset, limit in
 			break
 		}
 		if err != nil {
-			return 0, err
+			return n, err
 		}
 		log.V(3).Infof("Read: resource:%s offset:%d len(data):%d", name, offset, len(resp.Data))
 		nm, err := w.Write(resp.Data)


### PR DESCRIPTION
Transient errors are retried by `readStreamedRetried` and it continues reading from how many bytes were already read. When an error happens in the stream call (for example, `DeadlineExceeded`), we were returning that 0 bytes were read.

Since `DeadlineExceeded` is transient, the retry happens and we start from byte 0 again, leading to a lot of duplication.

Note that the other errors return a `fmt.Errorf`, which is not a transient error and won't be retried.

The current behavior seems to be only working to retry at the start of the stream, when no bytes were there yet.