### PR TITLE
Validate symlink targets stay within outDir in DownloadOutputs

### DIFF
--- a/go/pkg/client/cas_download.go
+++ b/go/pkg/client/cas_download.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -147,11 +148,32 @@ func (c *Client) DownloadOutputs(ctx context.Context, outs map[string]*TreeOutpu
 		}
 	}
 	for _, out := range symlinks {
-		if err := os.Symlink(out.SymlinkTarget, filepath.Join(outDir, out.Path)); err != nil {
+		linkPath := filepath.Join(outDir, out.Path)
+		if err := checkSymlinkTargetContained(outDir, linkPath, out.SymlinkTarget); err != nil {
+			return fullStats, err
+		}
+		if err := os.Symlink(out.SymlinkTarget, linkPath); err != nil {
 			return fullStats, err
 		}
 	}
 	return fullStats, nil
+}
+
+// checkSymlinkTargetContained verifies that a symlink at linkPath (already known to be
+// under outDir) does not resolve to a location outside outDir once target is applied.
+// target follows normal symlink semantics: an absolute target is used as-is, a relative
+// one is resolved relative to the directory containing linkPath.
+func checkSymlinkTargetContained(outDir, linkPath, target string) error {
+	resolved := target
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(filepath.Dir(linkPath), resolved)
+	}
+	resolved = filepath.Clean(resolved)
+	base := filepath.Clean(outDir)
+	if resolved != base && !strings.HasPrefix(resolved, base+string(filepath.Separator)) {
+		return fmt.Errorf("symlink target %q for %q resolves outside outDir %q", target, linkPath, outDir)
+	}
+	return nil
 }
 
 // DownloadDirectory downloads the entire directory of given digest.

--- a/go/pkg/client/cas_download_symlink_test.go
+++ b/go/pkg/client/cas_download_symlink_test.go
@@ -1,0 +1,74 @@
+package client_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/client"
+)
+
+// Regression test: DownloadOutputs validates TreeOutput.Path (the location a symlink is
+// created at) via getAbsPath, confirmed by the existing TestEscapeDownloadOutputs test.
+// It previously did not validate TreeOutput.SymlinkTarget (what the symlink points to),
+// which comes directly from server-controlled proto fields (ActionResult.
+// OutputFileSymlinks/OutputDirectorySymlinks, or a Directory's Symlinks) with no
+// containment check, unlike the upload-side ComputeMerkleTree path which enforces this
+// via getTargetRelPath/TreeSymlinkOpts. A malicious or compromised remote cache/RBE
+// server could make the client create a symlink, safely placed inside outDir, that
+// pointed anywhere on the local filesystem outside outDir.
+func TestDownloadOutputs_RejectsSymlinkTargetEscapingOutDir(t *testing.T) {
+	t.Parallel()
+	env := createEscapedPathTestEnv(t)
+
+	const linkName = "innocuous_output_link"
+	const maliciousTarget = "/etc/passwd" // stand-in for any sensitive file outside outDir
+
+	outputs := map[string]*client.TreeOutput{
+		linkName: {
+			Path:          linkName,
+			SymlinkTarget: maliciousTarget,
+		},
+	}
+
+	if _, err := env.c.DownloadOutputs(env.ctx, outputs, env.outDir, env.cache); err == nil {
+		t.Fatalf("DownloadOutputs succeeded with a symlink target escaping outDir, want an error")
+	}
+
+	if _, err := os.Lstat(filepath.Join(env.outDir, linkName)); err == nil {
+		t.Fatalf("symlink %v should not have been created", filepath.Join(env.outDir, linkName))
+	}
+}
+
+// A relative symlink target that resolves within outDir must still be allowed.
+func TestDownloadOutputs_AllowsSymlinkTargetWithinOutDir(t *testing.T) {
+	t.Parallel()
+	env := createEscapedPathTestEnv(t)
+
+	const linkName = "link_to_safe_file"
+	const relativeTarget = "safe_file.txt"
+
+	outputs := map[string]*client.TreeOutput{
+		env.safePath: {
+			Digest: env.safeDigest,
+			Path:   env.safePath,
+		},
+		linkName: {
+			Path:          linkName,
+			SymlinkTarget: relativeTarget,
+		},
+	}
+
+	if _, err := env.c.DownloadOutputs(env.ctx, outputs, env.outDir, env.cache); err != nil {
+		t.Fatalf("DownloadOutputs failed for a symlink target within outDir: %v", err)
+	}
+
+	linkPath := filepath.Join(env.outDir, linkName)
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("expected a symlink to have been created at %v: %v", linkPath, err)
+	}
+	if target != relativeTarget {
+		t.Fatalf("symlink target = %q, want %q", target, relativeTarget)
+	}
+}


### PR DESCRIPTION
DownloadOutputs in go/pkg/client/cas_download.go validates TreeOutput.Path (where a symlink gets created) via getAbsPath, but never validated TreeOutput.SymlinkTarget (what the symlink points to) before calling os.Symlink. That value comes directly from server-supplied proto fields (ActionResult.OutputFileSymlinks/OutputDirectorySymlinks, or a Directory's Symlinks), so a symlink target could resolve to any path outside outDir with no error at all.

This is asymmetric with the upload side: ComputeMerkleTree already enforces target containment for local symlinks via getTargetRelPath/TreeSymlinkOpts, rejecting a target outside the exec root by default. The download side had no equivalent check, not even behind an opt-in flag.

Added checkSymlinkTargetContained, applied the same way getAbsPath is applied to Path: resolves the target (relative to the symlink's own directory, or as-is if absolute) and rejects it if it falls outside outDir.

Added two regression tests: one confirming an escaping target is rejected and no symlink is created, one confirming a normal within-tree relative target still works.