### PR TITLE
Stop embedding raw response body in actas parse-error messages

### DIFF
--- a/go/pkg/actas/actas.go
+++ b/go/pkg/actas/actas.go
@@ -180,7 +180,10 @@ func (s *TokenSource) getSignedJWT(headers map[string]string) (*signaturePayload
 
 	payload := &signaturePayload{}
 	if err := json.Unmarshal(signatureBody, payload); err != nil {
-		return nil, fmt.Errorf("failed to parse sign jwt payload %q: %v", string(signatureBody), err)
+		// Deliberately not including the raw response body here: on a 200 response it
+		// may already contain a live signedJwt even though it failed to unmarshal (e.g.
+		// a truncated response), and that value should not end up in logs/error output.
+		return nil, fmt.Errorf("failed to parse sign jwt payload: %v", err)
 	}
 
 	log.V(1).Infof("Payload: %+v", payload)
@@ -243,7 +246,11 @@ func (s TokenSource) getToken(headers map[string]string, signature *signaturePay
 	payload := &tokenPayload{}
 	err = json.Unmarshal(tokenBody, payload)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse access token payload %q: %v", string(tokenBody), err)
+		// Deliberately not including the raw response body here: on a 200 response it
+		// may already contain a live access_token even though it failed to unmarshal
+		// (e.g. an unexpected field type or a truncated response), and that value
+		// should not end up in logs/error output.
+		return nil, fmt.Errorf("failed to parse access token payload: %v", err)
 	}
 
 	log.V(1).Infof("Payload: %+v", payload)

--- a/go/pkg/actas/actas_credential_leak_test.go
+++ b/go/pkg/actas/actas_credential_leak_test.go
@@ -1,0 +1,101 @@
+package actas
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Regression test: previously, on a 200-status response from the access-token
+// endpoint whose body failed to unmarshal into tokenPayload (e.g. because
+// expires_in is returned as a JSON string instead of a number, a real-world
+// OAuth2 server quirk), getToken() embedded the full raw response body --
+// including the live access_token -- verbatim into the returned error. The fix
+// drops the raw body from the error message.
+func TestTokenSource_Token_MalformedButSuccessfulResponseDoesNotLeakAccessToken(t *testing.T) {
+	ctx := context.Background()
+
+	h, cleanup := newFakeHTTP()
+	defer cleanup()
+
+	newSignJWTURL = func(string) string {
+		return h.Server.URL + "/sign"
+	}
+	audienceURL = h.Server.URL + "/token"
+
+	const liveSecretToken = "ya29.REAL-LOOKING-LIVE-ACCESS-TOKEN-abcXYZ123"
+
+	h.Handler = func(req *http.Request) (interface{}, error) {
+		if req.URL.Path == "/sign" {
+			return &signaturePayload{
+				KeyID:     "fake-key-id",
+				SignedJwt: "fake-signed-jwt",
+			}, nil
+		}
+		if req.URL.Path == "/token" {
+			// Real endpoint, HTTP 200, but expires_in is a STRING instead of a number --
+			// a real-world quirk seen from some OAuth2-compatible token servers. This makes
+			// json.Unmarshal into tokenPayload{ExpiresIn int64} fail even though the body
+			// legitimately contains a live access token.
+			return map[string]any{
+				"access_token": liveSecretToken,
+				"token_type":   "Bearer",
+				"expires_in":   "3600",
+			}, nil
+		}
+		return nil, nil
+	}
+
+	d := &stubDefaultCredentials{}
+	s := NewTokenSource(ctx, d, h.Client, account, []string{scope})
+
+	_, err := s.Token()
+	if err == nil {
+		t.Fatalf("Token() unexpectedly succeeded, expected the malformed-body parse error")
+	}
+
+	if strings.Contains(err.Error(), liveSecretToken) {
+		t.Fatalf("access token leaked into error text: %v", err)
+	}
+}
+
+// Regression test: previously, the sibling getSignedJWT() had the identical bug
+// shape for the signed-JWT bearer credential. A 200 response with a body that is
+// genuine JSON truncated mid-stream (a realistic network/proxy truncation
+// scenario) still failed json.Unmarshal, and the raw (truncated but still
+// credential-bearing) body was embedded verbatim in the returned error. The fix
+// drops the raw body from the error message.
+func TestTokenSource_Token_TruncatedResponseDoesNotLeakSignedJWT(t *testing.T) {
+	ctx := context.Background()
+
+	const liveSignedJwt = "eyJhbGciOiJSUzI1NiJ9.REAL-LOOKING-LIVE-SIGNED-JWT-PAYLOAD.sigSIG"
+
+	// Full well-formed body would be:
+	//   {"keyId":"fake-key-id","signedJwt":"eyJhbGciOiJSUzI1NiJ9.REAL-LOOKING-LIVE-SIGNED-JWT-PAYLOAD.sigSIG"}
+	// Simulate a network/proxy truncation that cuts it off right after the value,
+	// before the closing brace -- the signedJwt bytes are still fully present in the
+	// truncated body, but the JSON itself is now invalid.
+	truncatedBody := `{"keyId":"fake-key-id","signedJwt":"` + liveSignedJwt + `"`
+
+	signServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(truncatedBody))
+	}))
+	defer signServer.Close()
+
+	newSignJWTURL = func(string) string { return signServer.URL }
+
+	d := &stubDefaultCredentials{}
+	s := NewTokenSource(ctx, d, signServer.Client(), account, []string{scope})
+
+	_, err := s.Token()
+	if err == nil {
+		t.Fatalf("Token() unexpectedly succeeded, expected the truncated-body parse error")
+	}
+
+	if strings.Contains(err.Error(), liveSignedJwt) {
+		t.Fatalf("signed JWT leaked into error text: %v", err)
+	}
+}


### PR DESCRIPTION
getToken() and getSignedJWT() in go/pkg/actas/actas.go both included the full raw HTTP response body in the error returned when json.Unmarshal failed on an otherwise-successful (HTTP 200) response.

Since these responses carry an access token and a signed JWT respectively, a response that fails to unmarshal while still containing a live credential -- an unexpected field type such as expires_in coming back as a string instead of a number, or a body truncated by a network intermediary -- put that credential verbatim into the returned error, and from there into whatever logs the caller writes errors to.

Both call sites now format only the underlying json.Unmarshal error, dropping the raw response body entirely.

Added two regression tests reproducing both trigger conditions (a malformed-but-200 token response, a truncated signJWT response), confirming the credential is present in the error before the fix and absent after it.