### PR TITLE
credshelper accepts bazel credhelper compat GetCredentialsResponse json.

### DIFF
--- a/go/pkg/credshelper/credshelper_test.go
+++ b/go/pkg/credshelper/credshelper_test.go
@@ -116,6 +116,7 @@ func TestNewExternalCredentials(t *testing.T) {
 	exp := time.Now().Add(time.Hour).Truncate(time.Second)
 	expStr := exp.String()
 	unixExp := exp.Format(time.UnixDate)
+	rfc3339Exp := exp.Format(time.RFC3339)
 	tests := []struct {
 		name           string
 		wantErr        bool
@@ -138,6 +139,12 @@ func TestNewExternalCredentials(t *testing.T) {
 		name:           "Wrong Expiry Format",
 		wantErr:        true,
 		credshelperOut: fmt.Sprintf(`{"headers":{"hdr":"val"},"token":"%v","expiry":"%v"}`, testToken, expStr),
+	}, {
+		name:           "bazelCompatAndReclientLegacy",
+		credshelperOut: fmt.Sprintf(`{"headers":{"hdr":["val"]},"token":%q,"expiry":%q, "expires":%q}`, testToken, unixExp, rfc3339Exp),
+	}, {
+		name:           "bazelCompat",
+		credshelperOut: fmt.Sprintf(`{"headers":{"Authorization":["Bearer %s"]},"expires":%q}`, testToken, rfc3339Exp),
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
It would be nice if we can use the same credential helper with bazel's
https://github.com/EngFlow/credential-helper-spec/blob/main/spec.md

This CL allows credshelper package parses GetCredentialsResponse json message of bazel credential helper.