### PR TITLE
Upload channel of blobs

### DIFF
--- a/go/pkg/tool/tool.go
+++ b/go/pkg/tool/tool.go
@@ -304,7 +304,7 @@ func (c *Client) UploadBlobV2(ctx context.Context, path string) error {
 	})
 
 	eg.Go(func() error {
-		_, err := casC.Upload(ctx, cas.UploadOptions{}, inputC)
+		_, err := casC.Upload(ctx, cas.UploadOptions{}, inputC, nil)
 		return err
 	})
 


### PR DESCRIPTION
Re-use the Client.Upload implementation for batching
uploads of files with direct support for uploading blobs.

Change-Id: I0d79ccfc77feafeed92058e65121b31fbaf68055
