### PR TITLE
client: validate OutputDirectory.Path before os.RemoveAll in DownloadActionOutputs

### DIFF
--- a/go/pkg/client/cas_download.go
+++ b/go/pkg/client/cas_download.go
@@ -522,7 +522,11 @@ func (c *Client) DownloadActionOutputs(ctx context.Context, resPb *repb.ActionRe
 	}
 	// Remove the existing output directories before downloading.
 	for _, dir := range resPb.OutputDirectories {
-		if err := os.RemoveAll(filepath.Join(outDir, dir.Path)); err != nil {
+		absPath, err := getAbsPath(outDir, dir.Path)
+		if err != nil {
+			return nil, fmt.Errorf("invalid output directory path %q: %v", dir.Path, err)
+		}
+		if err := os.RemoveAll(absPath); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Summary

`DownloadActionOutputs()` deletes existing output directories before downloading
action outputs. The deletion path was not validated — `dir.Path` from an
untrusted `ActionResult` was passed directly to `os.RemoveAll(filepath.Join(outDir, dir.Path))`.

A malicious or compromised remote execution/cache service can return a path like
`../victim`, causing deletion of files or directories outside `outDir`. This
bypasses the fix in #649 because the unsafe `RemoveAll()` call happens before
`DownloadOutputs()` validates the flattened output paths.

## Fix

Use the existing `getAbsPath()` helper (introduced in #649) to apply the same
boundary check to the deletion path before calling `os.RemoveAll()`.