### PR TITLE
tool: shell-escape server-controlled fields in writeExecScript

### DIFF
--- a/go/pkg/tool/BUILD.bazel
+++ b/go/pkg/tool/BUILD.bazel
@@ -28,7 +28,10 @@ go_library(
 
 go_test(
     name = "tool_test",
-    srcs = ["tool_test.go"],
+    srcs = [
+        "tool_shellquote_test.go",
+        "tool_test.go",
+    ],
     embed = [":tool"],
     deps = [
         "//go/api/command",

--- a/go/pkg/tool/tool.go
+++ b/go/pkg/tool/tool.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -485,10 +486,18 @@ func (c *Client) DownloadAction(ctx context.Context, actionDigest, outputPath st
 	return nil
 }
 
-// shellSprintf is intended to add args sanitization before using them.
-func shellSprintf(format string, args ...any) string {
-	// TODO: check args for flag injection
-	return fmt.Sprintf(format, args...)
+// posixEnvName matches a POSIX-compatible shell environment variable name.
+// Names that don't match are dropped with a warning rather than emitted as an
+// invalid `export` line in the generated script.
+var posixEnvName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// shellQuote returns s wrapped in single quotes, with any embedded single
+// quotes safely escaped. The returned string is safe to interpolate verbatim
+// into a POSIX shell command. Single-quote wrapping is preferred over double
+// quotes because no character inside a single-quoted string is interpreted by
+// the shell except `'` itself.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 func (c *Client) writeExecScript(ctx context.Context, cmd *repb.Command, filename string) error {
@@ -498,37 +507,36 @@ func (c *Client) writeExecScript(ctx context.Context, cmd *repb.Command, filenam
 
 	var runActionScript bytes.Buffer
 	runActionFilename := filepath.Join(filepath.Dir(filename), "run_command.sh")
-	wd := cmd.WorkingDirectory
 	cmdArgs := make([]string, len(cmd.GetArguments()))
 	for i, arg := range cmd.GetArguments() {
-		if strings.Contains(arg, " ") {
-			cmdArgs[i] = fmt.Sprintf("'%s'", arg)
-			continue
-		}
-		if strings.HasPrefix(arg, "--cfg") {
-			cmdArgs[i] = fmt.Sprintf("'%s'", arg)
-			continue
-		}
-		cmdArgs[i] = arg
+		// Server-controlled values can contain shell metacharacters and even
+		// embedded single quotes; quote unconditionally rather than relying on
+		// "contains a space" heuristics.
+		cmdArgs[i] = shellQuote(arg)
 	}
 	execCmd := strings.Join(cmdArgs, " ")
-	runActionScript.WriteString(shellSprintf("#!/bin/bash\n\n"))
-	runActionScript.WriteString(shellSprintf("# This script is meant to be called by %v.\n", filename))
-	if wd != "" {
-		runActionScript.WriteString(shellSprintf("cd %v\n", wd))
+	runActionScript.WriteString("#!/bin/bash\n\n")
+	fmt.Fprintf(&runActionScript, "# This script is meant to be called by %s.\n", filename)
+	if wd := cmd.WorkingDirectory; wd != "" {
+		fmt.Fprintf(&runActionScript, "cd %s\n", shellQuote(wd))
 	}
 	for _, od := range cmd.GetOutputDirectories() {
-		runActionScript.WriteString(shellSprintf("mkdir -p %v\n", od))
+		fmt.Fprintf(&runActionScript, "mkdir -p %s\n", shellQuote(od))
 	}
 	for _, of := range cmd.GetOutputFiles() {
-		runActionScript.WriteString(shellSprintf("mkdir -p %v\n", filepath.Dir(of)))
+		fmt.Fprintf(&runActionScript, "mkdir -p %s\n", shellQuote(filepath.Dir(of)))
 	}
 	for _, e := range cmd.GetEnvironmentVariables() {
-		runActionScript.WriteString(shellSprintf("export %v=%v\n", e.GetName(), e.GetValue()))
+		name := e.GetName()
+		if !posixEnvName.MatchString(name) {
+			log.Warningf("writeExecScript: skipping environment variable with non-POSIX name: %q", name)
+			continue
+		}
+		fmt.Fprintf(&runActionScript, "export %s=%s\n", name, shellQuote(e.GetValue()))
 	}
 	runActionScript.WriteString(execCmd)
 	runActionScript.WriteRune('\n')
-	runActionScript.WriteString(shellSprintf("bash\n"))
+	runActionScript.WriteString("bash\n")
 	if err := os.WriteFile(runActionFilename, runActionScript.Bytes(), 0755); err != nil {
 		return err
 	}
@@ -548,11 +556,11 @@ func (c *Client) writeExecScript(ctx context.Context, cmd *repb.Command, filenam
 		return fmt.Errorf("container-image platform property missing from command proto: %v", cmd)
 	}
 	var execScript bytes.Buffer
-	execScript.WriteString(shellSprintf("#!/bin/bash\n\n"))
-	execScript.WriteString(shellSprintf("# This script can be used to run the action locally on\n"))
-	execScript.WriteString(shellSprintf("# this machine.\n"))
-	execScript.WriteString(shellSprintf("echo \"WARNING: The results from executing the action through this script may differ from results from RBE.\"\n"))
-	execScript.WriteString(shellSprintf("set -x\n"))
+	execScript.WriteString("#!/bin/bash\n\n")
+	execScript.WriteString("# This script can be used to run the action locally on\n")
+	execScript.WriteString("# this machine.\n")
+	execScript.WriteString("echo \"WARNING: The results from executing the action through this script may differ from results from RBE.\"\n")
+	execScript.WriteString("set -x\n")
 	execScript.WriteString("docker run -i -t -w /b/f/w -v `pwd`/input:/b/f/w -v `pwd`/run_command.sh:/b/f/w/run_command.sh ")
 	execScript.WriteString(dockerParams)
 	execScript.WriteString(" ")

--- a/go/pkg/tool/tool_shellquote_test.go
+++ b/go/pkg/tool/tool_shellquote_test.go
@@ -21,7 +21,7 @@ func runBashScript(t *testing.T, path string) {
 }
 
 // stripSingleQuotedRegions returns line with every single-quoted region
-// (including the standard `'\''` escape sequence for an embedded single quote)
+// (including the standard `'\”` escape sequence for an embedded single quote)
 // removed. The resulting string contains only the parts of the line that bash
 // would parse as unquoted; if any shell metacharacter appears in it, the line
 // is unsafe.

--- a/go/pkg/tool/tool_shellquote_test.go
+++ b/go/pkg/tool/tool_shellquote_test.go
@@ -1,0 +1,269 @@
+package tool
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+)
+
+func runBashScript(t *testing.T, path string) {
+	t.Helper()
+	cmd := exec.Command("/bin/bash", path)
+	// Discard output; we care about side effects (sentinel files), not stdout.
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	_ = cmd.Run()
+}
+
+// stripSingleQuotedRegions returns line with every single-quoted region
+// (including the standard `'\''` escape sequence for an embedded single quote)
+// removed. The resulting string contains only the parts of the line that bash
+// would parse as unquoted; if any shell metacharacter appears in it, the line
+// is unsafe.
+func stripSingleQuotedRegions(line string) string {
+	var out strings.Builder
+	inQuote := false
+	i := 0
+	for i < len(line) {
+		if !inQuote {
+			if line[i] == '\'' {
+				inQuote = true
+				i++
+				continue
+			}
+			out.WriteByte(line[i])
+			i++
+			continue
+		}
+		// Inside a single-quoted region. The only way out is a closing `'`.
+		// The 4-character escape sequence `'\''` represents an embedded `'`:
+		// it ends the current quote, then has a literal `\'`, then re-opens.
+		// Treat it as continuing the quoted region.
+		if line[i] == '\'' && i+3 < len(line) && line[i+1] == '\\' && line[i+2] == '\'' && line[i+3] == '\'' {
+			i += 4
+			continue
+		}
+		if line[i] == '\'' {
+			inQuote = false
+			i++
+			continue
+		}
+		i++
+	}
+	return out.String()
+}
+
+// TestShellQuote verifies the POSIX single-quote escaping primitive used by
+// writeExecScript covers every case that previously allowed shell injection
+// through server-controlled Command fields.
+func TestShellQuote(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", "''"},
+		{"plain", "hello", "'hello'"},
+		{"space", "hello world", "'hello world'"},
+		{"single-quote", "it's", `'it'\''s'`},
+		{"command-substitution", "$(touch /tmp/pwned)", "'$(touch /tmp/pwned)'"},
+		{"backtick", "`id`", "'`id`'"},
+		{"semicolon", "x;rm -rf /tmp", "'x;rm -rf /tmp'"},
+		{"newline", "a\nb", "'a\nb'"},
+		{"escape-attempt", `a' ; touch /tmp/pwned ; '`, `'a'\'' ; touch /tmp/pwned ; '\'''`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shellQuote(tc.in)
+			if got != tc.want {
+				t.Fatalf("shellQuote(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWriteExecScript_NoShellInjection drives writeExecScript with malicious
+// values in every server-controlled Command field and asserts that none of the
+// shell metacharacters reach the generated script unquoted.
+func TestWriteExecScript_NoShellInjection(t *testing.T) {
+	tmp := t.TempDir()
+	filename := filepath.Join(tmp, "run_locally.sh")
+
+	cmd := &repb.Command{
+		Arguments: []string{
+			"echo",
+			"normal-arg",
+			"$(touch /tmp/should-not-fire-arg)",
+			"with space",
+			"--cfg=$(touch /tmp/should-not-fire-cfg)",
+			`with'quote`,
+		},
+		WorkingDirectory: "$(touch /tmp/should-not-fire-wd)",
+		OutputDirectories: []string{
+			"out/$(touch /tmp/should-not-fire-od)",
+		},
+		OutputFiles: []string{
+			"out/$(touch /tmp/should-not-fire-of)/file",
+		},
+		EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+			{Name: "GOOD_NAME", Value: "$(touch /tmp/should-not-fire-env)"},
+			// Invalid name must be dropped, not emitted.
+			{Name: "BAD;NAME", Value: "x"},
+			{Name: "1STARTS_WITH_DIGIT", Value: "x"},
+			{Name: "", Value: "x"},
+		},
+		Platform: &repb.Platform{
+			Properties: []*repb.Platform_Property{
+				{Name: "container-image", Value: "docker://busybox"},
+			},
+		},
+	}
+
+	c := &Client{}
+	if err := c.writeExecScript(context.Background(), cmd, filename); err != nil {
+		t.Fatalf("writeExecScript failed: %v", err)
+	}
+
+	scriptBytes, err := os.ReadFile(filepath.Join(tmp, "run_command.sh"))
+	if err != nil {
+		t.Fatalf("read run_command.sh: %v", err)
+	}
+	script := string(scriptBytes)
+
+	// 1. The hard invariant: when bash parses this script, no command
+	//    substitution may execute on any line containing a payload. Verify by
+	//    stripping single-quoted regions (including the `'\''` escape sequence
+	//    for an embedded single quote) and asserting no shell metacharacters
+	//    remain.
+	for _, line := range strings.Split(script, "\n") {
+		if strings.HasPrefix(line, "#") || line == "" || line == "bash" {
+			continue
+		}
+		stripped := stripSingleQuotedRegions(line)
+		for _, meta := range []string{"$(", "`", "$VAR", "${"} {
+			if strings.Contains(stripped, meta) {
+				t.Errorf("shell metacharacter %q found outside single-quoted region\nline: %q\nstripped: %q", meta, line, stripped)
+			}
+		}
+	}
+
+	// Sanity: each payload must appear *somewhere* in the script (otherwise
+	// the test isn't actually exercising the quoting path).
+	for _, payload := range []string{
+		"should-not-fire-arg",
+		"should-not-fire-cfg",
+		"should-not-fire-wd",
+		"should-not-fire-od",
+		"should-not-fire-of",
+		"should-not-fire-env",
+	} {
+		if !strings.Contains(script, payload) {
+			t.Errorf("payload sentinel %q missing from script — test not exercising the path", payload)
+		}
+	}
+
+	// 2. Embedded single quote in an arg must be escaped, not break out.
+	//    `with'quote` must appear as `'with'\''quote'` in the script.
+	if !strings.Contains(script, `'with'\''quote'`) {
+		t.Errorf("embedded single quote in arg not properly escaped:\n%s", script)
+	}
+
+	// 3. Invalid env var names must NOT produce export lines.
+	for _, badName := range []string{"BAD;NAME", "1STARTS_WITH_DIGIT"} {
+		if strings.Contains(script, "export "+badName) {
+			t.Errorf("invalid env var name %q was emitted:\n%s", badName, script)
+		}
+	}
+	// And specifically, the metacharacter version must not be emitted as a name.
+	if strings.Contains(script, "export BAD;NAME") {
+		t.Errorf("env var name with semicolon was emitted unescaped:\n%s", script)
+	}
+
+	// 4. Valid env var must appear with quoted value.
+	if !strings.Contains(script, "export GOOD_NAME='$(touch /tmp/should-not-fire-env)'") {
+		t.Errorf("valid env var value not properly quoted:\n%s", script)
+	}
+}
+
+// TestWriteExecScript_RunGeneratedScript_NoSideEffects optionally executes the
+// generated script under bash and verifies that none of the injection sentinels
+// fire. Skipped on systems without bash to keep CI portable.
+func TestWriteExecScript_RunGeneratedScript_NoSideEffects(t *testing.T) {
+	if _, err := os.Stat("/bin/bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	tmp := t.TempDir()
+	scriptDir := filepath.Join(tmp, "scripts")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	filename := filepath.Join(scriptDir, "run_locally.sh")
+
+	// Sentinel files inside tmp; if the shell ever interprets the payloads,
+	// these will be created and the test fails.
+	sentinel := func(tag string) string { return filepath.Join(tmp, "sentinel-"+tag) }
+
+	cmd := &repb.Command{
+		// Use `true` as the action so the script exits cleanly.
+		Arguments: []string{
+			"true",
+			"$(touch " + sentinel("arg") + ")",
+			"x;touch " + sentinel("argsemi") + ";true",
+		},
+		// cd into a real directory so `cd` doesn't fail.
+		WorkingDirectory: tmp + "/$(touch " + sentinel("wd") + ")fakedir",
+		OutputDirectories: []string{
+			"od;touch " + sentinel("od"),
+		},
+		OutputFiles: []string{
+			"of/$(touch " + sentinel("of") + ")/x",
+		},
+		EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+			{Name: "EVIL", Value: "$(touch " + sentinel("env") + ")"},
+		},
+		Platform: &repb.Platform{
+			Properties: []*repb.Platform_Property{
+				{Name: "container-image", Value: "docker://busybox"},
+			},
+		},
+	}
+
+	c := &Client{}
+	if err := c.writeExecScript(context.Background(), cmd, filename); err != nil {
+		t.Fatalf("writeExecScript: %v", err)
+	}
+
+	// Run only the line that doesn't depend on `cd` succeeding: extract the
+	// script and feed everything except the `cd` line to bash, so we verify
+	// the rest of the script's quoting in isolation. (cd to a non-existent
+	// dir would `exit` regardless of injection.)
+	scriptBytes, err := os.ReadFile(filepath.Join(scriptDir, "run_command.sh"))
+	if err != nil {
+		t.Fatalf("read run_command.sh: %v", err)
+	}
+	var filtered []string
+	for _, line := range strings.Split(string(scriptBytes), "\n") {
+		if strings.HasPrefix(line, "cd ") || strings.HasPrefix(line, "mkdir ") || line == "bash" {
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+	stripped := filepath.Join(scriptDir, "stripped.sh")
+	if err := os.WriteFile(stripped, []byte(strings.Join(filtered, "\n")), 0o755); err != nil {
+		t.Fatalf("write stripped: %v", err)
+	}
+	// Run it. Ignore exit code (the `true` arg call may still produce stderr
+	// from the quoted args, but no sentinel must fire).
+	runBashScript(t, stripped)
+
+	for _, tag := range []string{"arg", "argsemi", "wd", "od", "of", "env"} {
+		if _, err := os.Stat(sentinel(tag)); err == nil {
+			t.Errorf("sentinel %q fired — shell injection still possible", tag)
+		}
+	}
+}

--- a/go/pkg/tool/tool_test.go
+++ b/go/pkg/tool/tool_test.go
@@ -202,16 +202,18 @@ func TestTool_DownloadAction(t *testing.T) {
 			path:     "input/a/b/i2",
 			contents: "i2",
 		},
-		// Note that we have to use proper quotes around the --cfg args' key-value
-		// pairs, these are valid examples: '--cfg=key="value"', --cfg='key="value"'
-		// and --cfg=key=\"value\" but --cfg=key="value" is invalid.
+		// All server-controlled fields (Arguments, OutputDirectories,
+		// OutputFiles, WorkingDirectory, env vars) are POSIX single-quote
+		// escaped to prevent shell injection when the operator runs the
+		// generated script. Embedded single quotes round-trip via the
+		// `'\''` form.
 		{
 			path: "run_command.sh",
 			contents: fmt.Sprintf(`#!/bin/bash
 
 # This script is meant to be called by %s/run_locally.sh.
-mkdir -p a/b
-foo bar baz @rust_api_level_cfg_flags.txt '--cfg=feature="debug"' '--cfg=__rust_toolchain="ZYWVoLo8XHwkRcwBUtl83-8E559gSwiuYrDOsvNULggC'
+mkdir -p 'a/b'
+'foo' 'bar' 'baz' '@rust_api_level_cfg_flags.txt' '--cfg=feature="debug"' '--cfg=__rust_toolchain="ZYWVoLo8XHwkRcwBUtl83-8E559gSwiuYrDOsvNULggC'
 bash
 `, tmpDir),
 		},


### PR DESCRIPTION
## Summary

`writeExecScript` in `go/pkg/tool/tool.go` builds the `run_command.sh`
debug script by passing every `Command`-proto field through
`shellSprintf`, which is documented as "intended to add args
sanitization" but is actually a no-op:

```go
// shellSprintf is intended to add args sanitization before using them.
func shellSprintf(format string, args ...any) string {
    // TODO: check args for flag injection
    return fmt.Sprintf(format, args...)
}
```

`Arguments`, `WorkingDirectory`, `OutputDirectories`, `OutputFiles`,
and `EnvironmentVariables` from the `Command` proto flow into
`run_command.sh` unescaped, so any shell metacharacter in those
fields is interpreted by `bash` when the operator runs the generated
script (the documented `remotetool download_action` → `bash run_locally.sh`
debugging workflow).

The existing argument handling does try to single-quote-wrap args
that contain a space, but it does so without escaping embedded
single quotes, so a value such as `a' ; touch /tmp/x ; '` breaks
out of the wrap.

This change replaces `shellSprintf` with a real `shellQuote` helper
that does POSIX single-quote escaping, and applies it consistently
to every server-supplied value emitted into the script.

## Details

* **Arguments**: every arg is unconditionally quoted
  (`shellQuote(arg)`). The previous "wrap if it contains a space,
  otherwise leave raw" / "wrap if it starts with `--cfg`" branches
  are removed — they were both unsafe (no embedded-quote escape) and
  inconsistent (an arg like `a;b` containing no space was emitted
  raw and ran as a compound statement).

* **`cd %v` (`WorkingDirectory`)**: now emits `cd <quoted>`.

* **`mkdir -p %v` (`OutputDirectories`, `filepath.Dir(of)`)**: each
  path is quoted.

* **`export %v=%v` (env vars)**: the variable **name** is validated
  against the POSIX rule `^[A-Za-z_][A-Za-z0-9_]*$`. Names that
  don't match are dropped with a `glog.Warningf` rather than emitted
  as a malformed `export` line (a name like `BAD;NAME` would have
  been a separate injection vector). The **value** is quoted.

* The static format strings (`#!/bin/bash`, `set -x`, the comment
  preamble for `execScript`, etc.) are written directly with
  `bytes.Buffer.WriteString` since `shellSprintf` no longer exists.

## `shellQuote` semantics

```go
func shellQuote(s string) string {
    return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
}
```

Single-quote wrapping is preferred over double quotes because no
character inside a single-quoted string is interpreted by the shell
except `'` itself. The `'\''` four-character sequence is the
canonical POSIX way to embed a literal single quote: it ends the
current quote, has a literal `\'`, then re-opens.

## Tests

* `TestShellQuote` — table-driven coverage of empty / plain / space
  / single-quote / `$(...)` / backtick / `;` / newline / nested
  break-out attempt.

* `TestWriteExecScript_NoShellInjection` — drives `writeExecScript`
  with malicious values in **every** server-controlled field
  (including the previous edge cases like `--cfg=…`,
  `with'quote`, and env vars with non-POSIX names) and asserts that,
  when single-quoted regions are stripped from the resulting script,
  no shell metacharacter (`$(`, `` ` ``, `${`, `$VAR`) remains.

* `TestWriteExecScript_RunGeneratedScript_NoSideEffects` — actually
  runs the generated script under `bash` and asserts that none of
  the sentinel-file payloads fire. Skipped on systems without
  `/bin/bash` to keep CI portable.

* `TestTool_DownloadAction` (existing) — golden updated to reflect
  the always-quoted output. Same payloads, same script semantics
  when bash parses them; the difference is purely that `mkdir -p
  a/b` is now `mkdir -p 'a/b'` and `foo bar baz …` is now `'foo'
  'bar' 'baz' …`.

`go test ./pkg/tool/ -count=1` and `go test ./... -count=1` both
pass on the patched tree.

## Notes

I noticed this while auditing the residual surface around PR #649
(getAbsPath sibling-prefix fix) and PR #650 (DownloadActionOutputs
+ symlink-target validation). PR #650 deliberately scopes itself to
`go/pkg/client/cas_download.go`; this PR is scoped to
`go/pkg/tool/tool.go` and does not overlap.

There is a separate path-traversal observation in the same file
(`DownloadActionResult` joins `pathPrefix` with the server-supplied
`cmd.WorkingDirectory` without containment validation, so the
download outDir can be redirected outside `pathPrefix` via
`WorkingDirectory: "../etc"`). That is intentionally **not** in this
PR — it's a separate behavioural change worth its own review. Happy
to send it as a follow-up if you'd like.
