### PR TITLE
fix: prevent path traversal in DownloadActionOutputs and validate symlink targets

### DIFF
--- a/go/pkg/client/cas_download.go
+++ b/go/pkg/client/cas_download.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -147,7 +148,21 @@ func (c *Client) DownloadOutputs(ctx context.Context, outs map[string]*TreeOutpu
 		}
 	}
 	for _, out := range symlinks {
-		if err := os.Symlink(out.SymlinkTarget, filepath.Join(outDir, out.Path)); err != nil {
+		symlinkPath, err := getAbsPath(outDir, out.Path)
+		if err != nil {
+			return fullStats, err
+		}
+		// Validate that the symlink target resolves within outDir to prevent
+		// symlink-based path traversal (e.g. target = "/etc/shadow").
+		target := out.SymlinkTarget
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(symlinkPath), target)
+		}
+		target = filepath.Clean(target)
+		if target != outDir && !strings.HasPrefix(target, outDir+string(filepath.Separator)) {
+			return fullStats, fmt.Errorf("symlink target %q resolves to %q which is outside output directory %q", out.SymlinkTarget, target, outDir)
+		}
+		if err := os.Symlink(out.SymlinkTarget, symlinkPath); err != nil {
 			return fullStats, err
 		}
 	}
@@ -522,7 +537,11 @@ func (c *Client) DownloadActionOutputs(ctx context.Context, resPb *repb.ActionRe
 	}
 	// Remove the existing output directories before downloading.
 	for _, dir := range resPb.OutputDirectories {
-		if err := os.RemoveAll(filepath.Join(outDir, dir.Path)); err != nil {
+		absPath, err := getAbsPath(outDir, dir.Path)
+		if err != nil {
+			return nil, err
+		}
+		if err := os.RemoveAll(absPath); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Summary

Two additional path traversal vectors were found in the download code path, both variants of the issue previously fixed in `getAbsPath`:

### 1. `DownloadActionOutputs`: `os.RemoveAll` with unvalidated `dir.Path`

`DownloadActionOutputs` passes `dir.Path` from the `ActionResult` proto directly to `os.RemoveAll` via `filepath.Join`, bypassing `getAbsPath` validation. A malicious remote execution server could set `OutputDirectories[].Path` to `../../important_data` to delete arbitrary directories on the client filesystem.

The deletion happens at line 525 **before** `DownloadOutputs` (which validates paths via `getAbsPath`) is called at line 529.

### 2. `DownloadOutputs`: Symlink target not validated for containment

When creating symlinks from remote server output, the symlink **placement** path (`out.Path`) is validated via `getAbsPath`, but the symlink **target** (`out.SymlinkTarget`) is used directly from the proto without any validation. A malicious server can set `SymlinkTarget` to `/etc/shadow` or `../../../../etc/passwd`, creating symlinks inside the output directory that point to arbitrary locations on the filesystem.

### Fixes

- Added `getAbsPath` validation in `DownloadActionOutputs` before `os.RemoveAll`
- Added symlink target containment validation in `DownloadOutputs` using the same separator-aware prefix check as `getAbsPath`