### PR TITLE
tool: reject non-local WorkingDirectory in DownloadActionResult

### DIFF
--- a/go/pkg/tool/BUILD.bazel
+++ b/go/pkg/tool/BUILD.bazel
@@ -28,7 +28,10 @@ go_library(
 
 go_test(
     name = "tool_test",
-    srcs = ["tool_test.go"],
+    srcs = [
+        "tool_test.go",
+        "tool_workingdir_test.go",
+    ],
     embed = [":tool"],
     deps = [
         "//go/api/command",

--- a/go/pkg/tool/tool.go
+++ b/go/pkg/tool/tool.go
@@ -204,7 +204,17 @@ func (c *Client) DownloadActionResult(ctx context.Context, actionDigest, pathPre
 	log.Infof("Downloading action results of %v to %v.", actionDigest, pathPrefix)
 	// We don't really need an in-memory filemetadata cache for debugging operations.
 	noopCache := filemetadata.NewNoopCache()
-	if _, err := c.GrpcClient.DownloadActionOutputs(ctx, resPb, filepath.Join(pathPrefix, cmd.WorkingDir), noopCache); err != nil {
+	// cmd.WorkingDir originates from the server-supplied Command proto; reject
+	// non-local values (absolute paths or `..` traversal) so the join below
+	// cannot redirect outDir outside of the operator-supplied pathPrefix.
+	outDir := pathPrefix
+	if cmd.WorkingDir != "" {
+		if !filepath.IsLocal(cmd.WorkingDir) {
+			return fmt.Errorf("WorkingDirectory %q in command proto is not a local path", cmd.WorkingDir)
+		}
+		outDir = filepath.Join(pathPrefix, cmd.WorkingDir)
+	}
+	if _, err := c.GrpcClient.DownloadActionOutputs(ctx, resPb, outDir, noopCache); err != nil {
 		log.Errorf("Failed downloading action outputs: %v.", err)
 	}
 

--- a/go/pkg/tool/tool_workingdir_test.go
+++ b/go/pkg/tool/tool_workingdir_test.go
@@ -1,0 +1,114 @@
+package tool
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/command"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/fakes"
+)
+
+// TestTool_DownloadActionResult_RejectsNonLocalWorkingDir verifies that a
+// server-supplied WorkingDirectory containing `..` traversal causes
+// DownloadActionResult to fail before downloading any outputs, instead of
+// allowing the download to be redirected outside of pathPrefix.
+func TestTool_DownloadActionResult_RejectsNonLocalWorkingDir(t *testing.T) {
+	cases := []struct {
+		name string
+		wd   string
+	}{
+		{"parent-traversal", "../escape"},
+		{"deep-parent-traversal", "../../escape"},
+		{"absolute-path", "/etc"},
+		{"trailing-traversal", "ok/../../escape"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e, cleanup := fakes.NewTestEnv(t)
+			defer cleanup()
+			cmd := &command.Command{
+				Args:        []string{"tool"},
+				ExecRoot:    e.ExecRoot,
+				WorkingDir:  tc.wd,
+				InputSpec:   &command.InputSpec{},
+				OutputFiles: []string{"a/b/out"},
+			}
+			opt := command.DefaultExecutionOptions()
+			_, acDg, _, _ := e.Set(cmd, opt,
+				&command.Result{Status: command.CacheHitResultStatus},
+				&fakes.OutputFile{Path: "a/b/out", Contents: "output"},
+				fakes.StdOut("stdout"), fakes.StdErr("stderr"))
+
+			toolClient := &Client{GrpcClient: e.Client.GrpcClient}
+			tmpDir := t.TempDir()
+
+			// Pre-create a sibling directory that would be the target of a
+			// successful traversal; we'll verify nothing was written to it.
+			sibling := filepath.Join(filepath.Dir(tmpDir), "escape")
+			if err := os.MkdirAll(sibling, 0o755); err != nil {
+				t.Fatalf("setup mkdir: %v", err)
+			}
+			defer os.RemoveAll(sibling)
+
+			err := toolClient.DownloadActionResult(context.Background(), acDg.String(), tmpDir)
+			if err == nil {
+				t.Fatalf("DownloadActionResult should have rejected non-local WorkingDirectory %q, got nil error", tc.wd)
+			}
+			if !strings.Contains(err.Error(), "WorkingDirectory") {
+				t.Errorf("expected error to mention WorkingDirectory, got: %v", err)
+			}
+
+			// Sanity: nothing was written to the sibling directory.
+			entries, err := os.ReadDir(sibling)
+			if err != nil {
+				t.Fatalf("read sibling: %v", err)
+			}
+			if len(entries) != 0 {
+				names := []string{}
+				for _, e := range entries {
+					names = append(names, e.Name())
+				}
+				t.Errorf("traversal still wrote into sibling directory %q: %v", sibling, names)
+			}
+		})
+	}
+}
+
+// TestTool_DownloadActionResult_AcceptsLocalWorkingDir is a regression test
+// confirming that a benign relative WorkingDirectory (the legitimate use case)
+// still works after the validation is added.
+func TestTool_DownloadActionResult_AcceptsLocalWorkingDir(t *testing.T) {
+	e, cleanup := fakes.NewTestEnv(t)
+	defer cleanup()
+	cmd := &command.Command{
+		Args:        []string{"tool"},
+		ExecRoot:    e.ExecRoot,
+		WorkingDir:  "subdir",
+		InputSpec:   &command.InputSpec{},
+		OutputFiles: []string{"a/b/out"},
+	}
+	opt := command.DefaultExecutionOptions()
+	_, acDg, _, _ := e.Set(cmd, opt,
+		&command.Result{Status: command.CacheHitResultStatus},
+		&fakes.OutputFile{Path: "a/b/out", Contents: "output"},
+		fakes.StdOut("stdout"), fakes.StdErr("stderr"))
+
+	toolClient := &Client{GrpcClient: e.Client.GrpcClient}
+	tmpDir := t.TempDir()
+	if err := toolClient.DownloadActionResult(context.Background(), acDg.String(), tmpDir); err != nil {
+		t.Fatalf("DownloadActionResult with local WorkingDirectory failed: %v", err)
+	}
+	// File should be written under tmpDir/subdir/a/b/out.
+	want := filepath.Join(tmpDir, "subdir", "a/b/out")
+	got, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("expected output at %v: %v", want, err)
+	}
+	if string(got) != "output" {
+		t.Errorf("output content = %q, want %q", string(got), "output")
+	}
+}


### PR DESCRIPTION
## Summary

`DownloadActionResult` in `go/pkg/tool/tool.go` joins the
server-supplied `commandProto.WorkingDirectory` directly with the
operator-supplied `pathPrefix` to derive the output directory passed
to `DownloadActionOutputs`:

```go
filepath.Join(pathPrefix, cmd.WorkingDir)
```

A `WorkingDirectory` containing `..` (e.g. `"../etc"`) or an absolute
path causes the join to resolve outside of `pathPrefix`. Each
individual output path in the action result is later validated by
`getAbsPath` against this joined `outDir`, so once `outDir` itself
sits outside `pathPrefix`, all subsequent containment checks for
`OutputFiles`, `OutputDirectories`, and symlinks pass against the
escaped base — defeating the per-path validation that PR #649 / #634
were intended to enforce.

This change validates `cmd.WorkingDirectory` with `filepath.IsLocal`
(Go 1.20+) before joining. Both `..` traversal and absolute paths are
covered by that single check. An empty `WorkingDirectory` continues to
behave exactly as before (`outDir == pathPrefix`).

## Diff

```diff
 	noopCache := filemetadata.NewNoopCache()
-	if _, err := c.GrpcClient.DownloadActionOutputs(ctx, resPb, filepath.Join(pathPrefix, cmd.WorkingDir), noopCache); err != nil {
+	// cmd.WorkingDir originates from the server-supplied Command proto; reject
+	// non-local values (absolute paths or `..` traversal) so the join below
+	// cannot redirect outDir outside of the operator-supplied pathPrefix.
+	outDir := pathPrefix
+	if cmd.WorkingDir != "" {
+		if !filepath.IsLocal(cmd.WorkingDir) {
+			return fmt.Errorf("WorkingDirectory %q in command proto is not a local path", cmd.WorkingDir)
+		}
+		outDir = filepath.Join(pathPrefix, cmd.WorkingDir)
+	}
+	if _, err := c.GrpcClient.DownloadActionOutputs(ctx, resPb, outDir, noopCache); err != nil {
 		log.Errorf("Failed downloading action outputs: %v.", err)
 	}
```

## Tests

* `TestTool_DownloadActionResult_RejectsNonLocalWorkingDir` runs four
  malicious `WorkingDirectory` subcases — parent traversal
  (`../escape`), deep parent traversal (`../../escape`), absolute path
  (`/etc`), and trailing traversal (`ok/../../escape`). Each asserts
  that `DownloadActionResult` returns an error mentioning
  `WorkingDirectory` and that the pre-staged sibling target directory
  remains empty.
* `TestTool_DownloadActionResult_AcceptsLocalWorkingDir` is a
  regression test for the legitimate "`WorkingDirectory` is a
  relative subdirectory" case (`subdir`), confirming output is
  written to `pathPrefix/subdir/a/b/out` exactly as before.

`go test ./pkg/tool/ -count=1` and `go test ./... -count=1` both pass
on the patched tree. The new test file is registered in
`go/pkg/tool/BUILD.bazel` so the bazel test runner picks it up.

## Notes

I noticed this while auditing the same `tool.go` surface as
#653. The two changes touch different functions (`writeExecScript`
in #653 vs `DownloadActionResult` here) and different defects (shell
escaping vs path containment); merging order does not matter.

Filed independently so each can be reviewed against its own concern
without becoming a multi-topic PR.
