### PR TITLE
Verify content digest on the batch CAS download path

### DIFF
--- a/go/pkg/client/batch_retries_test.go
+++ b/go/pkg/client/batch_retries_test.go
@@ -47,9 +47,9 @@ func (f *flakyBatchServer) BatchReadBlobs(ctx context.Context, req *repb.BatchRe
 		f.numErrors++
 		resp := &repb.BatchReadBlobsResponse{
 			Responses: []*repb.BatchReadBlobsResponse_Response{
-				{Digest: digest.TestNew("a", 1).ToProto(), Status: &spb.Status{Code: int32(codes.OK)}, Data: []byte{1}},
+				{Digest: digest.NewFromBlob([]byte{1}).ToProto(), Status: &spb.Status{Code: int32(codes.OK)}, Data: []byte{1}},
 				// all retriable errors.
-				{Digest: digest.TestNew("b", 1).ToProto(), Status: &spb.Status{Code: int32(codes.Internal)}},
+				{Digest: digest.NewFromBlob([]byte{2}).ToProto(), Status: &spb.Status{Code: int32(codes.Internal)}},
 				{Digest: digest.TestNew("c", 1).ToProto(), Status: &spb.Status{Code: int32(codes.Canceled)}},
 				{Digest: digest.TestNew("d", 1).ToProto(), Status: &spb.Status{Code: int32(codes.Aborted)}},
 			},
@@ -60,7 +60,7 @@ func (f *flakyBatchServer) BatchReadBlobs(ctx context.Context, req *repb.BatchRe
 		f.numErrors++
 		resp := &repb.BatchReadBlobsResponse{
 			Responses: []*repb.BatchReadBlobsResponse_Response{
-				{Digest: digest.TestNew("b", 1).ToProto(), Status: &spb.Status{Code: int32(codes.OK)}, Data: []byte{2}},
+				{Digest: digest.NewFromBlob([]byte{2}).ToProto(), Status: &spb.Status{Code: int32(codes.OK)}, Data: []byte{2}},
 				// all retriable errors.
 				{Digest: digest.TestNew("c", 1).ToProto(), Status: &spb.Status{Code: int32(codes.Internal)}},
 				{Digest: digest.TestNew("d", 1).ToProto(), Status: &spb.Status{Code: int32(codes.Canceled)}},
@@ -228,14 +228,14 @@ func TestBatchReadBlobsIndividualRequestRetries(t *testing.T) {
 	defer client.Close()
 
 	digests := []digest.Digest{
-		digest.TestNew("a", 1),
-		digest.TestNew("b", 1),
+		digest.NewFromBlob([]byte{1}),
+		digest.NewFromBlob([]byte{2}),
 		digest.TestNew("c", 1),
 		digest.TestNew("d", 1),
 	}
 	wantBlobs := map[digest.Digest][]byte{
-		digest.TestNew("a", 1): []byte{1},
-		digest.TestNew("b", 1): []byte{2},
+		digest.NewFromBlob([]byte{1}): []byte{1},
+		digest.NewFromBlob([]byte{2}): []byte{2},
 	}
 	gotBlobs, err := client.BatchDownloadBlobs(ctx, digests)
 	if err == nil {
@@ -249,8 +249,8 @@ func TestBatchReadBlobsIndividualRequestRetries(t *testing.T) {
 	wantRequests := []*repb.BatchReadBlobsRequest{
 		{
 			Digests: []*repb.Digest{
-				digest.TestNew("a", 1).ToProto(),
-				digest.TestNew("b", 1).ToProto(),
+				digest.NewFromBlob([]byte{1}).ToProto(),
+				digest.NewFromBlob([]byte{2}).ToProto(),
 				digest.TestNew("c", 1).ToProto(),
 				digest.TestNew("d", 1).ToProto(),
 			},
@@ -258,7 +258,7 @@ func TestBatchReadBlobsIndividualRequestRetries(t *testing.T) {
 		},
 		{
 			Digests: []*repb.Digest{
-				digest.TestNew("b", 1).ToProto(),
+				digest.NewFromBlob([]byte{2}).ToProto(),
 				digest.TestNew("c", 1).ToProto(),
 				digest.TestNew("d", 1).ToProto(),
 			},
@@ -273,15 +273,20 @@ func TestBatchReadBlobsIndividualRequestRetries(t *testing.T) {
 		},
 	}
 	if len(fake.readRequests) != len(wantRequests) {
-		t.Errorf("client.BatchWriteBlobs(ctx, blobs) wrong number of requests; expected %d, got %d", len(wantRequests), len(fake.readRequests))
+		t.Fatalf("client.BatchDownloadBlobs(ctx, digests) wrong number of requests; expected %d, got %d", len(wantRequests), len(fake.readRequests))
 	}
 	for i, req := range wantRequests {
 		dgs := fake.readRequests[i].Digests
 		sort.Slice(dgs, func(a, b int) bool {
 			return fmt.Sprint(dgs[a]) < fmt.Sprint(dgs[b])
 		})
+		// The order of digests within a batch request is not significant, so sort
+		// the expected digests the same way to keep the comparison order-independent.
+		sort.Slice(req.Digests, func(a, b int) bool {
+			return fmt.Sprint(req.Digests[a]) < fmt.Sprint(req.Digests[b])
+		})
 		if diff := cmp.Diff(req, fake.readRequests[i], cmp.Comparer(proto.Equal)); diff != "" {
-			t.Errorf("client.BatchWriteBlobs(ctx, blobs) diff on request at index %d (want -> got):\n%s", i, diff)
+			t.Errorf("client.BatchDownloadBlobs(ctx, digests) diff on request at index %d (want -> got):\n%s", i, diff)
 		}
 	}
 }

--- a/go/pkg/client/cas_download.go
+++ b/go/pkg/client/cas_download.go
@@ -271,11 +271,21 @@ func (c *Client) BatchDownloadBlobsWithStats(ctx context.Context, dgs []digest.D
 					allRetriable = false
 					continue
 				}
+				// Verify the returned bytes hash to the requested digest before
+				// trusting them, matching the streamed path (readBlobStreamed).
+				dg := digest.NewFromProtoUnvalidated(r.Digest)
+				if got := digest.NewFromBlob(r.Data); got != dg {
+					errDg = r.Digest
+					errMsg = fmt.Sprintf("calculated digest %s != expected digest %s", got, dg)
+					numErrs++
+					allRetriable = false
+					continue
+				}
 				bi := CompressedBlobInfo{
 					CompressedSize: int64(CompressedSize),
 					Data:           r.Data,
 				}
-				res[digest.NewFromProtoUnvalidated(r.Digest)] = bi
+				res[dg] = bi
 			}
 		}
 		req.Digests = failedDgs

--- a/go/pkg/client/cas_test.go
+++ b/go/pkg/client/cas_test.go
@@ -2051,6 +2051,55 @@ func TestBatchDownloadBlobsBrokenCompression(t *testing.T) {
 	}
 }
 
+func TestBatchDownloadBlobsDigestMismatch(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Cannot listen: %v", err)
+	}
+	defer listener.Close()
+	fakeCAS := fakes.NewCAS()
+	server := grpc.NewServer()
+	s := invalidReadServer{
+		ContentAddressableStorageServer: fakeCAS,
+	}
+	regrpc.RegisterContentAddressableStorageServer(server, &s)
+	go server.Serve(listener)
+	defer server.Stop()
+	c, err := client.NewClient(ctx, instance, client.DialParams{
+		Service:    listener.Addr().String(),
+		NoSecurity: true,
+	}, client.StartupCapabilities(false))
+	if err != nil {
+		t.Fatalf("Error connecting to server: %v", err)
+	}
+	defer c.Close()
+
+	fooDigest := fakeCAS.Put([]byte("foo"))
+	barDigest := fakeCAS.Put([]byte("bar"))
+	digests := []digest.Digest{fooDigest, barDigest}
+
+	// Server returns bytes that do not hash to the requested digest for one blob.
+	s.setModifier(func(idx int, resp *repb.BatchReadBlobsResponse_Response) {
+		if resp.GetDigest().GetHash() == fooDigest.Hash {
+			resp.Data = []byte("tampered")
+		}
+	})
+	defer s.setModifier(nil)
+
+	gotBlobs, err := c.BatchDownloadBlobsWithStats(ctx, digests)
+	if err == nil {
+		t.Fatal("client.BatchDownloadBlobsWithStats(ctx, digests) should return an error when returned bytes do not match the requested digest")
+	}
+	if !strings.Contains(err.Error(), "calculated digest") {
+		t.Errorf("expected a calculated-digest mismatch error, got: %v", err)
+	}
+	if _, ok := gotBlobs[fooDigest]; ok {
+		t.Error("a blob whose bytes do not match the requested digest must not be returned to the caller")
+	}
+}
+
 type escapedPathTestEnv struct {
 	ctx           context.Context
 	c             *client.Client


### PR DESCRIPTION
## What

`BatchDownloadBlobsWithStats` stores each blob returned by `BatchReadBlobs` keyed by the digest the server asserts in the response, without re-hashing the returned bytes:

```go
res[digest.NewFromProtoUnvalidated(r.Digest)] = bi
```

There is no length check and no `NewFromBlob(r.Data) == requested` check, so a CAS that returns bytes which do not match the requested digest — a buggy or compromised server, a caching/forwarding proxy, or an on-path party on a non-TLS connection — is taken at face value, and the bytes are later written to disk by `downloadBatch` / `downloadNonUnified`.

The streamed path already guards against this: `readBlobStreamed` tees the stream through `digest.NewFromReader` and returns `calculated digest %s != expected digest %s` on mismatch. Because `useBatchOps` defaults to true and `makeBatches` groups every sub-`MaxBatchSize` blob into a batch, the unverified batch path is the common route for most blobs.

## Change

Verify the returned (post-decompression) bytes hash to the requested digest before storing them, mirroring the streamed path, and key the result by the verified digest. Adds `TestBatchDownloadBlobsDigestMismatch`.
