### PR TITLE
fix: correct incomplete path traversal check in getAbsPath

### DIFF
--- a/go/pkg/client/tree.go
+++ b/go/pkg/client/tree.go
@@ -136,7 +136,9 @@ func getAbsPath(base, relPath string) (string, error) {
 		return "", fmt.Errorf("input path %q must be relative to the base directory", relPath)
 	}
 	res := filepath.Clean(filepath.Join(base, relPath))
-	if !strings.HasPrefix(res, base) {
+	// Use separator-aware prefix check to prevent traversal into sibling directories
+	// whose names share a prefix with base (e.g. base="/tmp/out", sibling="/tmp/output").
+	if res != base && !strings.HasPrefix(res, base+string(filepath.Separator)) {
 		return "", fmt.Errorf("path %v is not under %v", relPath, base)
 	}
 	return res, nil

--- a/go/pkg/client/tree_whitebox_test.go
+++ b/go/pkg/client/tree_whitebox_test.go
@@ -11,6 +11,74 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func TestGetAbsPath(t *testing.T) {
+	tests := []struct {
+		desc    string
+		base    string
+		relPath string
+		wantErr bool
+		wantRes string
+	}{
+		{
+			desc:    "simple file under base",
+			base:    "/tmp/output",
+			relPath: "subdir/file.txt",
+			wantRes: "/tmp/output/subdir/file.txt",
+		},
+		{
+			desc:    "base itself",
+			base:    "/tmp/output",
+			relPath: ".",
+			wantRes: "/tmp/output",
+		},
+		{
+			desc:    "absolute path rejected",
+			base:    "/tmp/output",
+			relPath: "/etc/passwd",
+			wantErr: true,
+		},
+		{
+			desc:    "full escape rejected",
+			base:    "/tmp/output",
+			relPath: "../../etc/passwd",
+			wantErr: true,
+		},
+		{
+			// Sibling directory whose name starts with the same prefix as base.
+			// e.g. base="/tmp/output", sibling="/tmp/outputevil"
+			// Previously HasPrefix check was tricked into allowing this.
+			desc:    "sibling directory with shared prefix rejected",
+			base:    "/tmp/output",
+			relPath: "../outputevil/secret",
+			wantErr: true,
+		},
+		{
+			desc:    "another sibling prefix bypass rejected",
+			base:    "/home/user/build/output",
+			relPath: "../outputextra/malware.sh",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			res, err := getAbsPath(tc.base, tc.relPath)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("getAbsPath(%q, %q) = %q, want error", tc.base, tc.relPath, res)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("getAbsPath(%q, %q) unexpected error: %v", tc.base, tc.relPath, err)
+				return
+			}
+			if res != tc.wantRes {
+				t.Errorf("getAbsPath(%q, %q) = %q, want %q", tc.base, tc.relPath, res, tc.wantRes)
+			}
+		})
+	}
+}
+
 func TestGetTargetRelPath(t *testing.T) {
 	execRoot := "/execRoot"
 	defaultSym := "symDir/sym"


### PR DESCRIPTION
## Security Fix

**Vulnerability:** Path Traversal — Incomplete fix bypass in `getAbsPath`
**Severity:** High
**Affected file:** `go/pkg/client/tree.go` (function `getAbsPath`, line 139)

### Root Cause

PR #634 introduced `getAbsPath` to prevent downloaded output files from escaping the designated output directory. However, the containment check uses:

```go
if !strings.HasPrefix(res, base) {
```

This check is insufficient. `strings.HasPrefix` does not verify that the matched prefix ends at a path separator boundary. When the output directory name is a prefix of a sibling directory name, the check incorrectly allows traversal:

```
base    = "/tmp/output"
relPath = "../outputevil/malware.sh"
res     = "/tmp/outputevil/malware.sh"
strings.HasPrefix("/tmp/outputevil/malware.sh", "/tmp/output") = true  ← WRONG
```

### Attack Scenario

A malicious or compromised remote execution server returns an `ActionResult` with output file paths like `../outputevil/secret`. The `getAbsPath` function returns the sibling path with no error, and the SDK writes attacker-controlled content outside the designated output directory.

### Fix

Use a separator-aware prefix check (standard safe pattern for path containment):

```go
if res != base && !strings.HasPrefix(res, base+string(filepath.Separator)) {
```

### Testing

All existing tests pass. Added `TestGetAbsPath` regression tests including the sibling-prefix bypass cases that were previously not caught.